### PR TITLE
feat: 수거 장소 domain/data 계층 구현

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.google.ksp)
+    alias(libs.plugins.hilt.android)
 }
 
 android {
@@ -45,6 +47,10 @@ dependencies {
     implementation(libs.retrofit)
     implementation(libs.retrofit.kotlinx.serialization.converter)
     implementation(libs.okhttp.logging.interceptor)
+
+    // Hilt
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.serialization)
@@ -14,16 +16,36 @@ android {
         }
     }
 
+    val localProperties = Properties().apply {
+        val file = rootProject.file("local.properties")
+        if (file.exists()) {
+            load(file.inputStream())
+        }
+    }
+
+    val publicDataServiceKey = localProperties.getProperty("PUBLIC_DATA_SERVICE_KEY")?.trim()
+        ?: throw GradleException("local.properties에 PUBLIC_DATA_SERVICE_KEY를 추가해야 합니다.")
+
     defaultConfig {
         minSdk = 28
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
+
+        buildConfigField(
+            "String",
+            "PUBLIC_DATA_SERVICE_KEY",
+            "\"$publicDataServiceKey\""
+        )
     }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 }
 

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/di/SpotDataModule.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/di/SpotDataModule.kt
@@ -1,0 +1,28 @@
+package com.team.yeogibeoryeo.data.spot.di
+
+import com.team.yeogibeoryeo.data.spot.geocoder.AndroidSpotGeocoder
+import com.team.yeogibeoryeo.data.spot.geocoder.SpotGeocoder
+import com.team.yeogibeoryeo.data.spot.repository.CollectionSpotRepositoryImpl
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class SpotDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindCollectionSpotRepository(
+        collectionSpotRepositoryImpl: CollectionSpotRepositoryImpl,
+    ): CollectionSpotRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindSpotGeocoder(
+        androidSpotGeocoder: AndroidSpotGeocoder,
+    ): SpotGeocoder
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/di/SpotNetworkModule.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/di/SpotNetworkModule.kt
@@ -1,0 +1,22 @@
+package com.team.yeogibeoryeo.data.spot.di
+
+import com.team.yeogibeoryeo.data.spot.remote.SpotApiService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import retrofit2.Retrofit
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SpotNetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideSpotApiService(
+        retrofit: Retrofit,
+    ): SpotApiService {
+        return retrofit.create(SpotApiService::class.java)
+    }
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/geocoder/SpotGeocoder.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/geocoder/SpotGeocoder.kt
@@ -1,0 +1,85 @@
+package com.team.yeogibeoryeo.data.spot.geocoder
+
+import androidx.annotation.RequiresApi
+import android.content.Context
+import android.location.Geocoder
+import android.os.Build
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.Locale
+import javax.inject.Inject
+import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+interface SpotGeocoder {
+    suspend fun geocode(address: String): Coordinate?
+}
+
+class AndroidSpotGeocoder @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : SpotGeocoder {
+
+    override suspend fun geocode(address: String): Coordinate? {
+        if (address.isBlank()) return null
+
+        val geocoder = Geocoder(context, Locale.KOREA)
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            geocodeForTiramisuAndAbove(
+                geocoder = geocoder,
+                address = address,
+            )
+        } else {
+            geocodeForBelowTiramisu(
+                geocoder = geocoder,
+                address = address,
+            )
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    private suspend fun geocodeForTiramisuAndAbove(
+        geocoder: Geocoder,
+        address: String,
+    ): Coordinate? {
+        return suspendCancellableCoroutine { continuation ->
+            geocoder.getFromLocationName(
+                address,
+                MAX_RESULT_COUNT,
+            ) { addresses ->
+                val firstAddress = addresses.firstOrNull()
+
+                continuation.resume(
+                    firstAddress?.let {
+                        Coordinate(
+                            latitude = it.latitude,
+                            longitude = it.longitude,
+                        )
+                    },
+                )
+            }
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun geocodeForBelowTiramisu(
+        geocoder: Geocoder,
+        address: String,
+    ): Coordinate? {
+        return runCatching {
+            geocoder.getFromLocationName(
+                address,
+                MAX_RESULT_COUNT,
+            )?.firstOrNull()?.let {
+                Coordinate(
+                    latitude = it.latitude,
+                    longitude = it.longitude,
+                )
+            }
+        }.getOrNull()
+    }
+
+    private companion object {
+        const val MAX_RESULT_COUNT = 1
+    }
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/mapper/SpotMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/mapper/SpotMapper.kt
@@ -1,0 +1,54 @@
+package com.team.yeogibeoryeo.data.spot.mapper
+
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotItemDto
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import javax.inject.Inject
+
+class SpotMapper @Inject constructor() {
+
+    fun mapToDomain(
+        dto: SpotItemDto,
+    ): CollectionSpot {
+        val name = dto.spotNm.orEmpty()
+        val address = dto.addrBase.orEmpty()
+        val detailLocation = dto.addrDtl?.takeIf { it.isNotBlank() }
+
+        return CollectionSpot(
+            id = createSpotId(
+                name = name,
+                address = address,
+                detailLocation = detailLocation,
+            ),
+            name = name,
+            type = SpotTypeMapper.mapToType(
+                spotName = name,
+                detailAddress = detailLocation,
+            ),
+            address = address,
+            detailLocation = detailLocation,
+            coordinate = null,
+            distanceMeter = null,
+            isBookmarked = false,
+        )
+    }
+
+    fun mapToDomainList(
+        dtoList: List<SpotItemDto>,
+    ): List<CollectionSpot> {
+        return dtoList.map { dto ->
+            mapToDomain(dto)
+        }
+    }
+
+    private fun createSpotId(
+        name: String,
+        address: String,
+        detailLocation: String?,
+    ): String {
+        return listOfNotNull(
+            name,
+            address,
+            detailLocation,
+        ).joinToString(separator = "_")
+    }
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/mapper/SpotTypeMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/mapper/SpotTypeMapper.kt
@@ -1,0 +1,42 @@
+package com.team.yeogibeoryeo.data.spot.mapper
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+
+object SpotTypeMapper {
+
+    fun mapToType(
+        spotName: String?,
+        detailAddress: String?,
+    ): CollectionSpotType {
+        val targetText = listOfNotNull(
+            spotName,
+            detailAddress,
+        ).joinToString(separator = " ").trim()
+
+        return when {
+            targetText.contains("건전지") -> {
+                CollectionSpotType.BATTERY_BIN
+            }
+
+            targetText.contains("휴대폰") -> {
+                CollectionSpotType.PHONE_DROP_OFF
+            }
+
+            targetText.contains("재활용센터") || targetText.contains("재활용 센터") -> {
+                CollectionSpotType.RECYCLING_CENTER
+            }
+
+            targetText.contains("종량제") || targetText.contains("봉투") -> {
+                CollectionSpotType.STANDARD_BAG_STORE
+            }
+
+            targetText.contains("중소형") || targetText.contains("수거함") -> {
+                CollectionSpotType.SMALL_E_WASTE_BIN
+            }
+
+            else -> {
+                CollectionSpotType.OTHER
+            }
+        }
+    }
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/remote/SpotApiService.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/remote/SpotApiService.kt
@@ -1,3 +1,20 @@
 package com.team.yeogibeoryeo.data.spot.remote
 
-// /getSpot API 자리
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotResponseDto
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface SpotApiService {
+
+    @GET("getSpot")
+    suspend fun getSpots(
+        @Query("serviceKey") serviceKey: String,
+        @Query("pageNo") pageNo: Int = 1,
+        @Query("numOfRows") numOfRows: Int = 100,
+        @Query("addr") addr: String,
+        @Query("latitude") latitude: Double? = null,
+        @Query("longitude") longitude: Double? = null,
+        @Query("radius") radius: Int? = null,
+        @Query("_type") type: String = "json",
+    ): SpotResponseDto
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/remote/datasource/SpotRemoteDataSource.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/remote/datasource/SpotRemoteDataSource.kt
@@ -1,0 +1,60 @@
+package com.team.yeogibeoryeo.data.spot.remote.datasource
+
+import com.team.yeogibeoryeo.data.spot.remote.SpotApiService
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotItemDto
+import javax.inject.Inject
+
+class SpotRemoteDataSource @Inject constructor(
+    private val apiService: SpotApiService,
+) {
+    suspend fun searchByKeyword(
+        serviceKey: String,
+        keyword: String,
+        pageNo: Int = 1,
+        numOfRows: Int = 100,
+    ): List<SpotItemDto> {
+        val response = apiService.getSpots(
+            serviceKey = serviceKey,
+            pageNo = pageNo,
+            numOfRows = numOfRows,
+            addr = keyword,
+        )
+
+        return response.toSpotItemsOrEmpty()
+    }
+
+    suspend fun searchByLocation(
+        serviceKey: String,
+        latitude: Double,
+        longitude: Double,
+        radiusMeter: Int,
+        pageNo: Int = 1,
+        numOfRows: Int = 100,
+    ): List<SpotItemDto> {
+        val response = apiService.getSpots(
+            serviceKey = serviceKey,
+            pageNo = pageNo,
+            numOfRows = numOfRows,
+            addr = " ",
+            latitude = latitude,
+            longitude = longitude,
+            radius = radiusMeter,
+        )
+
+        return response.toSpotItemsOrEmpty()
+    }
+
+    private fun com.team.yeogibeoryeo.data.spot.remote.dto.SpotResponseDto.toSpotItemsOrEmpty(): List<SpotItemDto> {
+        val resultCode = response.header.resultCode
+
+        if (resultCode == RESULT_CODE_NO_DATA) {
+            return emptyList()
+        }
+
+        return response.body.items?.item.orEmpty()
+    }
+
+    private companion object {
+        const val RESULT_CODE_NO_DATA = "03"
+    }
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/remote/dto/SpotItemDto.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/remote/dto/SpotItemDto.kt
@@ -1,0 +1,13 @@
+@file:OptIn(InternalSerializationApi::class)
+
+package com.team.yeogibeoryeo.data.spot.remote.dto
+
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SpotItemDto(
+    val spotNm: String? = null,
+    val addrBase: String? = null,
+    val addrDtl: String? = null,
+)

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/remote/dto/SpotResponseDto.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/remote/dto/SpotResponseDto.kt
@@ -1,0 +1,37 @@
+@file:OptIn(InternalSerializationApi::class)
+
+package com.team.yeogibeoryeo.data.spot.remote.dto
+
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+@Serializable
+data class SpotResponseDto(
+    val response: SpotResponseBodyDto,
+)
+
+@Serializable
+data class SpotResponseBodyDto(
+    val header: SpotHeaderDto,
+    val body: SpotBodyDto,
+)
+
+@Serializable
+data class SpotHeaderDto(
+    val resultCode: String,
+    val resultMsg: String,
+)
+
+@Serializable
+data class SpotBodyDto(
+    val items: SpotItemsDto? = null,
+    val numOfRows: JsonElement? = null,
+    val pageNo: JsonElement? = null,
+    val totalCount: JsonElement? = null,
+)
+
+@Serializable
+data class SpotItemsDto(
+    val item: List<SpotItemDto> = emptyList(),
+)

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
@@ -1,0 +1,79 @@
+package com.team.yeogibeoryeo.data.spot.repository
+
+import com.team.yeogibeoryeo.data.BuildConfig
+import com.team.yeogibeoryeo.data.spot.geocoder.SpotGeocoder
+import com.team.yeogibeoryeo.data.spot.mapper.SpotMapper
+import com.team.yeogibeoryeo.data.spot.remote.datasource.SpotRemoteDataSource
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
+import javax.inject.Inject
+
+class CollectionSpotRepositoryImpl @Inject constructor(
+    private val remoteDataSource: SpotRemoteDataSource,
+    private val spotMapper: SpotMapper,
+    private val spotGeocoder: SpotGeocoder,
+) : CollectionSpotRepository {
+
+    override suspend fun searchByKeyword(
+        keyword: String,
+        types: Set<CollectionSpotType>,
+    ): List<CollectionSpot> {
+        val spots = remoteDataSource.searchByKeyword(
+            serviceKey = BuildConfig.PUBLIC_DATA_SERVICE_KEY,
+            keyword = keyword,
+        ).let { dtoList ->
+            spotMapper.mapToDomainList(dtoList)
+        }
+
+        return spots
+            .filterByTypes(types)
+            .geocodeAll()
+    }
+
+    override suspend fun searchByLocation(
+        coordinate: Coordinate,
+        radiusMeter: Int,
+        types: Set<CollectionSpotType>,
+    ): List<CollectionSpot> {
+        val spots = remoteDataSource.searchByLocation(
+            serviceKey = BuildConfig.PUBLIC_DATA_SERVICE_KEY,
+            latitude = coordinate.latitude,
+            longitude = coordinate.longitude,
+            radiusMeter = radiusMeter,
+        ).let { dtoList ->
+            spotMapper.mapToDomainList(dtoList)
+        }
+
+        return spots
+            .filterByTypes(types)
+            .geocodeAll()
+    }
+
+    override suspend fun geocodeSpot(
+        spot: CollectionSpot,
+    ): CollectionSpot {
+        val coordinate = spotGeocoder.geocode(spot.address)
+
+        return spot.copy(
+            coordinate = coordinate,
+        )
+    }
+
+    private fun List<CollectionSpot>.filterByTypes(
+        types: Set<CollectionSpotType>,
+    ): List<CollectionSpot> {
+        if (types.isEmpty()) return this
+
+        return filter { spot ->
+            spot.type in types
+        }
+    }
+
+    private suspend fun List<CollectionSpot>.geocodeAll(): List<CollectionSpot> {
+        return map { spot ->
+            geocodeSpot(spot)
+        }
+    }
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.team.yeogibeoryeo.data.spot.repository
 
-import com.team.yeogibeoryeo.data.BuildConfig
+import com.team.yeogibeoryeo.data.core.key.PublicDataKeyProvider
 import com.team.yeogibeoryeo.data.spot.geocoder.SpotGeocoder
 import com.team.yeogibeoryeo.data.spot.mapper.SpotMapper
 import com.team.yeogibeoryeo.data.spot.remote.datasource.SpotRemoteDataSource
@@ -14,6 +14,7 @@ class CollectionSpotRepositoryImpl @Inject constructor(
     private val remoteDataSource: SpotRemoteDataSource,
     private val spotMapper: SpotMapper,
     private val spotGeocoder: SpotGeocoder,
+    private val publicDataKeyProvider: PublicDataKeyProvider,
 ) : CollectionSpotRepository {
 
     override suspend fun searchByKeyword(
@@ -21,7 +22,7 @@ class CollectionSpotRepositoryImpl @Inject constructor(
         types: Set<CollectionSpotType>,
     ): List<CollectionSpot> {
         val spots = remoteDataSource.searchByKeyword(
-            serviceKey = BuildConfig.PUBLIC_DATA_SERVICE_KEY,
+            serviceKey = publicDataKeyProvider.serviceKey,
             keyword = keyword,
         ).let { dtoList ->
             spotMapper.mapToDomainList(dtoList)
@@ -38,7 +39,7 @@ class CollectionSpotRepositoryImpl @Inject constructor(
         types: Set<CollectionSpotType>,
     ): List<CollectionSpot> {
         val spots = remoteDataSource.searchByLocation(
-            serviceKey = BuildConfig.PUBLIC_DATA_SERVICE_KEY,
+            serviceKey = publicDataKeyProvider.serviceKey,
             latitude = coordinate.latitude,
             longitude = coordinate.longitude,
             radiusMeter = radiusMeter,

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/mapper/SpotMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/mapper/SpotMapperTest.kt
@@ -1,0 +1,83 @@
+package com.team.yeogibeoryeo.data.spot.mapper
+
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotItemDto
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SpotMapperTest {
+
+    private val spotMapper = SpotMapper()
+
+    @Test
+    fun `SpotItemDto를 CollectionSpot으로 변환한다`() {
+        val dto = SpotItemDto(
+            spotNm = "폐건전지 수거함",
+            addrBase = "서울특별시 영등포구 문래동",
+            addrDtl = "주민센터 앞",
+        )
+
+        val result = spotMapper.mapToDomain(dto)
+
+        assertEquals("폐건전지 수거함", result.name)
+        assertEquals("서울특별시 영등포구 문래동", result.address)
+        assertEquals("주민센터 앞", result.detailLocation)
+        assertEquals(CollectionSpotType.BATTERY_BIN, result.type)
+        assertNull(result.coordinate)
+        assertNull(result.distanceMeter)
+        assertFalse(result.isBookmarked)
+    }
+
+    @Test
+    fun `SpotItemDto 변환 시 id는 장소명 주소 상세주소를 기반으로 생성된다`() {
+        val dto = SpotItemDto(
+            spotNm = "폐건전지 수거함",
+            addrBase = "서울특별시 영등포구 문래동",
+            addrDtl = "주민센터 앞",
+        )
+
+        val result = spotMapper.mapToDomain(dto)
+
+        assertEquals(
+            "폐건전지 수거함_서울특별시 영등포구 문래동_주민센터 앞",
+            result.id,
+        )
+    }
+
+    @Test
+    fun `addrDtl이 빈 문자열이면 detailLocation은 null로 변환된다`() {
+        val dto = SpotItemDto(
+            spotNm = "중소형 폐가전 수거함",
+            addrBase = "서울특별시 구로구 구로동",
+            addrDtl = "",
+        )
+
+        val result = spotMapper.mapToDomain(dto)
+
+        assertNull(result.detailLocation)
+    }
+
+    @Test
+    fun `SpotItemDto 리스트를 CollectionSpot 리스트로 변환한다`() {
+        val dtoList = listOf(
+            SpotItemDto(
+                spotNm = "폐건전지 수거함",
+                addrBase = "서울특별시 영등포구 문래동",
+                addrDtl = "주민센터 앞",
+            ),
+            SpotItemDto(
+                spotNm = "재활용센터",
+                addrBase = "서울특별시 구로구 구로동",
+                addrDtl = "센터 입구",
+            ),
+        )
+
+        val result = spotMapper.mapToDomainList(dtoList)
+
+        assertEquals(2, result.size)
+        assertEquals(CollectionSpotType.BATTERY_BIN, result[0].type)
+        assertEquals(CollectionSpotType.RECYCLING_CENTER, result[1].type)
+    }
+}

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/mapper/SpotTypeMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/mapper/SpotTypeMapperTest.kt
@@ -1,0 +1,78 @@
+package com.team.yeogibeoryeo.data.spot.mapper
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SpotTypeMapperTest {
+
+    @Test
+    fun `장소명이 폐건전지 수거함이면 BATTERY_BIN을 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "폐건전지 수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.BATTERY_BIN, result)
+    }
+
+    @Test
+    fun `장소명이 폐휴대폰 배출처이면 PHONE_DROP_OFF를 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "폐휴대폰 배출처",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.PHONE_DROP_OFF, result)
+    }
+
+    @Test
+    fun `장소명이 재활용센터이면 RECYCLING_CENTER를 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "구로 재활용센터",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.RECYCLING_CENTER, result)
+    }
+
+    @Test
+    fun `장소명이 종량제봉투 판매소이면 STANDARD_BAG_STORE를 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "종량제봉투 판매소",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.STANDARD_BAG_STORE, result)
+    }
+
+    @Test
+    fun `장소명이 중소형 수거함이면 SMALL_E_WASTE_BIN을 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "중소형 폐가전 수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.SMALL_E_WASTE_BIN, result)
+    }
+
+    @Test
+    fun `알 수 없는 장소명이면 OTHER를 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "임시 배출장소",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.OTHER, result)
+    }
+
+    @Test
+    fun `폐건전지 수거함은 수거함보다 건전지 조건이 우선되어 BATTERY_BIN을 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "폐건전지 수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.BATTERY_BIN, result)
+    }
+}

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/remote/datasource/SpotRemoteDataSourceTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/remote/datasource/SpotRemoteDataSourceTest.kt
@@ -1,0 +1,195 @@
+package com.team.yeogibeoryeo.data.spot.remote.datasource
+
+import com.team.yeogibeoryeo.data.spot.remote.SpotApiService
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotBodyDto
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotHeaderDto
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotItemDto
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotItemsDto
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotResponseBodyDto
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotResponseDto
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SpotRemoteDataSourceTest {
+
+    @Test
+    fun `검색어 기반 조회 시 keyword가 addr 파라미터로 전달된다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createNormalResponse(),
+        )
+        val dataSource = SpotRemoteDataSource(apiService)
+
+        val result = dataSource.searchByKeyword(
+            serviceKey = TEST_SERVICE_KEY,
+            keyword = "문래동",
+        )
+
+        assertEquals("문래동", apiService.requestedAddr)
+        assertNull(apiService.requestedLatitude)
+        assertNull(apiService.requestedLongitude)
+        assertNull(apiService.requestedRadius)
+        assertEquals(1, result.size)
+        assertEquals("폐건전지 수거함", result.first().spotNm)
+    }
+
+    @Test
+    fun `현재 위치 기반 조회 시 공백 addr와 좌표 반경이 전달된다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createNormalResponse(),
+        )
+        val dataSource = SpotRemoteDataSource(apiService)
+
+        val result = dataSource.searchByLocation(
+            serviceKey = TEST_SERVICE_KEY,
+            latitude = 37.5182396969791,
+            longitude = 126.895880210522,
+            radiusMeter = 500,
+        )
+
+        assertEquals(" ", apiService.requestedAddr)
+        assertEquals(37.5182396969791, apiService.requestedLatitude)
+        assertEquals(126.895880210522, apiService.requestedLongitude)
+        assertEquals(500, apiService.requestedRadius)
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `정상 응답이면 item 리스트를 반환한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createNormalResponse(),
+        )
+        val dataSource = SpotRemoteDataSource(apiService)
+
+        val result = dataSource.searchByKeyword(
+            serviceKey = TEST_SERVICE_KEY,
+            keyword = "문래동",
+        )
+
+        assertEquals(1, result.size)
+        assertEquals("폐건전지 수거함", result.first().spotNm)
+        assertEquals("서울특별시 영등포구 문래동", result.first().addrBase)
+        assertEquals("주민센터 앞", result.first().addrDtl)
+    }
+
+    @Test
+    fun `NODATA_ERROR 응답이면 빈 리스트를 반환한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createNoDataResponse(),
+        )
+        val dataSource = SpotRemoteDataSource(apiService)
+
+        val result = dataSource.searchByKeyword(
+            serviceKey = TEST_SERVICE_KEY,
+            keyword = "약수동",
+        )
+
+        assertEquals(emptyList<SpotItemDto>(), result)
+    }
+
+    @Test
+    fun `items가 null이면 빈 리스트를 반환한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createNormalResponseWithNullItems(),
+        )
+        val dataSource = SpotRemoteDataSource(apiService)
+
+        val result = dataSource.searchByKeyword(
+            serviceKey = TEST_SERVICE_KEY,
+            keyword = "문래동",
+        )
+
+        assertEquals(emptyList<SpotItemDto>(), result)
+    }
+
+    private class FakeSpotApiService(
+        private val response: SpotResponseDto,
+    ) : SpotApiService {
+
+        var requestedServiceKey: String? = null
+        var requestedPageNo: Int? = null
+        var requestedNumOfRows: Int? = null
+        var requestedAddr: String? = null
+        var requestedLatitude: Double? = null
+        var requestedLongitude: Double? = null
+        var requestedRadius: Int? = null
+        var requestedType: String? = null
+
+        override suspend fun getSpots(
+            serviceKey: String,
+            pageNo: Int,
+            numOfRows: Int,
+            addr: String,
+            latitude: Double?,
+            longitude: Double?,
+            radius: Int?,
+            type: String,
+        ): SpotResponseDto {
+            requestedServiceKey = serviceKey
+            requestedPageNo = pageNo
+            requestedNumOfRows = numOfRows
+            requestedAddr = addr
+            requestedLatitude = latitude
+            requestedLongitude = longitude
+            requestedRadius = radius
+            requestedType = type
+
+            return response
+        }
+    }
+
+    private companion object {
+        const val TEST_SERVICE_KEY = "test-service-key"
+
+        fun createNormalResponse(): SpotResponseDto {
+            return SpotResponseDto(
+                response = SpotResponseBodyDto(
+                    header = SpotHeaderDto(
+                        resultCode = "00",
+                        resultMsg = "NORMAL SERVICE",
+                    ),
+                    body = SpotBodyDto(
+                        items = SpotItemsDto(
+                            item = listOf(
+                                SpotItemDto(
+                                    spotNm = "폐건전지 수거함",
+                                    addrBase = "서울특별시 영등포구 문래동",
+                                    addrDtl = "주민센터 앞",
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        }
+
+        fun createNoDataResponse(): SpotResponseDto {
+            return SpotResponseDto(
+                response = SpotResponseBodyDto(
+                    header = SpotHeaderDto(
+                        resultCode = "03",
+                        resultMsg = "NODATA_ERROR",
+                    ),
+                    body = SpotBodyDto(
+                        items = null,
+                    ),
+                ),
+            )
+        }
+
+        fun createNormalResponseWithNullItems(): SpotResponseDto {
+            return SpotResponseDto(
+                response = SpotResponseBodyDto(
+                    header = SpotHeaderDto(
+                        resultCode = "00",
+                        resultMsg = "NORMAL SERVICE",
+                    ),
+                    body = SpotBodyDto(
+                        items = null,
+                    ),
+                ),
+            )
+        }
+    }
+}

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImplTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImplTest.kt
@@ -1,5 +1,6 @@
 package com.team.yeogibeoryeo.data.spot.repository
 
+import com.team.yeogibeoryeo.data.core.key.PublicDataKeyProvider
 import com.team.yeogibeoryeo.data.spot.geocoder.SpotGeocoder
 import com.team.yeogibeoryeo.data.spot.mapper.SpotMapper
 import com.team.yeogibeoryeo.data.spot.remote.SpotApiService
@@ -30,6 +31,7 @@ class CollectionSpotRepositoryImplTest {
             keyword = "문래동",
         )
 
+        assertEquals(TEST_SERVICE_KEY, apiService.requestedServiceKey)
         assertEquals("문래동", apiService.requestedAddr)
         assertEquals(2, result.size)
 
@@ -56,6 +58,7 @@ class CollectionSpotRepositoryImplTest {
             types = setOf(CollectionSpotType.RECYCLING_CENTER),
         )
 
+        assertEquals(TEST_SERVICE_KEY, apiService.requestedServiceKey)
         assertEquals(1, result.size)
         assertEquals("재활용센터", result.first().name)
         assertEquals(CollectionSpotType.RECYCLING_CENTER, result.first().type)
@@ -76,6 +79,7 @@ class CollectionSpotRepositoryImplTest {
             radiusMeter = 500,
         )
 
+        assertEquals(TEST_SERVICE_KEY, apiService.requestedServiceKey)
         assertEquals(" ", apiService.requestedAddr)
         assertEquals(37.5182396969791, apiService.requestedLatitude)
         assertEquals(126.895880210522, apiService.requestedLongitude)
@@ -94,6 +98,7 @@ class CollectionSpotRepositoryImplTest {
             keyword = "약수동",
         )
 
+        assertEquals(TEST_SERVICE_KEY, apiService.requestedServiceKey)
         assertEquals(emptyList<Any>(), result)
     }
 
@@ -104,7 +109,12 @@ class CollectionSpotRepositoryImplTest {
             remoteDataSource = SpotRemoteDataSource(apiService),
             spotMapper = SpotMapper(),
             spotGeocoder = FakeSpotGeocoder(),
+            publicDataKeyProvider = FakePublicDataKeyProvider(),
         )
+    }
+
+    private class FakePublicDataKeyProvider : PublicDataKeyProvider {
+        override val serviceKey: String = TEST_SERVICE_KEY
     }
 
     private class FakeSpotGeocoder : SpotGeocoder {
@@ -153,6 +163,7 @@ class CollectionSpotRepositoryImplTest {
     }
 
     private companion object {
+        const val TEST_SERVICE_KEY = "test-service-key"
 
         fun createNormalResponse(): SpotResponseDto {
             return SpotResponseDto(

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImplTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImplTest.kt
@@ -1,0 +1,198 @@
+package com.team.yeogibeoryeo.data.spot.repository
+
+import com.team.yeogibeoryeo.data.spot.geocoder.SpotGeocoder
+import com.team.yeogibeoryeo.data.spot.mapper.SpotMapper
+import com.team.yeogibeoryeo.data.spot.remote.SpotApiService
+import com.team.yeogibeoryeo.data.spot.remote.datasource.SpotRemoteDataSource
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotBodyDto
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotHeaderDto
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotItemDto
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotItemsDto
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotResponseBodyDto
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotResponseDto
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class CollectionSpotRepositoryImplTest {
+
+    @Test
+    fun `검색어 기반 조회 결과를 CollectionSpot으로 변환하고 좌표를 설정한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createNormalResponse(),
+        )
+        val repository = createRepository(apiService)
+
+        val result = repository.searchByKeyword(
+            keyword = "문래동",
+        )
+
+        assertEquals("문래동", apiService.requestedAddr)
+        assertEquals(2, result.size)
+
+        val firstSpot = result.first()
+
+        assertEquals("폐건전지 수거함", firstSpot.name)
+        assertEquals("서울특별시 영등포구 문래동", firstSpot.address)
+        assertEquals("주민센터 앞", firstSpot.detailLocation)
+        assertEquals(CollectionSpotType.BATTERY_BIN, firstSpot.type)
+        assertNotNull(firstSpot.coordinate)
+        assertEquals(37.5, firstSpot.coordinate?.latitude)
+        assertEquals(126.9, firstSpot.coordinate?.longitude)
+    }
+
+    @Test
+    fun `검색어 기반 조회 시 선택된 타입에 해당하는 장소만 반환한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createNormalResponse(),
+        )
+        val repository = createRepository(apiService)
+
+        val result = repository.searchByKeyword(
+            keyword = "문래동",
+            types = setOf(CollectionSpotType.RECYCLING_CENTER),
+        )
+
+        assertEquals(1, result.size)
+        assertEquals("재활용센터", result.first().name)
+        assertEquals(CollectionSpotType.RECYCLING_CENTER, result.first().type)
+    }
+
+    @Test
+    fun `현재 위치 기반 조회 시 공백 addr와 좌표 반경을 전달하고 결과를 반환한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createNormalResponse(),
+        )
+        val repository = createRepository(apiService)
+
+        val result = repository.searchByLocation(
+            coordinate = Coordinate(
+                latitude = 37.5182396969791,
+                longitude = 126.895880210522,
+            ),
+            radiusMeter = 500,
+        )
+
+        assertEquals(" ", apiService.requestedAddr)
+        assertEquals(37.5182396969791, apiService.requestedLatitude)
+        assertEquals(126.895880210522, apiService.requestedLongitude)
+        assertEquals(500, apiService.requestedRadius)
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun `NODATA_ERROR 응답이면 빈 리스트를 반환한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createNoDataResponse(),
+        )
+        val repository = createRepository(apiService)
+
+        val result = repository.searchByKeyword(
+            keyword = "약수동",
+        )
+
+        assertEquals(emptyList<Any>(), result)
+    }
+
+    private fun createRepository(
+        apiService: FakeSpotApiService,
+    ): CollectionSpotRepositoryImpl {
+        return CollectionSpotRepositoryImpl(
+            remoteDataSource = SpotRemoteDataSource(apiService),
+            spotMapper = SpotMapper(),
+            spotGeocoder = FakeSpotGeocoder(),
+        )
+    }
+
+    private class FakeSpotGeocoder : SpotGeocoder {
+        override suspend fun geocode(address: String): Coordinate {
+            return Coordinate(
+                latitude = 37.5,
+                longitude = 126.9,
+            )
+        }
+    }
+
+    private class FakeSpotApiService(
+        private val response: SpotResponseDto,
+    ) : SpotApiService {
+
+        var requestedServiceKey: String? = null
+        var requestedPageNo: Int? = null
+        var requestedNumOfRows: Int? = null
+        var requestedAddr: String? = null
+        var requestedLatitude: Double? = null
+        var requestedLongitude: Double? = null
+        var requestedRadius: Int? = null
+        var requestedType: String? = null
+
+        override suspend fun getSpots(
+            serviceKey: String,
+            pageNo: Int,
+            numOfRows: Int,
+            addr: String,
+            latitude: Double?,
+            longitude: Double?,
+            radius: Int?,
+            type: String,
+        ): SpotResponseDto {
+            requestedServiceKey = serviceKey
+            requestedPageNo = pageNo
+            requestedNumOfRows = numOfRows
+            requestedAddr = addr
+            requestedLatitude = latitude
+            requestedLongitude = longitude
+            requestedRadius = radius
+            requestedType = type
+
+            return response
+        }
+    }
+
+    private companion object {
+
+        fun createNormalResponse(): SpotResponseDto {
+            return SpotResponseDto(
+                response = SpotResponseBodyDto(
+                    header = SpotHeaderDto(
+                        resultCode = "00",
+                        resultMsg = "NORMAL SERVICE",
+                    ),
+                    body = SpotBodyDto(
+                        items = SpotItemsDto(
+                            item = listOf(
+                                SpotItemDto(
+                                    spotNm = "폐건전지 수거함",
+                                    addrBase = "서울특별시 영등포구 문래동",
+                                    addrDtl = "주민센터 앞",
+                                ),
+                                SpotItemDto(
+                                    spotNm = "재활용센터",
+                                    addrBase = "서울특별시 구로구 구로동",
+                                    addrDtl = "센터 입구",
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        }
+
+        fun createNoDataResponse(): SpotResponseDto {
+            return SpotResponseDto(
+                response = SpotResponseBodyDto(
+                    header = SpotHeaderDto(
+                        resultCode = "03",
+                        resultMsg = "NODATA_ERROR",
+                    ),
+                    body = SpotBodyDto(
+                        items = null,
+                    ),
+                ),
+            )
+        }
+    }
+}

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -9,3 +9,7 @@ java {
 kotlin {
     jvmToolchain(21)
 }
+dependencies {
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.javax.inject)
+}

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -2,14 +2,19 @@ plugins {
     id("java-library")
     alias(libs.plugins.jetbrains.kotlin.jvm)
 }
+
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
 }
+
 kotlin {
     jvmToolchain(21)
 }
+
 dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.javax.inject)
+
+    testImplementation(libs.junit)
 }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/CollectionSpot.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/CollectionSpot.kt
@@ -1,3 +1,12 @@
 package com.team.yeogibeoryeo.domain.spot.model
 
-//수빈님 지도 장소 모델 자리
+data class CollectionSpot(
+    val id: String,
+    val name: String,
+    val type: CollectionSpotType,
+    val address: String,
+    val detailLocation: String?,
+    val coordinate: Coordinate?,
+    val distanceMeter: Int? = null,
+    val isBookmarked: Boolean = false
+)

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/CollectionSpotType.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/CollectionSpotType.kt
@@ -1,0 +1,10 @@
+package com.team.yeogibeoryeo.domain.spot.model
+
+enum class CollectionSpotType {
+    SMALL_E_WASTE_BIN,     // 중소형 수거함
+    BATTERY_BIN,           // 폐건전지
+    PHONE_DROP_OFF,       // 폐휴대폰
+    RECYCLING_CENTER,      // 재활용센터
+    STANDARD_BAG_STORE,    // 종량제봉투 판매소
+    OTHER                 // 기타
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/Coordinate.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/Coordinate.kt
@@ -1,0 +1,6 @@
+package com.team.yeogibeoryeo.domain.spot.model
+
+data class Coordinate(
+    val latitude: Double,
+    val longitude: Double
+)

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/MapSearchCondition.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/MapSearchCondition.kt
@@ -1,0 +1,8 @@
+package com.team.yeogibeoryeo.domain.spot.model
+
+data class MapSearchCondition(
+    val keyword: String? = null,
+    val currentCoordinate: Coordinate? = null,
+    val radiusMeter: Int? = null,
+    val selectedTypes: Set<CollectionSpotType> = emptySet()
+)

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/CollectionSpotRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/CollectionSpotRepository.kt
@@ -11,9 +11,13 @@ interface CollectionSpotRepository {
         types: Set<CollectionSpotType> = emptySet()
     ): List<CollectionSpot>
 
-    suspend fun searchNearby(
+    suspend fun searchByLocation(
         coordinate: Coordinate,
         radiusMeter: Int,
         types: Set<CollectionSpotType> = emptySet()
     ): List<CollectionSpot>
+
+    suspend fun geocodeSpot(
+        spot: CollectionSpot
+    ): CollectionSpot
 }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/CollectionSpotRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/CollectionSpotRepository.kt
@@ -1,0 +1,19 @@
+package com.team.yeogibeoryeo.domain.spot.repository
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+
+interface CollectionSpotRepository {
+
+    suspend fun searchByKeyword(
+        keyword: String,
+        types: Set<CollectionSpotType> = emptySet()
+    ): List<CollectionSpot>
+
+    suspend fun searchNearby(
+        coordinate: Coordinate,
+        radiusMeter: Int,
+        types: Set<CollectionSpotType> = emptySet()
+    ): List<CollectionSpot>
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/FilterCollectionSpotsUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/FilterCollectionSpotsUseCase.kt
@@ -1,0 +1,19 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import javax.inject.Inject
+
+class FilterCollectionSpotsUseCase @Inject constructor() {
+
+    operator fun invoke(
+        spots: List<CollectionSpot>,
+        selectedTypes: Set<CollectionSpotType>
+    ): List<CollectionSpot> {
+        if (selectedTypes.isEmpty()) return spots
+
+        return spots.filter { spot ->
+            spot.type in selectedTypes
+        }
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/GeocodeCollectionSpotUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/GeocodeCollectionSpotUseCase.kt
@@ -1,0 +1,15 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
+import javax.inject.Inject
+
+class GeocodeCollectionSpotUseCase @Inject constructor(
+    private val repository: CollectionSpotRepository
+) {
+    suspend operator fun invoke(
+        spot: CollectionSpot
+    ): CollectionSpot {
+        return repository.geocodeSpot(spot)
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
@@ -1,0 +1,20 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
+import javax.inject.Inject
+
+class SearchCollectionSpotsByKeywordUseCase @Inject constructor(
+    private val repository: CollectionSpotRepository
+) {
+    suspend operator fun invoke(
+        keyword: String,
+        types: Set<CollectionSpotType> = emptySet()
+    ): List<CollectionSpot> {
+        return repository.searchByKeyword(
+            keyword = keyword,
+            types = types
+        )
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByLocationUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByLocationUseCase.kt
@@ -1,0 +1,23 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
+import javax.inject.Inject
+
+class SearchCollectionSpotsByLocationUseCase @Inject constructor(
+    private val repository: CollectionSpotRepository
+) {
+    suspend operator fun invoke(
+        coordinate: Coordinate,
+        radiusMeter: Int,
+        types: Set<CollectionSpotType> = emptySet()
+    ): List<CollectionSpot> {
+        return repository.searchByLocation(
+            coordinate = coordinate,
+            radiusMeter = radiusMeter,
+            types = types
+        )
+    }
+}

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/FilterCollectionSpotsUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/FilterCollectionSpotsUseCaseTest.kt
@@ -1,0 +1,107 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FilterCollectionSpotsUseCaseTest {
+
+    private val filterCollectionSpotsUseCase = FilterCollectionSpotsUseCase()
+
+    @Test
+    fun `선택된 타입이 없으면 전체 장소 목록을 반환한다`() {
+        val spots = createCollectionSpots()
+
+        val result = filterCollectionSpotsUseCase(
+            spots = spots,
+            selectedTypes = emptySet(),
+        )
+
+        assertEquals(spots, result)
+    }
+
+    @Test
+    fun `선택된 타입에 해당하는 장소만 반환한다`() {
+        val spots = createCollectionSpots()
+
+        val result = filterCollectionSpotsUseCase(
+            spots = spots,
+            selectedTypes = setOf(CollectionSpotType.BATTERY_BIN),
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(CollectionSpotType.BATTERY_BIN, result.first().type)
+    }
+
+    @Test
+    fun `여러 타입이 선택되면 해당 타입들의 장소를 모두 반환한다`() {
+        val spots = createCollectionSpots()
+
+        val result = filterCollectionSpotsUseCase(
+            spots = spots,
+            selectedTypes = setOf(
+                CollectionSpotType.BATTERY_BIN,
+                CollectionSpotType.RECYCLING_CENTER,
+            ),
+        )
+
+        assertEquals(2, result.size)
+        assertEquals(
+            listOf(
+                CollectionSpotType.BATTERY_BIN,
+                CollectionSpotType.RECYCLING_CENTER,
+            ),
+            result.map { it.type },
+        )
+    }
+
+    @Test
+    fun `선택된 타입에 해당하는 장소가 없으면 빈 리스트를 반환한다`() {
+        val spots = createCollectionSpots()
+
+        val result = filterCollectionSpotsUseCase(
+            spots = spots,
+            selectedTypes = setOf(CollectionSpotType.PHONE_DROP_OFF),
+        )
+
+        assertEquals(emptyList<CollectionSpot>(), result)
+    }
+
+    private fun createCollectionSpots(): List<CollectionSpot> {
+        return listOf(
+            createCollectionSpot(
+                id = "spot-1",
+                name = "폐건전지 수거함",
+                type = CollectionSpotType.BATTERY_BIN,
+            ),
+            createCollectionSpot(
+                id = "spot-2",
+                name = "재활용센터",
+                type = CollectionSpotType.RECYCLING_CENTER,
+            ),
+            createCollectionSpot(
+                id = "spot-3",
+                name = "종량제봉투 판매소",
+                type = CollectionSpotType.STANDARD_BAG_STORE,
+            ),
+        )
+    }
+
+    private fun createCollectionSpot(
+        id: String,
+        name: String,
+        type: CollectionSpotType,
+    ): CollectionSpot {
+        return CollectionSpot(
+            id = id,
+            name = name,
+            type = type,
+            address = "서울특별시 영등포구 문래동",
+            detailLocation = null,
+            coordinate = null,
+            distanceMeter = null,
+            isBookmarked = false,
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 agp = "9.2.1"
 kotlin = "2.2.10"
 jetbrainsKotlinJvm = "2.2.10"
-ksp = "2.2.10-2.0.2"
+ksp = "2.3.6"
 
 # AndroidX Core
 coreKtx = "1.10.1"
@@ -32,8 +32,9 @@ naverMapCompose = "1.6.0"
 room = "2.7.2"
 
 # DI
-hilt = "2.57"
+hilt = "2.59.2"
 hiltNavigationCompose = "1.2.0"
+javaxInject = "1"
 
 # Test
 junit = "4.13.2"
@@ -91,6 +92,7 @@ androidx-room-compiler = { group = "androidx.room", name = "room-compiler", vers
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+javax-inject = { group = "javax.inject", name = "javax.inject", version.ref = "javaxInject" }
 
 # Test
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
## 작업 내용

`/getSpot` API를 활용하여 지도에 표시할 수거 장소 데이터를 조회하고, 앱 내부 도메인 모델인 `CollectionSpot`으로 변환하는 `domain/data` 계층을 구현했습니다.

이번 PR에서는 Compose 지도 화면, ViewModel, 지도 마커 UI, 하단 리스트 UI는 포함하지 않습니다.  
추후 `presentation/map` 계층에서 본 구조를 활용하여 네이버 지도 마커, 장소 리스트, 장소 유형 필터 UI를 구현할 예정입니다.

---

## 주요 구현 사항

### Domain 계층

- `domain/spot/model` 패키지 추가
- `CollectionSpot` 도메인 모델 정의
- `CollectionSpotType` enum 정의
- `Coordinate` 도메인 모델 정의
- `MapSearchCondition` 도메인 모델 정의
- `CollectionSpotRepository` 인터페이스 정의
- 수거 장소 관련 UseCase 정의
  - `SearchCollectionSpotsByKeywordUseCase`
  - `SearchCollectionSpotsByLocationUseCase`
  - `FilterCollectionSpotsUseCase`
  - `GeocodeCollectionSpotUseCase`

### Data - Remote

- `data/spot/remote` 패키지 추가
- `/getSpot` API 응답 DTO 정의
- `SpotApiService` Retrofit 인터페이스 정의
- `SpotRemoteDataSource` 구현
- 검색어 기반 조회 시 `addr` 파라미터 전달
- 현재 위치 기반 조회 시 `addr = " "`, `latitude`, `longitude`, `radius` 전달
- `NODATA_ERROR` 응답 및 `items = null` 응답을 빈 리스트로 처리

### Data - Mapper

- `SpotMapper` 구현
- `SpotTypeMapper` 구현
- `SpotItemDto`를 `CollectionSpot`으로 변환
- `spotNm`, `addrDtl` 기반 장소 유형 분류
- Geocoding 전 단계에서는 `CollectionSpot.coordinate = null`로 처리
- `addrDtl`이 빈 문자열인 경우 `detailLocation = null`로 처리

### Data - Geocoder

- `SpotGeocoder` 인터페이스 정의
- Android `Geocoder` 기반 `AndroidSpotGeocoder` 구현
- `addrBase` 기반 Geocoding 처리 구조 구현
- Android 13 이상 / 미만 Geocoder 호출 방식 분기 처리
- Geocoding 실패 시 `coordinate = null` 유지

### Data - Repository

- `CollectionSpotRepositoryImpl` 구현
- 검색어 기반 조회와 현재 위치 기반 조회 연결
- DTO → Domain 변환
- 선택된 `CollectionSpotType` 기준 필터링
- `addrBase` 기반 Geocoding 적용
- Hilt를 통한 `CollectionSpotRepository`, `SpotGeocoder` binding 구성

### Gradle / 설정

- `data` 모듈에 Hilt 의존성 추가
- `data` 모듈에 `BuildConfig` 활성화
- `data` 모듈에 `PUBLIC_DATA_SERVICE_KEY` BuildConfigField 추가
- `domain` 모듈에 JUnit 테스트 의존성 추가

---

## 장소 유형 분류 기준

`SpotTypeMapper`에서 `/getSpot` 응답의 `spotNm`, `addrDtl` 문자열을 기준으로 아래 유형을 분류합니다.

- `SMALL_E_WASTE_BIN`: 중소형 수거함
- `BATTERY_BIN`: 폐건전지 수거함
- `PHONE_DROP_OFF`: 폐휴대폰 배출처
- `RECYCLING_CENTER`: 재활용센터
- `STANDARD_BAG_STORE`: 종량제봉투 판매소
- `OTHER`: 기타

`수거함` 키워드는 범위가 넓기 때문에 `건전지`, `휴대폰`, `종량제` 등을 먼저 검사한 뒤 마지막에 중소형 수거함 조건으로 분류하도록 처리했습니다.

---

## 테스트

아래 단위 테스트를 추가하고 통과 확인했습니다.

### Domain

- `FilterCollectionSpotsUseCaseTest`
  - 선택된 타입이 없으면 전체 장소 목록 반환
  - 선택된 타입이 있으면 해당 타입만 반환
  - 여러 타입 선택 시 해당 타입들의 장소 반환
  - 선택된 타입에 해당하는 장소가 없으면 빈 리스트 반환

### Data

- `SpotTypeMapperTest`
  - 장소명/상세주소 기반 `CollectionSpotType` 분류 검증
  - `수거함`보다 `건전지`, `휴대폰`, `종량제` 조건이 우선 적용되는지 검증

- `SpotMapperTest`
  - `SpotItemDto` → `CollectionSpot` 변환 검증
  - `spotNm`, `addrBase`, `addrDtl` 매핑 검증
  - 변환 직후 `coordinate = null` 검증
  - `id` 생성 결과 검증
  - `addrDtl` 빈 문자열 처리 검증

- `SpotRemoteDataSourceTest`
  - 검색어 기반 조회 시 `keyword`가 `addr` 파라미터로 전달되는지 검증
  - 현재 위치 기반 조회 시 `addr = " "`, `latitude`, `longitude`, `radius` 전달 검증
  - 정상 응답 시 item 리스트 반환 검증
  - `NODATA_ERROR` 응답 시 빈 리스트 반환 검증
  - `items = null`일 때 빈 리스트 반환 검증

- `CollectionSpotRepositoryImplTest`
  - 검색어 기반 조회 결과의 도메인 변환 검증
  - 선택된 `CollectionSpotType` 기준 필터링 검증
  - 현재 위치 기반 조회 파라미터 전달 검증
  - Geocoding 결과가 `CollectionSpot.coordinate`에 반영되는지 검증
  - `NODATA_ERROR` 응답 시 빈 리스트 반환 검증

## 참고 사항

- 이번 PR에는 Compose 화면, ViewModel, UiState, 지도 마커 UI 구현은 포함하지 않았습니다.
- /getSpot 응답의 주요 장소 필드는 spotNm, addrBase, addrDtl입니다.
- /getSpot의 latitude, longitude, radius는 응답 좌표가 아니라 현재 위치 기반 검색 조건입니다.
- /getSpot 응답에는 지도 표시용 좌표가 포함되지 않으므로, addrBase 기반 Geocoding을 통해 CollectionSpot.coordinate를 채우는 구조로 구현했습니다.
- 실제 API 호출 및 단말 Geocoding 검증은 서비스키, 네트워크, 단말 환경에 영향을 받기 때문에 후속 이슈로 분리할 예정입니다.
- getItem / getSpot의 공통 Retrofit, DI, API Key 관리 방식은 팀 논의 후 후속 이슈에서 정리할 예정입니다.

## 향후 고려사항

- 실제 `/getSpot` API 호출 및 Android `Geocoder` 동작 검증은 서비스키, 네트워크, 단말 환경에 영향을 받으므로 후속 이슈에서 수동 검증으로 진행할 예정입니다.
- 현재 `PUBLIC_DATA_SERVICE_KEY`는 `data BuildConfig`를 통해 참조하도록 구성했으나, 팀 공통 구조에 따라 `app BuildConfig`, `data BuildConfig`, 별도 `KeyProvider` 방식 중 하나로 정리할 필요가 있습니다.
- `getItem`과 `getSpot`의 API Service 생성 방식은 추후 통일이 필요합니다.
  - 기존 `WasteRecyclingServiceFactory` 유지 여부
  - Hilt Module 기반 Retrofit 제공 여부
- 공공데이터포털 인증키는 Encoding 키 / Decoding 키 중 어떤 값을 사용할지 팀 기준을 정하고, 이에 맞춰 `serviceKey` 전달 방식도 통일할 예정입니다.
  - Encoding 키 사용 시: `@Query(value = "serviceKey", encoded = true)`
  - Decoding 키 사용 시: `@Query("serviceKey")`
  

## 관련 이슈

Closes #13

후속 작업은 아래 이슈에서 진행합니다.

- #22 : `/getSpot` 실제 API 호출 및 Geocoding 수동 검증
- #23 : `getItem` / `getSpot` 공통 DI, Retrofit, API Key 관리 방식 정리