### PR TITLE
feat: Region 공통 도메인 및 주소 파서 구현

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.google.ksp)
+    alias(libs.plugins.hilt.android)
 }
 
 android {
@@ -45,6 +47,10 @@ dependencies {
     implementation(libs.retrofit)
     implementation(libs.retrofit.kotlinx.serialization.converter)
     implementation(libs.okhttp.logging.interceptor)
+
+    // Hilt
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)
 

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionNormalizer.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionNormalizer.kt
@@ -1,0 +1,46 @@
+package com.team.yeogibeoryeo.data.region
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+
+/**
+ * 행정구역 명칭을 배출 가이드 API(/info) 표준 포맷으로 보정하는 유틸리티
+ * 축약어(예: "서울")를 공식 명칭("서울특별시")으로 변환하고 특정 지역의 예외 케이스를 처리합니다.
+ */
+object RegionNormalizer {
+
+    private val sidoMap = mapOf(
+        "서울" to "서울특별시", "서울시" to "서울특별시",
+        "부산" to "부산광역시", "부산시" to "부산광역시",
+        "대구" to "대구광역시", "대구시" to "대구광역시",
+        "인천" to "인천광역시", "인천시" to "인천광역시",
+        "광주" to "광주광역시", "광주시" to "광주광역시",
+        "대전" to "대전광역시", "대전시" to "대전광역시",
+        "울산" to "울산광역시", "울산시" to "울산광역시",
+        "세종" to "세종특별자치시", "세종시" to "세종특별자치시",
+        "경기" to "경기도",
+        "강원" to "강원특별자치도",
+        "충북" to "충청북도",
+        "충남" to "충청남도",
+        "전북" to "전북특별자치도",
+        "전남" to "전라남도",
+        "경북" to "경상북도",
+        "경남" to "경상남도",
+        "제주" to "제주특별자치도"
+    )
+
+    fun normalize(region: Region): Region {
+        val normalizedSido = region.sido?.let { sidoMap[it] ?: it }
+
+        // [도메인 지식]: 세종특별자치시는 하위 구가 없으므로 API 오류 방지를 위해 sigungu 제거
+        val normalizedSigungu = if (normalizedSido == "세종특별자치시") {
+            null
+        } else {
+            region.sigungu
+        }
+
+        return region.copy(
+            sido = normalizedSido,
+            sigungu = normalizedSigungu
+        )
+    }
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionParser.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionParser.kt
@@ -1,3 +1,0 @@
-package com.team.yeogibeoryeo.data.region
-
-// 주소 → Region 파싱 자리

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionRepositoryImpl.kt
@@ -1,0 +1,30 @@
+package com.team.yeogibeoryeo.data.region
+
+import com.team.yeogibeoryeo.data.region.parser.RegionAddressParser
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.region.repository.RegionRepository
+import javax.inject.Inject
+
+/**
+ * [RegionRepository]의 실질적인 동작을 정의하는 Data 계층의 구현체
+ * 초기 1단계에서는 로컬 주소 파서만 활용하며, 향후 Geocoder API 등 외부 데이터 소스를 추가하여 확장합니다.
+ */
+class RegionRepositoryImpl @Inject constructor(
+    private val addressParser: RegionAddressParser
+) : RegionRepository {
+
+    override fun extractRegionFromAddress(address: String): Region? {
+        if (address.isBlank()) return null
+        return addressParser.parse(address)
+    }
+
+    override suspend fun resolveRegionFromKeyword(keyword: String): Region? {
+        if (keyword.isBlank()) return null
+        return addressParser.parse(keyword)
+    }
+
+    override suspend fun resolveRegionFromCoordinate(latitude: Double, longitude: Double): Region? {
+        // TODO: 향후 외부 API 기반 Reverse Geocoding 연동 시 구현
+        return null
+    }
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/parser/RegionAddressParser.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/parser/RegionAddressParser.kt
@@ -1,0 +1,45 @@
+package com.team.yeogibeoryeo.data.region.parser
+
+import com.team.yeogibeoryeo.data.region.RegionNormalizer
+import com.team.yeogibeoryeo.domain.region.model.Region
+import javax.inject.Inject
+
+/**
+ * 주소 문자열을 분석하여 [Region] 객체로 매핑하는 파서 (Parser)
+ * 띄어쓰기 및 접미사 단위로 행정구역을 추출한 뒤, [RegionNormalizer]를 거쳐 최종 반환합니다.
+ */
+class RegionAddressParser @Inject constructor() {
+
+    fun parse(address: String): Region {
+        val parts = address.trim().split("\\s+".toRegex())
+
+        var sido: String? = null
+        var sigungu: String? = null
+        var eupmyeondong: String? = null
+
+        parts.forEach { part ->
+            when {
+                (part.endsWith("도") || part.endsWith("시") || part in SIDO_ABBR) && sido == null -> {
+                    sido = part
+                }
+                (part.endsWith("시") || part.endsWith("군") || part.endsWith("구")) && part != sido -> {
+                    if (sigungu == null) sigungu = part
+                }
+                part.endsWith("읍") || part.endsWith("면") || part.endsWith("동") -> {
+                    if (eupmyeondong == null) eupmyeondong = part
+                }
+            }
+        }
+
+        // 1차 파싱된 데이터를 정규화 유틸리티를 거쳐 최종 포맷으로 변환
+        val parsedRegion = Region(sido = sido, sigungu = sigungu, eupmyeondong = eupmyeondong)
+        return RegionNormalizer.normalize(parsedRegion)
+    }
+
+    companion object {
+        private val SIDO_ABBR = setOf(
+            "서울", "부산", "대구", "인천", "광주", "대전", "울산", "세종",
+            "경기", "강원", "충북", "충남", "전북", "전남", "경북", "경남", "제주"
+        )
+    }
+}

--- a/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionNormalizerTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionNormalizerTest.kt
@@ -1,0 +1,34 @@
+package com.team.yeogibeoryeo.data.region
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RegionNormalizerTest {
+
+    @Test
+    fun `서울 축약명이 공식 명칭으로 변환된다`() {
+        val region = Region(
+            sido = "서울",
+            sigungu = "강남구"
+        )
+
+        val result = RegionNormalizer.normalize(region)
+
+        assertEquals("서울특별시", result.sido)
+    }
+
+    @Test
+    fun `세종특별자치시는 sigungu가 제거된다`() {
+        val region = Region(
+            sido = "세종",
+            sigungu = "세종시"
+        )
+
+        val result = RegionNormalizer.normalize(region)
+
+        assertEquals("세종특별자치시", result.sido)
+        assertNull(result.sigungu)
+    }
+}

--- a/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionRepositoryImplTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionRepositoryImplTest.kt
@@ -1,0 +1,46 @@
+package com.team.yeogibeoryeo.data.region
+
+import com.team.yeogibeoryeo.data.region.parser.RegionAddressParser
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class RegionRepositoryImplTest {
+
+    private lateinit var repository: RegionRepositoryImpl
+
+    @Before
+    fun setUp() {
+        repository = RegionRepositoryImpl(
+            addressParser = RegionAddressParser()
+        )
+    }
+
+    @Test
+    fun `주소 기반 Region 추출이 정상 동작한다`() {
+        val result = repository.extractRegionFromAddress(
+            "서울특별시 영등포구 당산동"
+        )
+
+        assertEquals("서울특별시", result?.sido)
+        assertEquals("영등포구", result?.sigungu)
+    }
+
+    @Test
+    fun `빈 주소는 null 반환`() {
+        val result = repository.extractRegionFromAddress("")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `검색어 기반 Region 변환이 정상 동작한다`() = runBlocking {
+        val result = repository.resolveRegionFromKeyword(
+            "서울 영등포구"
+        )
+
+        assertEquals("영등포구", result?.sigungu)
+    }
+}

--- a/data/src/test/java/com/team/yeogibeoryeo/data/region/parser/RegionAddressParserTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/region/parser/RegionAddressParserTest.kt
@@ -1,0 +1,73 @@
+package com.team.yeogibeoryeo.data.region.parser
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class RegionAddressParserTest {
+
+    private lateinit var parser: RegionAddressParser
+
+    @Before
+    fun setUp() {
+        parser = RegionAddressParser()
+    }
+
+    @Test
+    fun `표준 주소가 정상 파싱된다`() {
+        val result = parser.parse(
+            "서울특별시 강남구 역삼동 123-45"
+        )
+
+        assertEquals("서울특별시", result.sido)
+        assertEquals("강남구", result.sigungu)
+        assertEquals("역삼동", result.eupmyeondong)
+    }
+
+    @Test
+    fun `getSpot addrBase 포맷이 정상 파싱된다`() {
+        val result = parser.parse(
+            "서울특별시 영등포구 당산로 42"
+        )
+
+        assertEquals("서울특별시", result.sido)
+        assertEquals("영등포구", result.sigungu)
+
+        // 도로명 주소이므로 읍면동 없음
+        assertNull(result.eupmyeondong)
+    }
+
+    @Test
+    fun `세종특별자치시는 sigungu가 null 처리된다`() {
+        val result = parser.parse(
+            "세종특별자치시 한솔동 123"
+        )
+
+        assertEquals("세종특별자치시", result.sido)
+        assertNull(result.sigungu)
+        assertEquals("한솔동", result.eupmyeondong)
+    }
+
+    @Test
+    fun `축약 시도명이 정상 정규화된다`() {
+        val result = parser.parse(
+            "서울 강남구 역삼동"
+        )
+
+        assertEquals("서울특별시", result.sido)
+        assertEquals("강남구", result.sigungu)
+        assertEquals("역삼동", result.eupmyeondong)
+    }
+
+    @Test
+    fun `불규칙한 공백이 포함되어도 정상 파싱된다`() {
+        val result = parser.parse(
+            "  경기도   수원시  영통구 망포동   "
+        )
+
+        assertEquals("경기도", result.sido)
+        assertEquals("수원시", result.sigungu)
+        assertEquals("망포동", result.eupmyeondong)
+    }
+}

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -9,3 +9,7 @@ java {
 kotlin {
     jvmToolchain(21)
 }
+dependencies {
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.javax.inject)
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/model/Region.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/model/Region.kt
@@ -1,3 +1,14 @@
 package com.team.yeogibeoryeo.domain.region.model
 
-//정문님 지역 모델 자리
+/**
+ * 시/도, 시군구, 읍면동 정보를 담는 공통 행정구역 모델
+ *
+ * @property sido 시/도 명칭
+ * @property sigungu 시/군/구 명칭
+ * @property eupmyeondong 읍/면/동 명칭
+ */
+data class Region(
+    val sido: String? = null,
+    val sigungu: String? = null,
+    val eupmyeondong: String? = null
+)

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/model/RegionSearchContext.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/model/RegionSearchContext.kt
@@ -1,0 +1,14 @@
+package com.team.yeogibeoryeo.domain.region.model
+
+/**
+ * 사용자의 검색어와 추출된 지역 정보를 연결하는 모델
+ *
+ * @property originalKeyword 원본 검색어
+ * @property detectedRegion 변환된 행정구역 정보
+ * @property source 지역 정보 출처
+ */
+data class RegionSearchContext(
+    val originalKeyword: String,
+    val detectedRegion: Region?,
+    val source: RegionSource
+)

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/model/RegionSource.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/model/RegionSource.kt
@@ -1,0 +1,19 @@
+package com.team.yeogibeoryeo.domain.region.model
+
+/**
+ * 지역 정보의 출처를 구분하는 Enum
+ */
+enum class RegionSource {
+
+    /** 사용자가 직접 입력한 검색어 */
+    USER_INPUT,
+
+    /** GPS 좌표 기반 Reverse Geocoding 결과 */
+    GPS_REVERSE_GEOCODING,
+
+    /** 장소 정보 주소에서 추출한 지역 정보 */
+    SPOT_ADDRESS,
+
+    /** 사용자가 수동으로 선택한 지역 정보 */
+    MANUAL_SELECTED
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/repository/RegionRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/repository/RegionRepository.kt
@@ -1,0 +1,33 @@
+package com.team.yeogibeoryeo.domain.region.repository
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+
+/**
+ * 행정구역(Region) 데이터 변환 및 추출을 담당하는 Repository
+ */
+interface RegionRepository {
+
+    /**
+     * 주소 문자열에서 행정구역을 파싱합니다.
+     * 로컬 파싱 로직 기반으로 즉시 결과를 반환합니다.
+     *
+     * @param address 전체 주소 문자열
+     */
+    fun extractRegionFromAddress(address: String): Region?
+
+    /**
+     * 검색어 기반 행정구역 분석을 수행합니다.
+     * 향후 API 연동 가능성을 고려해 비동기로 처리합니다.
+     *
+     * @param keyword 검색어 (예: "문래동")
+     */
+    suspend fun resolveRegionFromKeyword(keyword: String): Region?
+
+    /**
+     * 좌표 기반 행정구역 변환(Reverse Geocoding)을 수행합니다.
+     */
+    suspend fun resolveRegionFromCoordinate(
+        latitude: Double,
+        longitude: Double
+    ): Region?
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ExtractRegionFromAddressUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ExtractRegionFromAddressUseCase.kt
@@ -1,0 +1,17 @@
+package com.team.yeogibeoryeo.domain.region.usecase
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.region.repository.RegionRepository
+import javax.inject.Inject
+
+/**
+ * 주소 문자열에서 행정구역을 추출하는 UseCase
+ * [동기 방식] 로컬 파싱 로직을 사용하여 즉시 결과를 반환합니다.
+ */
+class ExtractRegionFromAddressUseCase @Inject constructor(
+    private val repository: RegionRepository
+) {
+    operator fun invoke(address: String): Region? {
+        return repository.extractRegionFromAddress(address)
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromCoordinateUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromCoordinateUseCase.kt
@@ -1,0 +1,17 @@
+package com.team.yeogibeoryeo.domain.region.usecase
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.region.repository.RegionRepository
+import javax.inject.Inject
+
+/**
+ * 위도/경도 좌표를 기반으로 행정구역을 변환하는 UseCase (Reverse Geocoding)
+ * [비동기 방식] 외부 Geocoder API와의 네트워크 통신을 거쳐 결과를 반환합니다.
+ */
+class ResolveRegionFromCoordinateUseCase @Inject constructor(
+    private val repository: RegionRepository
+) {
+    suspend operator fun invoke(latitude: Double, longitude: Double): Region? {
+        return repository.resolveRegionFromCoordinate(latitude, longitude)
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCase.kt
@@ -1,0 +1,17 @@
+package com.team.yeogibeoryeo.domain.region.usecase
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.region.repository.RegionRepository
+import javax.inject.Inject
+
+/**
+ * 사용자 검색어 기반으로 행정구역을 분석하는 UseCase
+ * [비동기 방식] 향후 검색 API 연동을 고려하여 코루틴 환경에서 결과를 반환합니다.
+ */
+class ResolveRegionFromKeywordUseCase @Inject constructor(
+    private val repository: RegionRepository
+) {
+    suspend operator fun invoke(keyword: String): Region? {
+        return repository.resolveRegionFromKeyword(keyword)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 agp = "9.2.1"
 kotlin = "2.2.10"
 jetbrainsKotlinJvm = "2.2.10"
-ksp = "2.2.10-2.0.2"
+ksp = "2.3.6"
 
 # AndroidX Core
 coreKtx = "1.10.1"
@@ -32,7 +32,7 @@ naverMapCompose = "1.6.0"
 room = "2.7.2"
 
 # DI
-hilt = "2.57"
+hilt = "2.59.2"
 hiltNavigationCompose = "1.2.0"
 javaxInject = "1"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ room = "2.7.2"
 # DI
 hilt = "2.57"
 hiltNavigationCompose = "1.2.0"
+javaxInject = "1"
 
 # Test
 junit = "4.13.2"
@@ -91,6 +92,7 @@ androidx-room-compiler = { group = "androidx.room", name = "room-compiler", vers
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+javax-inject = { group = "javax.inject", name = "javax.inject", version.ref = "javaxInject" }
 
 # Test
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
## 작업 내용
**1. Domain 계층 세팅**
- `Region`, `RegionSearchContext` 도메인 모델 및 `RegionSource` Enum 추가
- `RegionRepository` 인터페이스 및 주소/키워드/좌표 기반 3가지 `UseCase` 정의

**2. 빌드 환경 업데이트 (`AGP 9.2.1` 대응)**
- `Hilt (2.59.2)` 및 `KSP (2.3.6)` 버전 업데이트
- `data` 모듈 Hilt/KSP 의존성 추가 및 Configuration 에러 해결

**3. Data 계층 및 파서 구현**
- `RegionAddressParser`: 띄어쓰기 및 접미사 기준으로 시/도, 시/군/구, 읍/면/동 추출 로직 구현
- `RegionNormalizer`: 축약어(예: 서울 -> 서울특별시) 정규화 및 예외 케이스 처리
- `RegionRepositoryImpl`: 도메인 인터페이스 구현체 연결

**4. ⚠️ 미결/예정 사항 (Reverse Geocoding)**
- 사용자 검색어 및 Reverse Geocoding 연동을 고려한 UseCase 및 Repository 구조를 정의했습니다.
- 실제 Reverse Geocoding 통신 구현 (`Geocoder` 또는 외부 API 연동)은 향후 네트워크 모듈(Retrofit 등) 세팅 및 API 연동을 다루는 별도 Data 계층 이슈에서 진행할 예정입니다.

##  테스트 결과 (검증 스크린샷)
로컬 환경에서 핵심 비즈니스 로직에 대한 단위 테스트가 모두 정상 통과함을 확인했습니다.
| RegionAddressParserTest| RegionNormalizerTest | RegionRepositoryImplTest |
| --- | --- | --- |
| <img width="810" height="198" alt="스크린샷 2026-05-14 160217" src="https://github.com/user-attachments/assets/42425453-8588-4e73-96e5-4a998d3a7ac5" /> | <img width="812" height="298" alt="스크린샷 2026-05-14 160054" src="https://github.com/user-attachments/assets/ef3effa4-316f-4a3b-82d9-cde69f329dc2" /> | <img width="818" height="148" alt="스크린샷 2026-05-14 160143" src="https://github.com/user-attachments/assets/e02f18df-e113-4d79-9582-b614052714a7" /> |

## 관련 이슈
- Closes #16 