### PR TITLE
feat: 지역별 배출 가이드 도메인 설계

### DIFF
--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalDisposalGuide.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalDisposalGuide.kt
@@ -1,3 +1,22 @@
 package com.team.yeogibeoryeo.domain.regionalguide.model
 
-//정문님 지역 배출 가이드 모델 자리
+import com.team.yeogibeoryeo.domain.region.model.Region
+
+/**
+ * 특정 행정구역(Region)의 종합적인 쓰레기 배출 가이드 모델
+ *
+ * @property region 대상 행정구역
+ * @property schedules 폐기물 종류별 배출 스케줄 목록
+ * @property uncollectedDays 수거 제외일
+ * @property disposalPlaceType 배출장소 유형
+ * @property guideUrl 지자체 공식 배출 안내 페이지 링크 (선택)
+ * @property inquiryPhone 관할 부서 문의 전화번호 (선택)
+ */
+data class RegionalDisposalGuide(
+    val region: Region,
+    val schedules: List<RegionalWasteSchedule>,
+    val uncollectedDays: String? = null,
+    val disposalPlaceType: String? = null,
+    val guideUrl: String? = null,
+    val inquiryPhone: String? = null
+)

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalWasteSchedule.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalWasteSchedule.kt
@@ -1,0 +1,20 @@
+package com.team.yeogibeoryeo.domain.regionalguide.model
+
+/**
+ * 특정 폐기물 종류별 배출 스케줄 정보
+ *
+ * @property wasteType 폐기물 종류
+ * @property disposalDays 배출 가능 요일
+ * @property disposalStartTime 배출 시작 시간
+ * @property disposalEndTime 배출 종료 시간
+ * @property disposalMethod 배출 방법
+ * @property notice 추가 안내사항
+ */
+data class RegionalWasteSchedule(
+    val wasteType: RegionalWasteType,
+    val disposalDays: String,
+    val disposalStartTime: String? = null,
+    val disposalEndTime: String? = null,
+    val disposalMethod: String? = null,
+    val notice: String? = null
+)

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalWasteType.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalWasteType.kt
@@ -1,0 +1,14 @@
+package com.team.yeogibeoryeo.domain.regionalguide.model
+
+/**
+ * 지역별 배출 폐기물의 종류를 정의하는 Enum
+ */
+enum class RegionalWasteType(
+    val description: String
+) {
+    GENERAL("일반쓰레기"),
+    FOOD("음식물쓰레기"),
+    RECYCLABLE("재활용품"),
+    LARGE_ITEM("대형폐기물"),
+    UNKNOWN("알 수 없음")
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/repository/RegionalDisposalGuideRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/repository/RegionalDisposalGuideRepository.kt
@@ -1,0 +1,19 @@
+package com.team.yeogibeoryeo.domain.regionalguide.repository
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
+
+/**
+ * 특정 지역(Region)에 대한 배출 가이드 데이터를 제공하는 Repository 인터페이스
+ */
+interface RegionalDisposalGuideRepository {
+
+    /**
+     * 특정 행정구역의 쓰레기 배출 가이드 정보를 비동기로 조회합니다.
+     * 향후 네트워크 API 통신을 고려하여 suspend 함수로 설계합니다.
+     *
+     * @param region 조회할 대상 지역
+     * @return 성공 시 [RegionalDisposalGuide], 해당 지역 정보가 없거나 실패 시 null
+     */
+    suspend fun getRegionalDisposalGuide(region: Region): RegionalDisposalGuide?
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/FilterRegionalGuideByDongUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/FilterRegionalGuideByDongUseCase.kt
@@ -1,0 +1,31 @@
+package com.team.yeogibeoryeo.domain.regionalguide.usecase
+
+import kotlin.collections.filter
+
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
+import javax.inject.Inject
+
+/**
+ * 행정동/관리구역명을 기준으로 지역별 배출 가이드 목록을 필터링하는 UseCase
+ */
+class FilterRegionalGuideByDongUseCase @Inject constructor() {
+
+    operator fun invoke(
+        guides: List<RegionalDisposalGuide>,
+        dongName: String?
+    ): List<RegionalDisposalGuide> {
+
+        if (dongName.isNullOrBlank()) {
+            return guides
+        }
+
+        return guides.filter { guide ->
+            val eupmyeondong = guide.region.eupmyeondong
+
+            eupmyeondong?.contains(
+                other = dongName,
+                ignoreCase = true
+            ) == true
+        }
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/GetRegionalDisposalGuideUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/GetRegionalDisposalGuideUseCase.kt
@@ -1,0 +1,17 @@
+package com.team.yeogibeoryeo.domain.regionalguide.usecase
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
+import com.team.yeogibeoryeo.domain.regionalguide.repository.RegionalDisposalGuideRepository
+import javax.inject.Inject
+
+/**
+ * 선택된 행정구역(Region)을 기반으로 지역별 배출 가이드를 가져오는 UseCase
+ */
+class GetRegionalDisposalGuideUseCase @Inject constructor(
+    private val repository: RegionalDisposalGuideRepository
+) {
+    suspend operator fun invoke(region: Region): RegionalDisposalGuide? {
+        return repository.getRegionalDisposalGuide(region)
+    }
+}


### PR DESCRIPTION
## 작업 내용

### 1. Domain Model 정의
- 행안부 지역별 배출 가이드 API 응답 구조를 기반으로 도메인 모델 설계
- `RegionalWasteType`
  - 일반 / 음식물 / 재활용 / 대형폐기물 등 폐기물 종류 Enum 정의
  - API Prefix(`LF_WST`, `FOD_WST`, `RCYCL` 등) 매핑 고려
- `RegionalWasteSchedule`
  - 배출 요일, 시작/종료 시간, 배출 방법 등을 담는 스케줄 모델 정의
- `RegionalDisposalGuide`
  - `Region` 및 폐기물 스케줄 목록을 포함하는 최상위 도메인 모델 정의
  - 수거 제외일(`UNCLLT_DAY`), 배출장소 유형(`EMSN_PLC_TYPE`) 대응 고려

### 2. Repository 및 UseCase 계층 설계
- `RegionalDisposalGuideRepository`
  - 지역 기반 배출 가이드 조회 인터페이스 정의
- `GetRegionalDisposalGuideUseCase`
  - 지역별 배출 가이드 조회 UseCase 추가
- `FilterRegionalGuideByDongUseCase`
  - 행정동(`eupmyeondong`) 기준 가이드 목록 필터링 로직 구현

---

## 관련 이슈
- Closes #18