### PR TITLE
feat: 행안부 /info API 통신 뼈대 연동

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalGuideMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalGuideMapper.kt
@@ -1,0 +1,24 @@
+package com.team.yeogibeoryeo.data.regionalguide.mapper
+
+import com.team.yeogibeoryeo.data.regionalguide.remote.dto.RegionalGuideItemDto
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
+
+/**
+ * Data 계층의 DTO를 Domain 계층의 최상위 모델인 RegionalDisposalGuide로 변환하는 매퍼.
+ * API 응답에 포함된 상세 행정동 명칭을 기반으로 기존 Region 객체를 정교화합니다.
+ */
+object RegionalGuideMapper {
+    fun mapToDomain(baseRegion: Region, dto: RegionalGuideItemDto): RegionalDisposalGuide {
+        val accurateRegion = baseRegion.copy(
+            eupmyeondong = dto.dongName ?: baseRegion.eupmyeondong
+        )
+
+        return RegionalDisposalGuide(
+            region = accurateRegion,
+            schedules = RegionalWasteScheduleMapper.mapToSchedules(dto),
+            uncollectedDays = dto.uncollectedDay,
+            disposalPlaceType = dto.disposalPlaceType
+        )
+    }
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalWasteScheduleMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalWasteScheduleMapper.kt
@@ -1,0 +1,64 @@
+package com.team.yeogibeoryeo.data.regionalguide.mapper
+
+import com.team.yeogibeoryeo.data.regionalguide.remote.dto.RegionalGuideItemDto
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteSchedule
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteType
+
+/**
+ * 공공데이터 API의 폐기물 종류별 필드(Prefix)를 분석하여 도메인 모델 스케줄 리스트로 변환하는 매퍼.
+ */
+object RegionalWasteScheduleMapper {
+    fun mapToSchedules(dto: RegionalGuideItemDto): List<RegionalWasteSchedule> {
+        val schedules = mutableListOf<RegionalWasteSchedule>()
+
+        if (!dto.generalDisposalDays.isNullOrBlank()) {
+            schedules.add(
+                RegionalWasteSchedule(
+                    wasteType = RegionalWasteType.GENERAL,
+                    disposalDays = dto.generalDisposalDays,
+                    disposalStartTime = dto.generalStartTime,
+                    disposalEndTime = dto.generalEndTime,
+                    disposalMethod = dto.generalMethod
+                )
+            )
+        }
+
+        if (!dto.foodDisposalDays.isNullOrBlank()) {
+            schedules.add(
+                RegionalWasteSchedule(
+                    wasteType = RegionalWasteType.FOOD,
+                    disposalDays = dto.foodDisposalDays,
+                    disposalStartTime = dto.foodStartTime,
+                    disposalEndTime = dto.foodEndTime,
+                    disposalMethod = dto.foodMethod
+                )
+            )
+        }
+
+        if (!dto.recycleDisposalDays.isNullOrBlank()) {
+            schedules.add(
+                RegionalWasteSchedule(
+                    wasteType = RegionalWasteType.RECYCLABLE,
+                    disposalDays = dto.recycleDisposalDays,
+                    disposalStartTime = dto.recycleStartTime,
+                    disposalEndTime = dto.recycleEndTime,
+                    disposalMethod = dto.recycleMethod
+                )
+            )
+        }
+
+        if (!dto.largeItemDisposalDays.isNullOrBlank()) {
+            schedules.add(
+                RegionalWasteSchedule(
+                    wasteType = RegionalWasteType.LARGE_ITEM,
+                    disposalDays = dto.largeItemDisposalDays,
+                    disposalStartTime = dto.largeItemStartTime,
+                    disposalEndTime = dto.largeItemEndTime,
+                    disposalMethod = dto.largeItemMethod
+                )
+            )
+        }
+
+        return schedules
+    }
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/remote/RegionalGuideApiService.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/remote/RegionalGuideApiService.kt
@@ -1,3 +1,33 @@
 package com.team.yeogibeoryeo.data.regionalguide.remote
 
-// /info API 자리
+import com.team.yeogibeoryeo.data.regionalguide.remote.dto.RegionalGuideResponseDto
+import com.team.yeogibeoryeo.data.regionalguide.remote.dto.RegionalGuideRootDto
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+/**
+ * 행정안전부 지역별 쓰레기 배출 가이드 API 인터페이스 정의.
+ * Base URL: https://apis.data.go.kr/
+ */
+interface RegionalGuideApiService {
+
+    /**
+     * 특정 시군구(SGG_NM)의 배출 가이드 정보를 필터링하여 조회합니다.
+     *
+     * @param serviceKey 공공데이터포털 API 인증키
+     * @param pageNo 조회할 페이지 번호 (기본값: 1)
+     * @param numOfRows 한 페이지당 데이터 개수 (최대: 100)
+     * @param returnType 응답 포맷 (기본값: json)
+     * @param sigunguName 검색 조건: 시군구명 필터
+     * @return [Response]로 감싸진 최상위 응답 DTO
+     */
+    @GET("1741000/household_waste_info/info")
+    suspend fun getRegionalGuides(
+        @Query("serviceKey") serviceKey: String,
+        @Query("pageNo") pageNo: Int = 1,
+        @Query("numOfRows") numOfRows: Int = 100,
+        @Query("returnType") returnType: String = "json",
+        @Query("cond[SGG_NM::LIKE]") sigunguName: String
+    ): Response<RegionalGuideRootDto>
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/remote/RegionalGuideRemoteDataSource.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/remote/RegionalGuideRemoteDataSource.kt
@@ -1,0 +1,39 @@
+package com.team.yeogibeoryeo.data.regionalguide.remote
+
+import com.team.yeogibeoryeo.data.regionalguide.remote.dto.RegionalGuideItemDto
+import javax.inject.Inject
+
+/**
+ * 행정안전부 지역별 배출 가이드 데이터 패치를 담당하는 원격 데이터 소스(Remote DataSource).
+ * Retrofit 통신 결과를 안전한 [Result] 래퍼로 변환하여 Repository 계층으로 전달합니다.
+ */
+class RegionalGuideRemoteDataSource @Inject constructor(
+    private val apiService: RegionalGuideApiService
+) {
+    // TODO: BuildConfig 또는 local.properties 기반 API Key 주입 방식 적용 예정
+    private val TEMP_API_KEY = "PUBLIC_DATA_SERVICE_KEY"
+
+    /**
+     * 시군구명을 기반으로 배출 가이드 리스트를 비동기 요청합니다.
+     *
+     * @param sigunguName 검색할 시군구명 (예: "강남구")
+     * @return 성공 시 데이터 리스트를 포함한 Result.success, 실패 시 예외를 포함한 Result.failure 반환
+     */
+    suspend fun fetchRegionalGuides(sigunguName: String): Result<List<RegionalGuideItemDto>> {
+        return try {
+            val response = apiService.getRegionalGuides(
+                serviceKey = TEMP_API_KEY,
+                sigunguName = sigunguName
+            )
+
+            if (response.isSuccessful) {
+                val items = response.body()?.response?.body?.items?.item ?: emptyList()
+                Result.success(items)
+            } else {
+                Result.failure(Exception("API 통신 실패 [HTTP ${response.code()}]: ${response.message()}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/remote/dto/RegionalGuideItemDto.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/remote/dto/RegionalGuideItemDto.kt
@@ -1,0 +1,44 @@
+@file:OptIn(InternalSerializationApi::class)
+
+package com.team.yeogibeoryeo.data.regionalguide.remote.dto
+
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * 행정안전부 지역별 쓰레기 배출 가이드 단일 항목 DTO.
+ * 공공데이터 API 특성상 응답 필드 누락이 발생할 수 있으므로, 모든 속성을 Nullable 및 기본값(null)으로 처리합니다.
+ */
+@Serializable
+data class RegionalGuideItemDto(
+    @SerialName("CTPV_NM") val sidoName: String? = null,
+    @SerialName("SGG_NM") val sigunguName: String? = null,
+    @SerialName("MNG_ZONE_TRGT_RGN_NM") val dongName: String? = null,
+    @SerialName("EMSN_PLC_TYPE") val disposalPlaceType: String? = null,
+    @SerialName("UNCLLT_DAY") val uncollectedDay: String? = null,
+
+    // 일반 쓰레기
+    @SerialName("LF_WST_EMSN_DOW") val generalDisposalDays: String? = null,
+    @SerialName("LF_WST_EMSN_BGNG_TM") val generalStartTime: String? = null,
+    @SerialName("LF_WST_EMSN_END_TM") val generalEndTime: String? = null,
+    @SerialName("LF_WST_EMSN_MTHD") val generalMethod: String? = null,
+
+    // 음식물 쓰레기
+    @SerialName("FOD_WST_EMSN_DOW") val foodDisposalDays: String? = null,
+    @SerialName("FOD_WST_EMSN_BGNG_TM") val foodStartTime: String? = null,
+    @SerialName("FOD_WST_EMSN_END_TM") val foodEndTime: String? = null,
+    @SerialName("FOD_WST_EMSN_MTHD") val foodMethod: String? = null,
+
+    // 재활용품
+    @SerialName("RCYCL_EMSN_DOW") val recycleDisposalDays: String? = null,
+    @SerialName("RCYCL_EMSN_BGNG_TM") val recycleStartTime: String? = null,
+    @SerialName("RCYCL_EMSN_END_TM") val recycleEndTime: String? = null,
+    @SerialName("RCYCL_EMSN_MTHD") val recycleMethod: String? = null,
+
+    // 대형 폐기물
+    @SerialName("TMPRY_BULK_WASTE_EMSN_DOW") val largeItemDisposalDays: String? = null,
+    @SerialName("TMPRY_BULK_WASTE_EMSN_BGNG_TM") val largeItemStartTime: String? = null,
+    @SerialName("TMPRY_BULK_WASTE_EMSN_END_TM") val largeItemEndTime: String? = null,
+    @SerialName("TMPRY_BULK_WASTE_EMSN_MTHD") val largeItemMethod: String? = null
+)

--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/remote/dto/RegionalGuideResponseDto.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/remote/dto/RegionalGuideResponseDto.kt
@@ -1,0 +1,32 @@
+@file:OptIn(InternalSerializationApi::class)
+
+package com.team.yeogibeoryeo.data.regionalguide.remote.dto
+
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * 공공데이터 API 실제 응답 구조 (response -> body -> items -> item)
+ */
+
+@Serializable
+data class RegionalGuideRootDto(
+    @SerialName("response") val response: RegionalGuideResponseDto? = null
+)
+
+@Serializable
+data class RegionalGuideResponseDto(
+    @SerialName("body") val body: RegionalGuideBodyDto? = null
+)
+
+@Serializable
+data class RegionalGuideBodyDto(
+    @SerialName("totalCount") val totalCount: Int? = null,
+    @SerialName("items") val items: RegionalGuideItemsDto? = null
+)
+
+@Serializable
+data class RegionalGuideItemsDto(
+    @SerialName("item") val item: List<RegionalGuideItemDto> = emptyList()
+)

--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImpl.kt
@@ -1,0 +1,46 @@
+package com.team.yeogibeoryeo.data.regionalguide.repository
+
+import com.team.yeogibeoryeo.data.regionalguide.mapper.RegionalGuideMapper
+import com.team.yeogibeoryeo.data.regionalguide.remote.RegionalGuideRemoteDataSource
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
+import com.team.yeogibeoryeo.domain.regionalguide.repository.RegionalDisposalGuideRepository
+import javax.inject.Inject
+
+/**
+ * [RegionalDisposalGuideRepository]의 Data 계층 구현체.
+ * RemoteDataSource를 통해 데이터를 패치하고, 사용자 지역 정보에 가장 적합한 배출 가이드 데이터를 선별하여 반환합니다.
+ */
+class RegionalDisposalGuideRepositoryImpl @Inject constructor(
+    private val remoteDataSource: RegionalGuideRemoteDataSource
+) : RegionalDisposalGuideRepository {
+
+    override suspend fun getRegionalDisposalGuide(region: Region): RegionalDisposalGuide? {
+        val sigungu = region.sigungu
+
+        if (sigungu.isNullOrBlank()) {
+            return null
+        }
+
+        val result = remoteDataSource.fetchRegionalGuides(sigungu)
+
+        if (result.isSuccess) {
+            val dtoList = result.getOrNull() ?: emptyList()
+            if (dtoList.isEmpty()) return null
+
+            val eupmyeondong = region.eupmyeondong
+
+            // 사용자의 행정동 명칭과 매칭되는 데이터 탐색, 없을 경우 첫 번째 데이터 폴백
+            val targetDto = if (!eupmyeondong.isNullOrBlank()) {
+                dtoList.find { it.dongName?.contains(eupmyeondong) == true } ?: dtoList.first()
+            } else {
+                dtoList.first()
+            }
+
+            return RegionalGuideMapper.mapToDomain(region, targetDto)
+
+        } else {
+            return null
+        }
+    }
+}

--- a/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/remote/RegionalGuideRemoteDataSourceTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/remote/RegionalGuideRemoteDataSourceTest.kt
@@ -1,0 +1,78 @@
+package com.team.yeogibeoryeo.data.regionalguide.remote
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+
+/**
+ * 실제 행정안전부 공공데이터 API와 통신하는 Integration Test.
+ *
+ * 검증 대상:
+ * 1. /info API 200 OK 통신 여부
+ * 2. JSON 응답이 DTO에 정상적으로 매핑되는지 여부
+ *
+ * 주의:
+ * - 실제 네트워크 환경이 필요합니다.
+ * - API Key 설정이 필요합니다.
+ * - 외부 API 상태에 따라 테스트가 실패할 수 있습니다.
+ */
+class RegionalGuideRemoteDataSourceTest {
+
+    private lateinit var dataSource: RegionalGuideRemoteDataSource
+
+    @Before
+    fun setUp() {
+        val json = Json { ignoreUnknownKeys = true }
+
+        val loggingInterceptor = HttpLoggingInterceptor { message ->
+            println(message)
+        }.apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor(loggingInterceptor)
+            .build()
+
+        val retrofit = Retrofit.Builder()
+            .baseUrl("https://apis.data.go.kr/")
+            .client(okHttpClient)
+            .addConverterFactory(
+                json.asConverterFactory("application/json".toMediaType())
+            )
+            .build()
+
+        val apiService = retrofit.create(RegionalGuideApiService::class.java)
+        dataSource = RegionalGuideRemoteDataSource(apiService)
+    }
+
+    @Test
+    fun `행안부 API 실제 통신 및 JSON DTO 파싱이 정상 수행된다`() = runBlocking {
+        val sigunguName = "영등포구"
+        val result = dataSource.fetchRegionalGuides(sigunguName)
+
+        assertTrue("API 통신 실패: ${result.exceptionOrNull()?.message}", result.isSuccess)
+
+        val items = result.getOrNull()
+
+        println(
+            """
+            =========================================
+            ✅ 파싱된 아이템 개수: ${items?.size}
+            
+            ✅ 첫 번째 데이터 샘플:
+            ${items?.firstOrNull()}
+            =========================================
+            """.trimIndent()
+        )
+
+        assertTrue("데이터가 비어있습니다.", !items.isNullOrEmpty())
+    }
+}


### PR DESCRIPTION
## 작업 내용

### 1. 공공데이터 맞춤형 DTO 및 통신 계층
- 공공데이터 API의 중첩 응답 구조(`response -> body -> items -> item`)를 반영한 DTO 설계
- 필드 누락 가능성을 고려하여 Nullable 및 기본값 기반으로 안정적인 DTO 구성
- `RegionalGuideApiService` Retrofit 인터페이스 정의
- `RegionalGuideRemoteDataSource` 구현
- `cond[SGG_NM::LIKE]` 기반 시군구 필터링 쿼리 적용

### 2. 도메인 매핑 및 Repository 로직 구현
- `RegionalGuideMapper`
  - DTO → `RegionalDisposalGuide` 변환 로직 구현
- `RegionalWasteScheduleMapper`
  - 폐기물 종류별 Prefix(`LF_WST_*`, `FOD_WST_*` 등) 기반 스케줄 매핑 로직 구현
- `RegionalDisposalGuideRepositoryImpl`
  - 행정동(`eupmyeondong`) 우선 매칭 로직 구현
  - 매칭 실패 시 첫 번째 응답 데이터를 사용하는 fallback 처리

### 3. 통합 테스트(Integration Test)
- `RegionalGuideRemoteDataSourceTest` 작성
- 실제 행안부 `/info` API 통신 검증
- JSON 응답 DTO 파싱 및 데이터 매핑 확인

## 테스트 결과 (검증 스크린샷)
> 공공데이터 API의 중첩 응답 구조(`response -> body -> items -> item`)가 설계한 DTO 계층에 정상적으로 매핑되는 것을 확인했습니다.

<img width="1746" height="582" alt="공공데이터포털 JSON 응답 규격 대응을 위한 DTO 계층 세분화(후-상세)" src="https://github.com/user-attachments/assets/7d2ef147-2822-486f-95e8-2913f2a6f09e" />

## 관련 이슈
- Closes #19