### PR TITLE
faat: RegionalGuide 매퍼(Mapper) 및 예외 처리 구현 

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalGuideMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalGuideMapper.kt
@@ -11,14 +11,19 @@ import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
 object RegionalGuideMapper {
     fun mapToDomain(baseRegion: Region, dto: RegionalGuideItemDto): RegionalDisposalGuide {
         val accurateRegion = baseRegion.copy(
-            eupmyeondong = dto.dongName ?: baseRegion.eupmyeondong
+            eupmyeondong = dto.dongName?.trim() ?: baseRegion.eupmyeondong
         )
 
         return RegionalDisposalGuide(
             region = accurateRegion,
+            managementZoneName = dto.managementZoneName?.trim(),
+            targetRegionName = dto.dongName?.trim(),
+            disposalPlaceType = dto.disposalPlaceType?.trim(),
+            disposalPlaceDescription = dto.placeDescription?.trim(),
             schedules = RegionalWasteScheduleMapper.mapToSchedules(dto),
-            uncollectedDays = dto.uncollectedDay,
-            disposalPlaceType = dto.disposalPlaceType
+            uncollectedDays = RegionalWasteScheduleMapper.parseDays(dto.uncollectedDay),
+            departmentName = dto.departmentName?.trim(),
+            departmentPhoneNumber = dto.departmentPhoneNumber?.trim()
         )
     }
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalWasteScheduleMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalWasteScheduleMapper.kt
@@ -8,57 +8,56 @@ import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteType
  * 공공데이터 API의 폐기물 종류별 필드(Prefix)를 분석하여 도메인 모델 스케줄 리스트로 변환하는 매퍼.
  */
 object RegionalWasteScheduleMapper {
+
     fun mapToSchedules(dto: RegionalGuideItemDto): List<RegionalWasteSchedule> {
-        val schedules = mutableListOf<RegionalWasteSchedule>()
+        return listOfNotNull(
+            createSchedule(RegionalWasteType.GENERAL, dto.generalDisposalDays, dto.generalStartTime, dto.generalEndTime, dto.generalMethod),
+            createSchedule(RegionalWasteType.FOOD, dto.foodDisposalDays, dto.foodStartTime, dto.foodEndTime, dto.foodMethod),
+            createSchedule(RegionalWasteType.RECYCLABLE, dto.recycleDisposalDays, dto.recycleStartTime, dto.recycleEndTime, dto.recycleMethod),
+            createSchedule(RegionalWasteType.LARGE_ITEM, dto.largeItemDisposalDays, dto.largeItemStartTime, dto.largeItemEndTime, dto.largeItemMethod)
+        )
+    }
 
-        if (!dto.generalDisposalDays.isNullOrBlank()) {
-            schedules.add(
-                RegionalWasteSchedule(
-                    wasteType = RegionalWasteType.GENERAL,
-                    disposalDays = dto.generalDisposalDays,
-                    disposalStartTime = dto.generalStartTime,
-                    disposalEndTime = dto.generalEndTime,
-                    disposalMethod = dto.generalMethod
-                )
-            )
-        }
+    private fun createSchedule(
+        type: RegionalWasteType,
+        days: String?,
+        start: String?,
+        end: String?,
+        method: String?
+    ): RegionalWasteSchedule? {
+        if (days.isNullOrBlank() && start.isNullOrBlank() &&
+            end.isNullOrBlank() && method.isNullOrBlank()) return null
 
-        if (!dto.foodDisposalDays.isNullOrBlank()) {
-            schedules.add(
-                RegionalWasteSchedule(
-                    wasteType = RegionalWasteType.FOOD,
-                    disposalDays = dto.foodDisposalDays,
-                    disposalStartTime = dto.foodStartTime,
-                    disposalEndTime = dto.foodEndTime,
-                    disposalMethod = dto.foodMethod
-                )
-            )
-        }
+        return RegionalWasteSchedule(
+            wasteType = type,
+            disposalDays = parseDays(days),
+            disposalStartTime = parseTime(start),
+            disposalEndTime = parseTime(end),
+            disposalMethod = parseMethod(method)
+        )
+    }
 
-        if (!dto.recycleDisposalDays.isNullOrBlank()) {
-            schedules.add(
-                RegionalWasteSchedule(
-                    wasteType = RegionalWasteType.RECYCLABLE,
-                    disposalDays = dto.recycleDisposalDays,
-                    disposalStartTime = dto.recycleStartTime,
-                    disposalEndTime = dto.recycleEndTime,
-                    disposalMethod = dto.recycleMethod
-                )
-            )
-        }
+    // [로직] 요일 텍스트 정제 (예: "월요일, 화요일" -> "월, 화")
+    internal fun parseDays(days: String?): String {
+        if (days.isNullOrBlank()) return "미지정"
+        return days.replace("요일", "")
+            .replace("+", ", ")
+            .split(Regex("[,/|]"))
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .distinct()
+            .joinToString(", ")
+    }
 
-        if (!dto.largeItemDisposalDays.isNullOrBlank()) {
-            schedules.add(
-                RegionalWasteSchedule(
-                    wasteType = RegionalWasteType.LARGE_ITEM,
-                    disposalDays = dto.largeItemDisposalDays,
-                    disposalStartTime = dto.largeItemStartTime,
-                    disposalEndTime = dto.largeItemEndTime,
-                    disposalMethod = dto.largeItemMethod
-                )
-            )
-        }
+    // [로직] 시간 데이터 예외 처리
+    internal fun parseTime(time: String?): String? {
+        val trimmed = time?.trim()
+        return if (trimmed.isNullOrBlank() || trimmed == "00:00" || trimmed == "00:00:00") null else trimmed
+    }
 
-        return schedules
+    // [로직] 배출 방법 정제
+    internal fun parseMethod(method: String?): String {
+        if (method.isNullOrBlank()) return "지정된 배출 방법이 없습니다."
+        return method.replace(Regex("\\s+"), " ").trim()
     }
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/remote/RegionalGuideRemoteDataSource.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/remote/RegionalGuideRemoteDataSource.kt
@@ -4,12 +4,19 @@ import com.team.yeogibeoryeo.data.regionalguide.remote.dto.RegionalGuideItemDto
 import javax.inject.Inject
 
 /**
+ * 데이터 소스를 추상화한 인터페이스.
+ */
+interface RegionalGuideDataSource {
+    suspend fun fetchRegionalGuides(sigunguName: String): Result<List<RegionalGuideItemDto>>
+}
+
+/**
  * 행정안전부 지역별 배출 가이드 데이터 패치를 담당하는 원격 데이터 소스(Remote DataSource).
  * Retrofit 통신 결과를 안전한 [Result] 래퍼로 변환하여 Repository 계층으로 전달합니다.
  */
 class RegionalGuideRemoteDataSource @Inject constructor(
     private val apiService: RegionalGuideApiService
-) {
+) : RegionalGuideDataSource {
     // TODO: BuildConfig 또는 local.properties 기반 API Key 주입 방식 적용 예정
     private val TEMP_API_KEY = "PUBLIC_DATA_SERVICE_KEY"
 
@@ -19,7 +26,7 @@ class RegionalGuideRemoteDataSource @Inject constructor(
      * @param sigunguName 검색할 시군구명 (예: "강남구")
      * @return 성공 시 데이터 리스트를 포함한 Result.success, 실패 시 예외를 포함한 Result.failure 반환
      */
-    suspend fun fetchRegionalGuides(sigunguName: String): Result<List<RegionalGuideItemDto>> {
+    override suspend fun fetchRegionalGuides(sigunguName: String): Result<List<RegionalGuideItemDto>> {
         return try {
             val response = apiService.getRegionalGuides(
                 serviceKey = TEMP_API_KEY,

--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/remote/dto/RegionalGuideItemDto.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/remote/dto/RegionalGuideItemDto.kt
@@ -14,8 +14,11 @@ import kotlinx.serialization.Serializable
 data class RegionalGuideItemDto(
     @SerialName("CTPV_NM") val sidoName: String? = null,
     @SerialName("SGG_NM") val sigunguName: String? = null,
+    @SerialName("MNG_ZONE_NM") val managementZoneName: String? = null,
     @SerialName("MNG_ZONE_TRGT_RGN_NM") val dongName: String? = null,
+
     @SerialName("EMSN_PLC_TYPE") val disposalPlaceType: String? = null,
+    @SerialName("EMSN_PLC_EXPLN") val placeDescription: String? = null,
     @SerialName("UNCLLT_DAY") val uncollectedDay: String? = null,
 
     // 일반 쓰레기
@@ -40,5 +43,9 @@ data class RegionalGuideItemDto(
     @SerialName("TMPRY_BULK_WASTE_EMSN_DOW") val largeItemDisposalDays: String? = null,
     @SerialName("TMPRY_BULK_WASTE_EMSN_BGNG_TM") val largeItemStartTime: String? = null,
     @SerialName("TMPRY_BULK_WASTE_EMSN_END_TM") val largeItemEndTime: String? = null,
-    @SerialName("TMPRY_BULK_WASTE_EMSN_MTHD") val largeItemMethod: String? = null
+    @SerialName("TMPRY_BULK_WASTE_EMSN_MTHD") val largeItemMethod: String? = null,
+
+    // 관리 부서 정보
+    @SerialName("CHRG_DEPT_NM") val departmentName: String? = null,
+    @SerialName("CHRG_DEPT_TELNO") val departmentPhoneNumber: String? = null
 )

--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.team.yeogibeoryeo.data.regionalguide.repository
 
 import com.team.yeogibeoryeo.data.regionalguide.mapper.RegionalGuideMapper
-import com.team.yeogibeoryeo.data.regionalguide.remote.RegionalGuideRemoteDataSource
+import com.team.yeogibeoryeo.data.regionalguide.remote.RegionalGuideDataSource
 import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
 import com.team.yeogibeoryeo.domain.regionalguide.repository.RegionalDisposalGuideRepository
@@ -12,15 +12,14 @@ import javax.inject.Inject
  * RemoteDataSource를 통해 데이터를 패치하고, 사용자 지역 정보에 가장 적합한 배출 가이드 데이터를 선별하여 반환합니다.
  */
 class RegionalDisposalGuideRepositoryImpl @Inject constructor(
-    private val remoteDataSource: RegionalGuideRemoteDataSource
+    private val remoteDataSource: RegionalGuideDataSource
 ) : RegionalDisposalGuideRepository {
 
     override suspend fun getRegionalDisposalGuide(region: Region): RegionalDisposalGuide? {
-        val sigungu = region.sigungu
+        val isSejong = region.sido?.contains("세종") == true
+        val sigungu = if (isSejong) "세종" else region.sigungu
 
-        if (sigungu.isNullOrBlank()) {
-            return null
-        }
+        if (sigungu.isNullOrBlank()) return null
 
         val result = remoteDataSource.fetchRegionalGuides(sigungu)
 
@@ -30,15 +29,14 @@ class RegionalDisposalGuideRepositoryImpl @Inject constructor(
 
             val eupmyeondong = region.eupmyeondong
 
-            // 사용자의 행정동 명칭과 매칭되는 데이터 탐색, 없을 경우 첫 번째 데이터 폴백
             val targetDto = if (!eupmyeondong.isNullOrBlank()) {
-                dtoList.find { it.dongName?.contains(eupmyeondong) == true } ?: dtoList.first()
+                dtoList.find { it.dongName?.trim() == eupmyeondong.trim() }
+                    ?: dtoList.find { it.dongName?.contains(eupmyeondong) == true }
+                    ?: dtoList.first()
             } else {
                 dtoList.first()
             }
-
             return RegionalGuideMapper.mapToDomain(region, targetDto)
-
         } else {
             return null
         }

--- a/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalGuideMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalGuideMapperTest.kt
@@ -1,0 +1,30 @@
+package com.team.yeogibeoryeo.data.regionalguide.mapper
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RegionalGuideMapperTest {
+
+    @Test
+    fun `시간파싱_유효하지 않은 입력은 null 반환한다`() {
+        assertNull(RegionalWasteScheduleMapper.parseTime("00:00"))
+        assertNull(RegionalWasteScheduleMapper.parseTime("   "))
+        assertNull(RegionalWasteScheduleMapper.parseTime(null))
+
+        assertEquals("18:00", RegionalWasteScheduleMapper.parseTime(" 18:00 "))
+    }
+
+    @Test
+    fun `요일 파싱_불필요한 요일 단어와 기호를 제거하여 정제한다`() {
+        assertEquals("월, 화, 수", RegionalWasteScheduleMapper.parseDays("월요일/화요일+수요일,월요일"))
+        assertEquals("명절, 공휴일", RegionalWasteScheduleMapper.parseDays("명절+공휴일"))
+        assertEquals("미지정", RegionalWasteScheduleMapper.parseDays(null))
+    }
+
+    @Test
+    fun `배출 방법 파싱_과도한 공백과 줄바꿈을 하나의 공백으로 치환한다`() {
+        val rawMethod = "종량제 봉투에 담아 \n   지정된 장소에 배출"
+        assertEquals("종량제 봉투에 담아 지정된 장소에 배출", RegionalWasteScheduleMapper.parseMethod(rawMethod))
+    }
+}

--- a/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImplTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImplTest.kt
@@ -1,0 +1,62 @@
+package com.team.yeogibeoryeo.data.regionalguide.repository
+
+import com.team.yeogibeoryeo.data.regionalguide.remote.RegionalGuideDataSource
+import com.team.yeogibeoryeo.data.regionalguide.remote.dto.RegionalGuideItemDto
+import com.team.yeogibeoryeo.domain.region.model.Region
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * 모킹 프레임워크를 대체하는 Fake 데이터 소스.ㅇ
+ */
+class FakeRegionalGuideDataSource : RegionalGuideDataSource {
+    var mockResult: Result<List<RegionalGuideItemDto>> = Result.success(emptyList())
+    var calledSigunguName: String? = null
+
+    override suspend fun fetchRegionalGuides(sigunguName: String): Result<List<RegionalGuideItemDto>> {
+        calledSigunguName = sigunguName
+        return mockResult
+    }
+}
+
+class RegionalDisposalGuideRepositoryImplTest {
+
+    private lateinit var fakeDataSource: FakeRegionalGuideDataSource
+    private lateinit var repository: RegionalDisposalGuideRepositoryImpl
+
+    @Before
+    fun setUp() {
+        fakeDataSource = FakeRegionalGuideDataSource()
+        repository = RegionalDisposalGuideRepositoryImpl(fakeDataSource)
+    }
+
+    @Test
+    fun `세종시 지역 객체 전달 시 시군구가 없어도 세종 키워드로 API를 호출한다`() = runBlocking {
+        val sejongRegion = Region(sido = "세종특별자치시", sigungu = "", eupmyeondong = "새롬동")
+        val mockData = listOf(RegionalGuideItemDto(sidoName = "세종특별자치시", dongName = "새롬동"))
+        fakeDataSource.mockResult = Result.success(mockData)
+
+        val result = repository.getRegionalDisposalGuide(sejongRegion)
+
+        assertEquals("세종", fakeDataSource.calledSigunguName)
+        assertEquals("새롬동", result?.region?.eupmyeondong)
+    }
+
+    @Test
+    fun `동일한 동명칭 포함 시 정확히 일치하는 데이터를 최우선으로 선택한다`() = runBlocking {
+        val region = Region(sido = "서울특별시", sigungu = "종로구", eupmyeondong = "인사동")
+        val mockData = listOf(
+            RegionalGuideItemDto(dongName = "인사동1가"),
+            RegionalGuideItemDto(dongName = "인사동"),
+            RegionalGuideItemDto(dongName = "인사동2가")
+        )
+        fakeDataSource.mockResult = Result.success(mockData)
+
+        val result = repository.getRegionalDisposalGuide(region)
+
+        assertEquals("종로구", fakeDataSource.calledSigunguName)
+        assertEquals("인사동", result?.region?.eupmyeondong)
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalDisposalGuide.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalDisposalGuide.kt
@@ -5,18 +5,24 @@ import com.team.yeogibeoryeo.domain.region.model.Region
 /**
  * 특정 행정구역(Region)의 종합적인 쓰레기 배출 가이드 모델
  *
- * @property region 대상 행정구역
- * @property schedules 폐기물 종류별 배출 스케줄 목록
- * @property uncollectedDays 수거 제외일
+ * @property region 대상 행정구역 정보
+ * @property managementZoneName 관리구역명
+ * @property targetRegionName 관리구역 대상 지역명
  * @property disposalPlaceType 배출장소 유형
- * @property guideUrl 지자체 공식 배출 안내 페이지 링크 (선택)
- * @property inquiryPhone 관할 부서 문의 전화번호 (선택)
+ * @property disposalPlaceDescription 배출장소 상세 설명
+ * @property schedules 폐기물 유형별 배출 스케줄 목록
+ * @property uncollectedDays 수거 제외일
+ * @property departmentName 담당 관리부서명
+ * @property departmentPhoneNumber 담당 부서 연락처
  */
 data class RegionalDisposalGuide(
     val region: Region,
+    val managementZoneName: String? = null,
+    val targetRegionName: String? = null,
+    val disposalPlaceType: String? = null,
+    val disposalPlaceDescription: String? = null,
     val schedules: List<RegionalWasteSchedule>,
     val uncollectedDays: String? = null,
-    val disposalPlaceType: String? = null,
-    val guideUrl: String? = null,
-    val inquiryPhone: String? = null
+    val departmentName: String? = null,
+    val departmentPhoneNumber: String? = null,
 )

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalWasteSchedule.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalWasteSchedule.kt
@@ -8,13 +8,11 @@ package com.team.yeogibeoryeo.domain.regionalguide.model
  * @property disposalStartTime 배출 시작 시간
  * @property disposalEndTime 배출 종료 시간
  * @property disposalMethod 배출 방법
- * @property notice 추가 안내사항
  */
 data class RegionalWasteSchedule(
     val wasteType: RegionalWasteType,
-    val disposalDays: String,
+    val disposalDays: String? = null,
     val disposalStartTime: String? = null,
     val disposalEndTime: String? = null,
-    val disposalMethod: String? = null,
-    val notice: String? = null
+    val disposalMethod: String? = null
 )


### PR DESCRIPTION
## 작업 내용
### 1. 데이터 클리닝 및 매퍼 고도화
불규칙한 공공데이터 원본을 도메인 모델에 맞게 정제하는 로직을 Mapper 계층에 집약했습니다.
* **요일 데이터 정규화**: `월요일, 화요일` -> `월, 화` 변환 및 중복/다양한 구분자(+, /) 처리
* **시간 데이터 예외 처리**: 무의미한 데이터(`00:00:00` 등)를 `null`로 변환하여 UI 노이즈 제거
* **문자열 정규화**: 정규식(`\s+`)을 통한 불필요한 줄바꿈 및 연속 공백 제거
* **필드 확장**: 관리부서 정보 및 '일시적 다량폐기물' 스케줄 매핑 추가

### 2. 엣지 케이스 및 비즈니스 예외 대응
공공데이터 API의 한계를 극복하기 위한 서비스 전용 로직을 반영했습니다.
* **특수 행정구역 대응**: '구'가 없는 세종특별자치시의 검색 키워드 강제 전환 로직 구현
* **행정동 필터링 우선순위**: 동일 동명(예: 인사동) 충돌 방지를 위한 정확도 기반 매칭 적용
  - (순위: Exact Match > Partial Match > Default First)

### 3. 검증 및 안정성 확보
- `RegionalGuideMapperTest`와 `RegionalDisposalGuideRepositoryImplTest`를 통해 정제 로직 및 필터링 알고리즘을 검증했습니다.

## 테스트 결과 (검증 스크린샷)

| RegionalGuideMapperTest |   RegionalDisposalGuideRepositoryImplTest |
| --- | --- |
| <img width="1026" alt="스크린샷 2026-05-15 005500" src="https://github.com/user-attachments/assets/1d4d7881-2cf5-444f-b035-50896ca2de1e" /> | <img width="1034" alt="스크린샷 2026-05-15 010040" src="https://github.com/user-attachments/assets/3c42e5db-2e69-4b09-abe8-6c4c7eea9308" /> |

## 관련 이슈
- Closes #20 