### PR TITLE
[Feature/#29] 공통 Hilt, Network, API Key 관리 구조 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,8 @@ import java.util.Properties
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.google.ksp)
+    alias(libs.plugins.hilt.android)
 }
 
 android {
@@ -38,8 +40,17 @@ android {
 
         manifestPlaceholders["NAVER_CLIENT_ID"] = naverClientId
 
-        buildConfigField("String", "NAVER_CLIENT_ID", "\"$naverClientId\"")
-        buildConfigField("String", "PUBLIC_DATA_SERVICE_KEY", "\"$publicDataServiceKey\"")
+        buildConfigField(
+            "String",
+            "NAVER_CLIENT_ID",
+            "\"$naverClientId\"",
+        )
+
+        buildConfigField(
+            "String",
+            "PUBLIC_DATA_SERVICE_KEY",
+            "\"$publicDataServiceKey\"",
+        )
     }
 
     buildTypes {
@@ -47,7 +58,7 @@ android {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }
@@ -80,6 +91,11 @@ dependencies {
 
     implementation(libs.bundles.coroutines)
     implementation(libs.bundles.naver.map)
+
+    // Hilt
+    implementation(libs.hilt.android)
+    implementation(libs.hilt.navigation.compose)
+    ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".YeogiBeoryeoApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/team/yeogibeoryeo/YeogiBeoryeoApplication.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/YeogiBeoryeoApplication.kt
@@ -1,0 +1,7 @@
+package com.team.yeogibeoryeo
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class YeogiBeoryeoApplication : Application()

--- a/app/src/main/java/com/team/yeogibeoryeo/core/di/KeyProviderModule.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/core/di/KeyProviderModule.kt
@@ -1,0 +1,20 @@
+package com.team.yeogibeoryeo.core.di
+
+import com.team.yeogibeoryeo.core.key.BuildConfigPublicDataKeyProvider
+import com.team.yeogibeoryeo.data.core.key.PublicDataKeyProvider
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class KeyProviderModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindPublicDataKeyProvider(
+        buildConfigPublicDataKeyProvider: BuildConfigPublicDataKeyProvider,
+    ): PublicDataKeyProvider
+}

--- a/app/src/main/java/com/team/yeogibeoryeo/core/key/BuildConfigPublicDataKeyProvider.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/core/key/BuildConfigPublicDataKeyProvider.kt
@@ -1,0 +1,11 @@
+package com.team.yeogibeoryeo.core.key
+
+import com.team.yeogibeoryeo.BuildConfig
+import com.team.yeogibeoryeo.data.core.key.PublicDataKeyProvider
+import javax.inject.Inject
+
+class BuildConfigPublicDataKeyProvider @Inject constructor() : PublicDataKeyProvider {
+
+    override val serviceKey: String
+        get() = BuildConfig.PUBLIC_DATA_SERVICE_KEY
+}

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.google.ksp)
+    alias(libs.plugins.hilt.android)
 }
 
 android {
@@ -35,18 +37,17 @@ dependencies {
     implementation(libs.androidx.core.ktx)
 
     // Coroutine
-    implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.kotlinx.coroutines.android)
-
-    // Serialization
-    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.bundles.coroutines)
 
     // Network
-    implementation(libs.retrofit)
-    implementation(libs.retrofit.kotlinx.serialization.converter)
-    implementation(libs.okhttp.logging.interceptor)
+    implementation(libs.bundles.network)
+
+    // Hilt
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.core)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/data/src/main/java/com/team/yeogibeoryeo/data/core/key/PublicDataKeyProvider.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/core/key/PublicDataKeyProvider.kt
@@ -1,0 +1,5 @@
+package com.team.yeogibeoryeo.data.core.key
+
+interface PublicDataKeyProvider {
+    val serviceKey: String
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/di/NetworkModule.kt
@@ -1,0 +1,62 @@
+package com.team.yeogibeoryeo.data.di
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    private const val BASE_URL = "https://apis.data.go.kr/B552584/RecyclingInfoService/"
+
+    @Provides
+    @Singleton
+    fun provideJson(): Json {
+        return Json {
+            ignoreUnknownKeys = true
+            coerceInputValues = true
+        }
+    }
+
+    @Provides
+    @Singleton
+    fun provideHttpLoggingInterceptor(): HttpLoggingInterceptor {
+        return HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+    }
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(
+        httpLoggingInterceptor: HttpLoggingInterceptor,
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(httpLoggingInterceptor)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(
+        json: Json,
+        okHttpClient: OkHttpClient,
+    ): Retrofit {
+        val contentType = "application/json".toMediaType()
+
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(json.asConverterFactory(contentType))
+            .build()
+    }
+}

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -2,10 +2,23 @@ plugins {
     id("java-library")
     alias(libs.plugins.jetbrains.kotlin.jvm)
 }
+
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
 }
+
 kotlin {
     jvmToolchain(21)
+}
+
+dependencies {
+    // Coroutine
+    implementation(libs.kotlinx.coroutines.core)
+
+    // Inject
+    implementation(libs.javax.inject)
+
+    // Test
+    testImplementation(libs.junit)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,8 +32,9 @@ naverMapCompose = "1.6.0"
 room = "2.7.2"
 
 # DI
-hilt = "2.57"
+hilt = "2.59.2"
 hiltNavigationCompose = "1.2.0"
+javaxInject = "1"
 
 # Test
 junit = "4.13.2"
@@ -91,6 +92,7 @@ androidx-room-compiler = { group = "androidx.room", name = "room-compiler", vers
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+javax-inject = { group = "javax.inject", name = "javax.inject", version.ref = "javaxInject" }
 
 # Test
 junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 agp = "9.2.1"
 kotlin = "2.2.10"
 jetbrainsKotlinJvm = "2.2.10"
-ksp = "2.2.10-2.0.2"
+ksp = "2.3.6"
 
 # AndroidX Core
 coreKtx = "1.10.1"


### PR DESCRIPTION
## 작업 내용

프로젝트 전체에서 공통으로 사용할 Hilt, Retrofit, API Key 관리 기반 구조를 추가했습니다.

이번 PR은 개별 API 기능 구현이 아니라, 추후 `getItem`, `getSpot` 등 공공데이터 API 연동 기능에서 공통으로 사용할 네트워크/DI/키 관리 구조를 정리하는 작업입니다.

`develop` 기준에서는 각 API Service의 실제 구현이 feature 브랜치에 존재하므로, 이번 PR에서는 개별 `ItemApiService`, `SpotApiService` provider를 직접 추가하지 않고 공통 `Retrofit`, `OkHttpClient`, `Json`, `KeyProvider` 기반만 먼저 정리했습니다.

---

## 주요 구현 사항

### Gradle / TOML 정리

- `libs.versions.toml` 공통 의존성 정리
- Kotlin / KSP / Hilt 버전 통일
- `app/build.gradle.kts` 설정 정리
- `data/build.gradle.kts` 설정 정리
- `domain/build.gradle.kts` 설정 정리
- app/data 모듈에 Hilt, KSP 설정 추가
- domain 모듈에는 `javax.inject` 기반 의존성 추가

### Hilt 설정 추가

- `@HiltAndroidApp` 기반 Application 클래스 추가
- `AndroidManifest.xml`에 Application 클래스 등록
- app 모듈 Hilt 적용
- data 모듈에서 Hilt 주입 구조를 사용할 수 있도록 설정

### API Key 관리 구조 추가

- `PublicDataKeyProvider` 인터페이스 추가
- app `BuildConfig.PUBLIC_DATA_SERVICE_KEY` 기반 구현체 추가
- `KeyProviderModule`을 통해 Hilt binding 구성
- Repository 또는 DataSource에서 `BuildConfig`를 직접 참조하지 않고 KeyProvider를 통해 서비스키를 주입받을 수 있는 기반 마련

### 공통 NetworkModule 추가

- 공통 `Json` 제공
- 공통 `HttpLoggingInterceptor` 제공
- 공통 `OkHttpClient` 제공
- 공통 `Retrofit` 인스턴스 제공
- 공공데이터 API baseUrl을 공통 NetworkModule에서 관리

---

## 결정된 공통 방향

- 공공데이터포털 인증키는 Decoding 키 사용
- Retrofit에서는 `@Query("serviceKey")` 방식 사용
- 실제 서비스키는 `local.properties`에서 관리
- Git에는 실제 키를 올리지 않음
- `PUBLIC_DATA_SERVICE_KEY`는 app `BuildConfig`에서 읽고, data 계층에는 `PublicDataKeyProvider`를 통해 주입
- 공통 `Retrofit`, `OkHttpClient`, `Json`은 Hilt `NetworkModule`에서 제공

---

## 이번 PR에서 제외한 작업

아래 작업은 각 기능 브랜치에서 최신 `develop`을 반영한 뒤 처리할 예정입니다.

- `ItemApiService` provider 추가
- `SpotApiService` provider 추가
- 기존 `WasteRecyclingServiceFactory` 제거 또는 미사용 처리
- `getItem` 구조를 공통 Retrofit/Hilt 구조로 수정
- `getSpot` 구조를 공통 Retrofit/Hilt 구조로 수정
- 각 기능별 Repository에서 `PublicDataKeyProvider` 적용
- 실제 API 호출 검증

---

## 참고 사항

- 이번 PR은 개별 API 기능 구현 PR이 아니라 공통 기반 설정 PR입니다.
- 이 PR이 `develop`에 merge된 뒤, 각자의 feature 브랜치에서 최신 `develop`을 반영하여 `getItem`, `getSpot` 구조를 맞출 예정입니다.
- Gradle/TOML 파일은 충돌 가능성이 높기 때문에 공통 설정을 먼저 반영하는 목적으로 작업했습니다.
- 실제 API 호출 및 Android Geocoder 검증은 별도 이슈에서 진행합니다.

---

## 테스트

- Gradle Sync 확인
- 앱 빌드 기준으로 공통 설정 오류 여부 확인
- Hilt Application / KeyProvider / NetworkModule 구성 확인

Close #29 