### PR TITLE
fix: 세종특별자치시 배출 가이드 조회 예외 처리 수정

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImpl.kt
@@ -16,8 +16,7 @@ class RegionalDisposalGuideRepositoryImpl @Inject constructor(
 ) : RegionalDisposalGuideRepository {
 
     override suspend fun getRegionalDisposalGuide(region: Region): RegionalDisposalGuide? {
-        val isSejong = region.sido?.contains("세종") == true
-        val sigungu = if (isSejong) "세종" else region.sigungu
+        val sigungu = if (region.sido == "세종특별자치시") "없음" else  region.sigungu
 
         if (sigungu.isNullOrBlank()) return null
 

--- a/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImplTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImplTest.kt
@@ -9,7 +9,7 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * 모킹 프레임워크를 대체하는 Fake 데이터 소스.ㅇ
+ * 모킹 프레임워크를 대체하는 Fake 데이터 소스.
  */
 class FakeRegionalGuideDataSource : RegionalGuideDataSource {
     var mockResult: Result<List<RegionalGuideItemDto>> = Result.success(emptyList())
@@ -33,14 +33,14 @@ class RegionalDisposalGuideRepositoryImplTest {
     }
 
     @Test
-    fun `세종시 지역 객체 전달 시 시군구가 없어도 세종 키워드로 API를 호출한다`() = runBlocking {
+    fun `세종시 지역 객체 전달 시 시군구가 없어도 없음 키워드로 API를 호출한다`() = runBlocking {
         val sejongRegion = Region(sido = "세종특별자치시", sigungu = "", eupmyeondong = "새롬동")
-        val mockData = listOf(RegionalGuideItemDto(sidoName = "세종특별자치시", dongName = "새롬동"))
+        val mockData = listOf(RegionalGuideItemDto(sidoName = "세종특별자치시", sigunguName = "없음", dongName = "새롬동"))
         fakeDataSource.mockResult = Result.success(mockData)
 
         val result = repository.getRegionalDisposalGuide(sejongRegion)
 
-        assertEquals("세종", fakeDataSource.calledSigunguName)
+        assertEquals("없음", fakeDataSource.calledSigunguName)
         assertEquals("새롬동", result?.region?.eupmyeondong)
     }
 


### PR DESCRIPTION
## 변경 사항
- 세종특별자치시 조회 시 `SGG_NM` 값을 `"세종"` 대신 `"없음"`으로 보정
- 세종 예외 처리 테스트 기대값 수정

## 배경
- `/info` 실제 데이터 확인 결과, 세종특별자치시의 `SGG_NM` 값은 `"없음"`으로 저장되어 있음
- 기존 구현은 `"세종"`으로 조회하고 있어 결과가 0건으로 반환됨