### PR TITLE
[Setup] lifecycle-runtime-compose 의존성 추가

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 
 # Lifecycle
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleViewModelKtx" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewModelKtx" }
 

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
 
     // Coroutine
     implementation(libs.bundles.coroutines)


### PR DESCRIPTION
## 개요

`presentation` 모듈에서 `collectAsStateWithLifecycle()`를 사용할 수 있도록 lifecycle runtime compose 의존성을 추가합니다.

## 반영 내용

- 버전 카탈로그에 `androidx.lifecycle:lifecycle-runtime-compose` alias 추가
- `presentation` 모듈에 `lifecycle-runtime-compose` 의존성 연결

## 확인 사항

- `./gradlew :presentation:compileDebugKotlin` 성공 확인

## 관련 이슈

- Related to #42