### PR TITLE
[Feature] 수거 장소 지도 검색 및 현재 위치 조회 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:name=".YeogiBeoryeoApplication"

--- a/app/src/main/java/com/team/yeogibeoryeo/MainActivity.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/MainActivity.kt
@@ -7,43 +7,30 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import com.team.yeogibeoryeo.presentation.map.CollectionSpotMapScreen
 import com.team.yeogibeoryeo.ui.theme.YeogiBeoryeoTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
         setContent {
             YeogiBeoryeoTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
+                Scaffold(
+                    modifier = Modifier.fillMaxSize(),
+                ) { innerPadding ->
+                    CollectionSpotMapScreen(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
                     )
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    YeogiBeoryeoTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/team/yeogibeoryeo/MainActivity.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/MainActivity.kt
@@ -7,30 +7,43 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.team.yeogibeoryeo.presentation.map.CollectionSpotMapScreen
+import androidx.compose.ui.tooling.preview.Preview
 import com.team.yeogibeoryeo.ui.theme.YeogiBeoryeoTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-
         setContent {
             YeogiBeoryeoTheme {
-                Scaffold(
-                    modifier = Modifier.fillMaxSize(),
-                ) { innerPadding ->
-                    CollectionSpotMapScreen(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(innerPadding),
+                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+                    Greeting(
+                        name = "Android",
+                        modifier = Modifier.padding(innerPadding)
                     )
                 }
             }
         }
+    }
+}
+
+@Composable
+fun Greeting(name: String, modifier: Modifier = Modifier) {
+    Text(
+        text = "Hello $name!",
+        modifier = modifier
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun GreetingPreview() {
+    YeogiBeoryeoTheme {
+        Greeting("Android")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,8 @@ espressoCore = "3.5.1"
 appcompat = "1.7.1"
 material = "1.13.0"
 
+playServicesLocation = "21.3.0"
+
 
 [libraries]
 # AndroidX Core
@@ -85,6 +87,8 @@ okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-i
 # Naver Map
 naver-map-sdk = { group = "com.naver.maps", name = "map-sdk", version.ref = "naverMapSdk" }
 naver-map-compose = { group = "io.github.fornewid", name = "naver-map-compose", version.ref = "naverMapCompose" }
+
+google-android-gms-play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
 
 # Room
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 
 # Navigation
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
@@ -128,6 +129,7 @@ compose = [
     "androidx-compose-ui-graphics",
     "androidx-compose-ui-tooling-preview",
     "androidx-compose-material3",
+    "androidx-compose-material-icons-extended",
     "androidx-navigation-compose",
     "androidx-lifecycle-viewmodel-compose"
 ]

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -48,6 +48,9 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
 
+    // Location
+    implementation(libs.google.android.gms.play.services.location)
+
     // Coroutine
     implementation(libs.bundles.coroutines)
 

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -51,6 +51,9 @@ dependencies {
     // Coroutine
     implementation(libs.bundles.coroutines)
 
+    // Naver Map
+    implementation(libs.bundles.naver.map)
+
     // Hilt
     implementation(libs.hilt.android)
     implementation(libs.hilt.navigation.compose)

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -1,9 +1,18 @@
 package com.team.yeogibeoryeo.presentation.map
 
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.LocationManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -11,12 +20,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.presentation.map.components.CollectionSpotNaverMap
+import com.team.yeogibeoryeo.presentation.map.components.CurrentLocationButton
 import com.team.yeogibeoryeo.presentation.map.components.EmptySpotResult
 import com.team.yeogibeoryeo.presentation.map.components.MapSearchBar
 import com.team.yeogibeoryeo.presentation.map.components.SpotBottomList
@@ -27,12 +41,48 @@ fun CollectionSpotMapScreen(
     modifier: Modifier = Modifier,
     viewModel: CollectionSpotMapViewModel = hiltViewModel(),
 ) {
+    val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val locationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { isGranted ->
+        if (isGranted) {
+            val coordinate = getLastKnownCoordinate(context)
+
+            if (coordinate != null) {
+                viewModel.searchByCurrentLocation(
+                    latitude = coordinate.latitude,
+                    longitude = coordinate.longitude,
+                )
+            } else {
+                viewModel.onCurrentLocationNotFound()
+            }
+        } else {
+            viewModel.onLocationPermissionDenied()
+        }
+    }
 
     CollectionSpotMapContent(
         uiState = uiState,
         onKeywordChanged = viewModel::onSearchKeywordChanged,
         onSearchClick = viewModel::searchByKeyword,
+        onCurrentLocationClick = {
+            if (hasFineLocationPermission(context)) {
+                val coordinate = getLastKnownCoordinate(context)
+
+                if (coordinate != null) {
+                    viewModel.searchByCurrentLocation(
+                        latitude = coordinate.latitude,
+                        longitude = coordinate.longitude,
+                    )
+                } else {
+                    viewModel.onCurrentLocationNotFound()
+                }
+            } else {
+                locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+            }
+        },
         onTypeClick = viewModel::onSpotTypeClick,
         onSpotClick = viewModel::onSpotClick,
         modifier = modifier,
@@ -44,6 +94,7 @@ private fun CollectionSpotMapContent(
     uiState: CollectionSpotMapUiState,
     onKeywordChanged: (String) -> Unit,
     onSearchClick: () -> Unit,
+    onCurrentLocationClick: () -> Unit,
     onTypeClick: (CollectionSpotType) -> Unit,
     onSpotClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
@@ -61,6 +112,16 @@ private fun CollectionSpotMapContent(
             selectedTypes = uiState.selectedTypes,
             onTypeClick = onTypeClick,
         )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        ) {
+            CurrentLocationButton(
+                onClick = onCurrentLocationClick,
+            )
+        }
 
         CollectionSpotNaverMap(
             spots = uiState.spots,
@@ -81,6 +142,13 @@ private fun CollectionSpotMapContent(
                 ) {
                     CircularProgressIndicator()
                 }
+            }
+
+            uiState.locationNoticeMessage != null -> {
+                EmptySpotResult(
+                    title = "현재 위치 검색 안내",
+                    description = uiState.locationNoticeMessage,
+                )
             }
 
             uiState.errorMessage != null -> {
@@ -106,6 +174,43 @@ private fun CollectionSpotMapContent(
     }
 }
 
+private fun hasFineLocationPermission(
+    context: Context,
+): Boolean {
+    return ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.ACCESS_FINE_LOCATION,
+    ) == PackageManager.PERMISSION_GRANTED
+}
+
+@SuppressLint("MissingPermission")
+private fun getLastKnownCoordinate(
+    context: Context,
+): Coordinate? {
+    val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+
+    return try {
+        val providers = locationManager.getProviders(true)
+
+        providers
+            .asSequence()
+            .mapNotNull { provider ->
+                locationManager.getLastKnownLocation(provider)
+            }
+            .maxByOrNull { location ->
+                location.time
+            }
+            ?.let { location ->
+                Coordinate(
+                    latitude = location.latitude,
+                    longitude = location.longitude,
+                )
+            }
+    } catch (exception: SecurityException) {
+        null
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun CollectionSpotMapContentPreview() {
@@ -118,6 +223,7 @@ private fun CollectionSpotMapContentPreview() {
                 ),
                 onKeywordChanged = {},
                 onSearchClick = {},
+                onCurrentLocationClick = {},
                 onTypeClick = {},
                 onSpotClick = {},
             )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -1,6 +1,5 @@
 package com.team.yeogibeoryeo.presentation.map
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,7 +7,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -18,6 +16,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.presentation.map.components.CollectionSpotNaverMap
 import com.team.yeogibeoryeo.presentation.map.components.EmptySpotResult
 import com.team.yeogibeoryeo.presentation.map.components.MapSearchBar
 import com.team.yeogibeoryeo.presentation.map.components.SpotBottomList
@@ -63,19 +62,14 @@ private fun CollectionSpotMapContent(
             onTypeClick = onTypeClick,
         )
 
-        Box(
+        CollectionSpotNaverMap(
+            spots = uiState.spots,
+            selectedSpot = uiState.selectedSpot,
+            onSpotClick = onSpotClick,
             modifier = Modifier
                 .fillMaxWidth()
-                .weight(1f)
-                .background(MaterialTheme.colorScheme.surfaceVariant),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = "지도 영역",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+                .weight(1f),
+        )
 
         when {
             uiState.isLoading -> {
@@ -96,13 +90,14 @@ private fun CollectionSpotMapContent(
                 )
             }
 
-            uiState.spots.isEmpty() && uiState.searchKeyword.isNotBlank() -> {
+            uiState.hasSearched && uiState.spots.isEmpty() -> {
                 EmptySpotResult()
             }
 
             uiState.spots.isNotEmpty() -> {
                 SpotBottomList(
                     spots = uiState.spots,
+                    selectedSpot = uiState.selectedSpot,
                     onSpotClick = onSpotClick,
                     modifier = Modifier.weight(0.45f),
                 )
@@ -119,6 +114,7 @@ private fun CollectionSpotMapContentPreview() {
             CollectionSpotMapContent(
                 uiState = CollectionSpotMapUiState(
                     searchKeyword = "문래동",
+                    hasSearched = true,
                 ),
                 onKeywordChanged = {},
                 onSearchClick = {},

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -1,0 +1,130 @@
+package com.team.yeogibeoryeo.presentation.map
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.presentation.map.components.EmptySpotResult
+import com.team.yeogibeoryeo.presentation.map.components.MapSearchBar
+import com.team.yeogibeoryeo.presentation.map.components.SpotBottomList
+import com.team.yeogibeoryeo.presentation.map.components.SpotFilterChipRow
+
+@Composable
+fun CollectionSpotMapScreen(
+    modifier: Modifier = Modifier,
+    viewModel: CollectionSpotMapViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    CollectionSpotMapContent(
+        uiState = uiState,
+        onKeywordChanged = viewModel::onSearchKeywordChanged,
+        onSearchClick = viewModel::searchByKeyword,
+        onTypeClick = viewModel::onSpotTypeClick,
+        onSpotClick = viewModel::onSpotClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun CollectionSpotMapContent(
+    uiState: CollectionSpotMapUiState,
+    onKeywordChanged: (String) -> Unit,
+    onSearchClick: () -> Unit,
+    onTypeClick: (CollectionSpotType) -> Unit,
+    onSpotClick: (CollectionSpot) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        MapSearchBar(
+            keyword = uiState.searchKeyword,
+            onKeywordChanged = onKeywordChanged,
+            onSearchClick = onSearchClick,
+        )
+
+        SpotFilterChipRow(
+            selectedTypes = uiState.selectedTypes,
+            onTypeClick = onTypeClick,
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "지도 영역",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        when {
+            uiState.isLoading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(0.45f),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            uiState.errorMessage != null -> {
+                EmptySpotResult(
+                    title = "수거 장소를 불러오지 못했습니다.",
+                    description = uiState.errorMessage,
+                )
+            }
+
+            uiState.spots.isEmpty() && uiState.searchKeyword.isNotBlank() -> {
+                EmptySpotResult()
+            }
+
+            uiState.spots.isNotEmpty() -> {
+                SpotBottomList(
+                    spots = uiState.spots,
+                    onSpotClick = onSpotClick,
+                    modifier = Modifier.weight(0.45f),
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CollectionSpotMapContentPreview() {
+    MaterialTheme {
+        Surface {
+            CollectionSpotMapContent(
+                uiState = CollectionSpotMapUiState(
+                    searchKeyword = "문래동",
+                ),
+                onKeywordChanged = {},
+                onSearchClick = {},
+                onTypeClick = {},
+                onSpotClick = {},
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapUiState.kt
@@ -1,0 +1,17 @@
+package com.team.yeogibeoryeo.presentation.map
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+
+data class CollectionSpotMapUiState(
+    val searchKeyword: String = "",
+    val searchMode: MapSearchMode = MapSearchMode.KEYWORD,
+    val spots: List<CollectionSpot> = emptyList(),
+    val selectedSpot: CollectionSpot? = null,
+    val selectedTypes: Set<CollectionSpotType> = emptySet(),
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+) {
+    val isEmpty: Boolean
+        get() = !isLoading && spots.isEmpty() && errorMessage == null
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapUiState.kt
@@ -12,6 +12,7 @@ data class CollectionSpotMapUiState(
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
     val hasSearched: Boolean = false,
+    val locationNoticeMessage: String? = null,
 ) {
     val isEmpty: Boolean
         get() = hasSearched && !isLoading && spots.isEmpty() && errorMessage == null

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapUiState.kt
@@ -11,7 +11,8 @@ data class CollectionSpotMapUiState(
     val selectedTypes: Set<CollectionSpotType> = emptySet(),
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
+    val hasSearched: Boolean = false,
 ) {
     val isEmpty: Boolean
-        get() = !isLoading && spots.isEmpty() && errorMessage == null
+        get() = hasSearched && !isLoading && spots.isEmpty() && errorMessage == null
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -27,7 +27,10 @@ class CollectionSpotMapViewModel @Inject constructor(
 
     fun onSearchKeywordChanged(keyword: String) {
         _uiState.update {
-            it.copy(searchKeyword = keyword)
+            it.copy(
+                searchKeyword = keyword,
+                errorMessage = null,
+            )
         }
     }
 
@@ -35,10 +38,14 @@ class CollectionSpotMapViewModel @Inject constructor(
         val keyword = uiState.value.searchKeyword.trim()
 
         if (keyword.isBlank()) {
+            originalSpots = emptyList()
+
             _uiState.update {
                 it.copy(
                     spots = emptyList(),
                     selectedSpot = null,
+                    isLoading = false,
+                    hasSearched = false,
                     errorMessage = "검색어를 입력해주세요.",
                 )
             }
@@ -49,6 +56,7 @@ class CollectionSpotMapViewModel @Inject constructor(
             _uiState.update {
                 it.copy(
                     isLoading = true,
+                    hasSearched = true,
                     errorMessage = null,
                     selectedSpot = null,
                     searchMode = MapSearchMode.KEYWORD,
@@ -71,7 +79,9 @@ class CollectionSpotMapViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         spots = filteredSpots,
+                        selectedSpot = null,
                         isLoading = false,
+                        hasSearched = true,
                         errorMessage = null,
                     )
                 }
@@ -81,8 +91,9 @@ class CollectionSpotMapViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         spots = emptyList(),
-                        isLoading = false,
                         selectedSpot = null,
+                        isLoading = false,
+                        hasSearched = true,
                         errorMessage = throwable.message ?: "수거 장소를 불러오지 못했습니다.",
                     )
                 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -1,0 +1,127 @@
+package com.team.yeogibeoryeo.presentation.map
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
+import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByKeywordUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class CollectionSpotMapViewModel @Inject constructor(
+    private val searchCollectionSpotsByKeywordUseCase: SearchCollectionSpotsByKeywordUseCase,
+    private val filterCollectionSpotsUseCase: FilterCollectionSpotsUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CollectionSpotMapUiState())
+    val uiState: StateFlow<CollectionSpotMapUiState> = _uiState.asStateFlow()
+
+    private var originalSpots: List<CollectionSpot> = emptyList()
+
+    fun onSearchKeywordChanged(keyword: String) {
+        _uiState.update {
+            it.copy(searchKeyword = keyword)
+        }
+    }
+
+    fun searchByKeyword() {
+        val keyword = uiState.value.searchKeyword.trim()
+
+        if (keyword.isBlank()) {
+            _uiState.update {
+                it.copy(
+                    spots = emptyList(),
+                    selectedSpot = null,
+                    errorMessage = "검색어를 입력해주세요.",
+                )
+            }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    isLoading = true,
+                    errorMessage = null,
+                    selectedSpot = null,
+                    searchMode = MapSearchMode.KEYWORD,
+                )
+            }
+
+            runCatching {
+                searchCollectionSpotsByKeywordUseCase(
+                    keyword = keyword,
+                    types = emptySet(),
+                )
+            }.onSuccess { spots ->
+                originalSpots = spots
+
+                val filteredSpots = filterCollectionSpotsUseCase(
+                    spots = originalSpots,
+                    selectedTypes = uiState.value.selectedTypes,
+                )
+
+                _uiState.update {
+                    it.copy(
+                        spots = filteredSpots,
+                        isLoading = false,
+                        errorMessage = null,
+                    )
+                }
+            }.onFailure { throwable ->
+                originalSpots = emptyList()
+
+                _uiState.update {
+                    it.copy(
+                        spots = emptyList(),
+                        isLoading = false,
+                        selectedSpot = null,
+                        errorMessage = throwable.message ?: "수거 장소를 불러오지 못했습니다.",
+                    )
+                }
+            }
+        }
+    }
+
+    fun onSpotTypeClick(type: CollectionSpotType) {
+        val currentTypes = uiState.value.selectedTypes
+
+        val updatedTypes = if (type in currentTypes) {
+            currentTypes - type
+        } else {
+            currentTypes + type
+        }
+
+        val filteredSpots = filterCollectionSpotsUseCase(
+            spots = originalSpots,
+            selectedTypes = updatedTypes,
+        )
+
+        _uiState.update {
+            it.copy(
+                selectedTypes = updatedTypes,
+                spots = filteredSpots,
+                selectedSpot = null,
+            )
+        }
+    }
+
+    fun onSpotClick(spot: CollectionSpot) {
+        _uiState.update {
+            it.copy(selectedSpot = spot)
+        }
+    }
+
+    fun clearErrorMessage() {
+        _uiState.update {
+            it.copy(errorMessage = null)
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByKeywordUseCase
+import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByLocationUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,6 +19,7 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class CollectionSpotMapViewModel @Inject constructor(
     private val searchCollectionSpotsByKeywordUseCase: SearchCollectionSpotsByKeywordUseCase,
+    private val searchCollectionSpotsByLocationUseCase: SearchCollectionSpotsByLocationUseCase,
     private val filterCollectionSpotsUseCase: FilterCollectionSpotsUseCase,
 ) : ViewModel() {
 
@@ -30,6 +33,7 @@ class CollectionSpotMapViewModel @Inject constructor(
             it.copy(
                 searchKeyword = keyword,
                 errorMessage = null,
+                locationNoticeMessage = null,
             )
         }
     }
@@ -47,6 +51,8 @@ class CollectionSpotMapViewModel @Inject constructor(
                     isLoading = false,
                     hasSearched = false,
                     errorMessage = "검색어를 입력해주세요.",
+                    locationNoticeMessage = null,
+                    searchMode = MapSearchMode.KEYWORD,
                 )
             }
             return
@@ -58,6 +64,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     isLoading = true,
                     hasSearched = true,
                     errorMessage = null,
+                    locationNoticeMessage = null,
                     selectedSpot = null,
                     searchMode = MapSearchMode.KEYWORD,
                 )
@@ -69,34 +76,46 @@ class CollectionSpotMapViewModel @Inject constructor(
                     types = emptySet(),
                 )
             }.onSuccess { spots ->
-                originalSpots = spots
-
-                val filteredSpots = filterCollectionSpotsUseCase(
-                    spots = originalSpots,
-                    selectedTypes = uiState.value.selectedTypes,
-                )
-
-                _uiState.update {
-                    it.copy(
-                        spots = filteredSpots,
-                        selectedSpot = null,
-                        isLoading = false,
-                        hasSearched = true,
-                        errorMessage = null,
-                    )
-                }
+                updateSpotResult(spots)
             }.onFailure { throwable ->
-                originalSpots = emptyList()
+                updateSpotFailure(
+                    message = throwable.message ?: "수거 장소를 불러오지 못했습니다.",
+                )
+            }
+        }
+    }
 
-                _uiState.update {
-                    it.copy(
-                        spots = emptyList(),
-                        selectedSpot = null,
-                        isLoading = false,
-                        hasSearched = true,
-                        errorMessage = throwable.message ?: "수거 장소를 불러오지 못했습니다.",
-                    )
-                }
+    fun searchByCurrentLocation(
+        latitude: Double,
+        longitude: Double,
+    ) {
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    isLoading = true,
+                    hasSearched = true,
+                    errorMessage = null,
+                    locationNoticeMessage = null,
+                    selectedSpot = null,
+                    searchMode = MapSearchMode.CURRENT_LOCATION,
+                )
+            }
+
+            runCatching {
+                searchCollectionSpotsByLocationUseCase(
+                    coordinate = Coordinate(
+                        latitude = latitude,
+                        longitude = longitude,
+                    ),
+                    radiusMeter = DEFAULT_RADIUS_METER,
+                    types = emptySet(),
+                )
+            }.onSuccess { spots ->
+                updateSpotResult(spots)
+            }.onFailure { throwable ->
+                updateSpotFailure(
+                    message = throwable.message ?: "현재 위치 주변 수거 장소를 불러오지 못했습니다.",
+                )
             }
         }
     }
@@ -130,9 +149,71 @@ class CollectionSpotMapViewModel @Inject constructor(
         }
     }
 
+    fun onLocationPermissionDenied() {
+        _uiState.update {
+            it.copy(
+                isLoading = false,
+                hasSearched = false,
+                errorMessage = null,
+                locationNoticeMessage = "현재 위치 검색은 위치 권한을 허용하면 사용할 수 있어요. 직접 동네나 주소를 검색할 수도 있습니다.",
+                searchMode = MapSearchMode.KEYWORD,
+            )
+        }
+    }
+
+    fun onCurrentLocationNotFound() {
+        _uiState.update {
+            it.copy(
+                isLoading = false,
+                errorMessage = null,
+                locationNoticeMessage = "현재 위치를 확인하지 못했습니다. 직접 동네나 주소를 검색해 주세요.",
+                searchMode = MapSearchMode.KEYWORD,
+            )
+        }
+    }
+
     fun clearErrorMessage() {
         _uiState.update {
             it.copy(errorMessage = null)
         }
+    }
+
+    private fun updateSpotResult(spots: List<CollectionSpot>) {
+        originalSpots = spots
+
+        val filteredSpots = filterCollectionSpotsUseCase(
+            spots = originalSpots,
+            selectedTypes = uiState.value.selectedTypes,
+        )
+
+        _uiState.update {
+            it.copy(
+                spots = filteredSpots,
+                selectedSpot = null,
+                isLoading = false,
+                hasSearched = true,
+                errorMessage = null,
+                locationNoticeMessage = null,
+            )
+        }
+    }
+
+    private fun updateSpotFailure(message: String) {
+        originalSpots = emptyList()
+
+        _uiState.update {
+            it.copy(
+                spots = emptyList(),
+                selectedSpot = null,
+                isLoading = false,
+                hasSearched = true,
+                errorMessage = message,
+                locationNoticeMessage = null,
+            )
+        }
+    }
+
+    private companion object {
+        const val DEFAULT_RADIUS_METER = 500
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/MapSearchMode.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/MapSearchMode.kt
@@ -1,0 +1,6 @@
+package com.team.yeogibeoryeo.presentation.map
+
+enum class MapSearchMode {
+    KEYWORD,
+    CURRENT_LOCATION,
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CollectionSpotNaverMap.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CollectionSpotNaverMap.kt
@@ -1,0 +1,99 @@
+package com.team.yeogibeoryeo.presentation.map.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.CameraPosition
+import com.naver.maps.map.CameraUpdate
+import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.Marker
+import com.naver.maps.map.compose.MarkerState
+import com.naver.maps.map.compose.NaverMap
+import com.naver.maps.map.compose.rememberCameraPositionState
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+
+@OptIn(ExperimentalNaverMapApi::class)
+@Composable
+fun CollectionSpotNaverMap(
+    spots: List<CollectionSpot>,
+    selectedSpot: CollectionSpot?,
+    onSpotClick: (CollectionSpot) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val markerSpots = spots.filter { spot ->
+        spot.coordinate != null
+    }
+
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition(
+            DEFAULT_LOCATION,
+            DEFAULT_ZOOM,
+        )
+    }
+
+    LaunchedEffect(markerSpots) {
+        val firstSpot = markerSpots.firstOrNull()
+        val coordinate = firstSpot?.coordinate
+
+        if (coordinate != null) {
+            cameraPositionState.move(
+                CameraUpdate.scrollAndZoomTo(
+                    LatLng(
+                        coordinate.latitude,
+                        coordinate.longitude,
+                    ),
+                    SEARCH_RESULT_ZOOM,
+                ),
+            )
+        }
+    }
+
+    LaunchedEffect(selectedSpot?.id) {
+        val coordinate = selectedSpot?.coordinate
+
+        if (coordinate != null) {
+            cameraPositionState.move(
+                CameraUpdate.scrollAndZoomTo(
+                    LatLng(
+                        coordinate.latitude,
+                        coordinate.longitude,
+                    ),
+                    SELECTED_SPOT_ZOOM,
+                ),
+            )
+        }
+    }
+
+    NaverMap(
+        modifier = modifier,
+        cameraPositionState = cameraPositionState,
+    ) {
+        markerSpots.forEach { spot ->
+            val coordinate = spot.coordinate ?: return@forEach
+
+            Marker(
+                state = MarkerState(
+                    position = LatLng(
+                        coordinate.latitude,
+                        coordinate.longitude,
+                    ),
+                ),
+                captionText = spot.name,
+                onClick = {
+                    onSpotClick(spot)
+                    true
+                },
+            )
+        }
+    }
+}
+
+private val DEFAULT_LOCATION = LatLng(
+    37.5666102,
+    126.9783881,
+)
+
+private const val DEFAULT_ZOOM = 12.0
+private const val SEARCH_RESULT_ZOOM = 15.0
+private const val SELECTED_SPOT_ZOOM = 16.0

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CollectionSpotNaverMap.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CollectionSpotNaverMap.kt
@@ -3,6 +3,7 @@ package com.team.yeogibeoryeo.presentation.map.components
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
 import com.naver.maps.map.CameraUpdate
@@ -71,6 +72,7 @@ fun CollectionSpotNaverMap(
     ) {
         markerSpots.forEach { spot ->
             val coordinate = spot.coordinate ?: return@forEach
+            val isSelected = selectedSpot?.id == spot.id
 
             Marker(
                 state = MarkerState(
@@ -80,6 +82,16 @@ fun CollectionSpotNaverMap(
                     ),
                 ),
                 captionText = spot.name,
+                iconTintColor = if (isSelected) {
+                    SELECTED_MARKER_COLOR
+                } else {
+                    DEFAULT_MARKER_COLOR
+                },
+                zIndex = if (isSelected) {
+                    SELECTED_MARKER_Z_INDEX
+                } else {
+                    DEFAULT_MARKER_Z_INDEX
+                },
                 onClick = {
                     onSpotClick(spot)
                     true
@@ -94,6 +106,12 @@ private val DEFAULT_LOCATION = LatLng(
     126.9783881,
 )
 
+private val DEFAULT_MARKER_COLOR = Color(0xFF00C853)
+private val SELECTED_MARKER_COLOR = Color(0xFFFF7043)
+
 private const val DEFAULT_ZOOM = 12.0
 private const val SEARCH_RESULT_ZOOM = 15.0
 private const val SELECTED_SPOT_ZOOM = 16.0
+
+private const val DEFAULT_MARKER_Z_INDEX = 0
+private const val SELECTED_MARKER_Z_INDEX = 10

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CurrentLocationButton.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CurrentLocationButton.kt
@@ -1,0 +1,45 @@
+package com.team.yeogibeoryeo.presentation.map.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CurrentLocationButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    FilledTonalButton(
+        onClick = onClick,
+        modifier = modifier,
+    ) {
+        Icon(
+            imageVector = Icons.Default.MyLocation,
+            contentDescription = null,
+        )
+
+        Text(
+            text = "현재 위치",
+            modifier = Modifier.padding(start = 6.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CurrentLocationButtonPreview() {
+    MaterialTheme {
+        CurrentLocationButton(
+            onClick = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/EmptySpotResult.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/EmptySpotResult.kt
@@ -1,0 +1,52 @@
+package com.team.yeogibeoryeo.presentation.map.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun EmptySpotResult(
+    modifier: Modifier = Modifier,
+    title: String = "검색 결과가 없습니다.",
+    description: String = "다른 동네명이나 주소로 다시 검색해 주세요.",
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp, vertical = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+
+        Text(
+            text = description,
+            modifier = Modifier.padding(top = 8.dp),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun EmptySpotResultPreview() {
+    MaterialTheme {
+        Surface {
+            EmptySpotResult()
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
@@ -1,3 +1,93 @@
 package com.team.yeogibeoryeo.presentation.map.components
 
-// 지도 화면 검색바 (수빈님)
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun MapSearchBar(
+    keyword: String,
+    onKeywordChanged: (String) -> Unit,
+    onSearchClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        OutlinedTextField(
+            value = keyword,
+            onValueChange = onKeywordChanged,
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 56.dp),
+            placeholder = {
+                Text(text = "동네 또는 주소를 검색해주세요.")
+            },
+            singleLine = true,
+            trailingIcon = {
+                IconButton(
+                    onClick = onSearchClick,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Search,
+                        contentDescription = "검색",
+                    )
+                }
+            },
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Search,
+            ),
+            keyboardActions = KeyboardActions(
+                onSearch = {
+                    onSearchClick()
+                },
+            ),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MapSearchBarPreview() {
+    MaterialTheme {
+        Surface {
+            MapSearchBar(
+                keyword = "",
+                onKeywordChanged = {},
+                onSearchClick = {},
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MapSearchBarWithKeywordPreview() {
+    MaterialTheme {
+        Surface {
+            MapSearchBar(
+                keyword = "용답동",
+                onKeywordChanged = {},
+                onSearchClick = {},
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomCard.kt
@@ -1,0 +1,138 @@
+package com.team.yeogibeoryeo.presentation.map.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.presentation.map.mapper.toDisplayName
+
+@Composable
+fun SpotBottomCard(
+    spot: CollectionSpot,
+    onClick: (CollectionSpot) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable {
+                onClick(spot)
+            },
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 2.dp,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            Row {
+                Text(
+                    text = spot.type.toDisplayName(),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+
+                spot.distanceMeter?.let { distanceMeter ->
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    Text(
+                        text = "${distanceMeter}m",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            Text(
+                text = spot.name,
+                modifier = Modifier.padding(top = 6.dp),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+
+            Text(
+                text = spot.address,
+                modifier = Modifier.padding(top = 4.dp),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            spot.detailLocation?.let { detailLocation ->
+                Text(
+                    text = detailLocation,
+                    modifier = Modifier.padding(top = 2.dp),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SpotBottomCardPreview() {
+    MaterialTheme {
+        Surface(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            SpotBottomCard(
+                spot = CollectionSpot(
+                    id = "1",
+                    name = "폐건전지 수거함",
+                    type = CollectionSpotType.BATTERY_BIN,
+                    address = "서울특별시 영등포구 문래동",
+                    detailLocation = "주민센터 앞",
+                    coordinate = null,
+                    distanceMeter = 120,
+                    isBookmarked = false,
+                ),
+                onClick = {},
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SpotBottomCardWithoutDetailPreview() {
+    MaterialTheme {
+        Surface(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            SpotBottomCard(
+                spot = CollectionSpot(
+                    id = "2",
+                    name = "재활용센터",
+                    type = CollectionSpotType.RECYCLING_CENTER,
+                    address = "서울특별시 구로구 구로동",
+                    detailLocation = null,
+                    coordinate = null,
+                    distanceMeter = null,
+                    isBookmarked = false,
+                ),
+                onClick = {},
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomCard.kt
@@ -24,6 +24,7 @@ import com.team.yeogibeoryeo.presentation.map.mapper.toDisplayName
 @Composable
 fun SpotBottomCard(
     spot: CollectionSpot,
+    isSelected: Boolean,
     onClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -34,10 +35,14 @@ fun SpotBottomCard(
                 onClick(spot)
             },
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface,
+            containerColor = if (isSelected) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surface
+            },
         ),
         elevation = CardDefaults.cardElevation(
-            defaultElevation = 2.dp,
+            defaultElevation = if (isSelected) 6.dp else 2.dp,
         ),
     ) {
         Column(
@@ -49,7 +54,11 @@ fun SpotBottomCard(
                 Text(
                     text = spot.type.toDisplayName(),
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary,
+                    color = if (isSelected) {
+                        MaterialTheme.colorScheme.onPrimaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.primary
+                    },
                 )
 
                 spot.distanceMeter?.let { distanceMeter ->
@@ -107,6 +116,32 @@ private fun SpotBottomCardPreview() {
                     distanceMeter = 120,
                     isBookmarked = false,
                 ),
+                isSelected = false,
+                onClick = {},
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SpotBottomCardSelectedPreview() {
+    MaterialTheme {
+        Surface(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            SpotBottomCard(
+                spot = CollectionSpot(
+                    id = "1",
+                    name = "폐건전지 수거함",
+                    type = CollectionSpotType.BATTERY_BIN,
+                    address = "서울특별시 영등포구 문래동",
+                    detailLocation = "주민센터 앞",
+                    coordinate = null,
+                    distanceMeter = 120,
+                    isBookmarked = false,
+                ),
+                isSelected = true,
                 onClick = {},
             )
         }
@@ -131,6 +166,7 @@ private fun SpotBottomCardWithoutDetailPreview() {
                     distanceMeter = null,
                     isBookmarked = false,
                 ),
+                isSelected = false,
                 onClick = {},
             )
         }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomList.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomList.kt
@@ -1,0 +1,85 @@
+package com.team.yeogibeoryeo.presentation.map.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+
+@Composable
+fun SpotBottomList(
+    spots: List<CollectionSpot>,
+    onSpotClick: (CollectionSpot) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(
+            horizontal = 16.dp,
+            vertical = 12.dp,
+        ),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        items(
+            items = spots,
+            key = { spot -> spot.id },
+        ) { spot ->
+            SpotBottomCard(
+                spot = spot,
+                onClick = onSpotClick,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SpotBottomListPreview() {
+    MaterialTheme {
+        Surface {
+            SpotBottomList(
+                spots = listOf(
+                    CollectionSpot(
+                        id = "1",
+                        name = "폐건전지 수거함",
+                        type = CollectionSpotType.BATTERY_BIN,
+                        address = "서울특별시 영등포구 문래동",
+                        detailLocation = "주민센터 앞",
+                        coordinate = null,
+                        distanceMeter = 120,
+                        isBookmarked = false,
+                    ),
+                    CollectionSpot(
+                        id = "2",
+                        name = "중소형 폐가전 수거함",
+                        type = CollectionSpotType.SMALL_E_WASTE_BIN,
+                        address = "서울특별시 구로구 구로동",
+                        detailLocation = "아파트 관리사무소 옆",
+                        coordinate = null,
+                        distanceMeter = 350,
+                        isBookmarked = false,
+                    ),
+                    CollectionSpot(
+                        id = "3",
+                        name = "재활용센터",
+                        type = CollectionSpotType.RECYCLING_CENTER,
+                        address = "서울특별시 성동구 용답동",
+                        detailLocation = null,
+                        coordinate = null,
+                        distanceMeter = null,
+                        isBookmarked = false,
+                    ),
+                ),
+                onSpotClick = {},
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomList.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomList.kt
@@ -2,8 +2,7 @@ package com.team.yeogibeoryeo.presentation.map.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -17,16 +16,14 @@ import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 @Composable
 fun SpotBottomList(
     spots: List<CollectionSpot>,
+    selectedSpot: CollectionSpot?,
     onSpotClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(
-        modifier = modifier.fillMaxWidth(),
-        contentPadding = PaddingValues(
-            horizontal = 16.dp,
-            vertical = 12.dp,
-        ),
-        verticalArrangement = Arrangement.spacedBy(10.dp),
+    LazyRow(
+        modifier = modifier,
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         items(
             items = spots,
@@ -34,7 +31,10 @@ fun SpotBottomList(
         ) { spot ->
             SpotBottomCard(
                 spot = spot,
-                onClick = onSpotClick,
+                isSelected = spot.id == selectedSpot?.id,
+                onClick = {
+                    onSpotClick(spot)
+                },
             )
         }
     }
@@ -43,41 +43,44 @@ fun SpotBottomList(
 @Preview(showBackground = true)
 @Composable
 private fun SpotBottomListPreview() {
+    val previewSpots = listOf(
+        CollectionSpot(
+            id = "1",
+            name = "폐건전지 수거함",
+            type = CollectionSpotType.BATTERY_BIN,
+            address = "서울특별시 영등포구 문래동",
+            detailLocation = "주민센터 앞",
+            coordinate = null,
+            distanceMeter = 120,
+            isBookmarked = false,
+        ),
+        CollectionSpot(
+            id = "2",
+            name = "중소형 폐가전 수거함",
+            type = CollectionSpotType.SMALL_E_WASTE_BIN,
+            address = "서울특별시 구로구 구로동",
+            detailLocation = "아파트 관리사무소 옆",
+            coordinate = null,
+            distanceMeter = 350,
+            isBookmarked = false,
+        ),
+        CollectionSpot(
+            id = "3",
+            name = "재활용센터",
+            type = CollectionSpotType.RECYCLING_CENTER,
+            address = "서울특별시 성동구 용답동",
+            detailLocation = null,
+            coordinate = null,
+            distanceMeter = null,
+            isBookmarked = false,
+        ),
+    )
+
     MaterialTheme {
         Surface {
             SpotBottomList(
-                spots = listOf(
-                    CollectionSpot(
-                        id = "1",
-                        name = "폐건전지 수거함",
-                        type = CollectionSpotType.BATTERY_BIN,
-                        address = "서울특별시 영등포구 문래동",
-                        detailLocation = "주민센터 앞",
-                        coordinate = null,
-                        distanceMeter = 120,
-                        isBookmarked = false,
-                    ),
-                    CollectionSpot(
-                        id = "2",
-                        name = "중소형 폐가전 수거함",
-                        type = CollectionSpotType.SMALL_E_WASTE_BIN,
-                        address = "서울특별시 구로구 구로동",
-                        detailLocation = "아파트 관리사무소 옆",
-                        coordinate = null,
-                        distanceMeter = 350,
-                        isBookmarked = false,
-                    ),
-                    CollectionSpot(
-                        id = "3",
-                        name = "재활용센터",
-                        type = CollectionSpotType.RECYCLING_CENTER,
-                        address = "서울특별시 성동구 용답동",
-                        detailLocation = null,
-                        coordinate = null,
-                        distanceMeter = null,
-                        isBookmarked = false,
-                    ),
-                ),
+                spots = previewSpots,
+                selectedSpot = previewSpots[1],
                 onSpotClick = {},
             )
         }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomList.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomList.kt
@@ -2,11 +2,14 @@ package com.team.yeogibeoryeo.presentation.map.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -20,21 +23,35 @@ fun SpotBottomList(
     onSpotClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyRow(
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(selectedSpot?.id, spots) {
+        val selectedIndex = spots.indexOfFirst { spot ->
+            spot.id == selectedSpot?.id
+        }
+
+        if (selectedIndex >= 0) {
+            listState.animateScrollToItem(selectedIndex)
+        }
+    }
+
+    LazyColumn(
+        state = listState,
         modifier = modifier,
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        items(
+        itemsIndexed(
             items = spots,
-            key = { spot -> spot.id },
-        ) { spot ->
+            key = { _, spot -> spot.id },
+        ) { _, spot ->
             SpotBottomCard(
                 spot = spot,
                 isSelected = spot.id == selectedSpot?.id,
                 onClick = {
                     onSpotClick(spot)
                 },
+                modifier = Modifier.fillMaxWidth(),
             )
         }
     }
@@ -43,44 +60,51 @@ fun SpotBottomList(
 @Preview(showBackground = true)
 @Composable
 private fun SpotBottomListPreview() {
-    val previewSpots = listOf(
-        CollectionSpot(
-            id = "1",
-            name = "폐건전지 수거함",
-            type = CollectionSpotType.BATTERY_BIN,
-            address = "서울특별시 영등포구 문래동",
-            detailLocation = "주민센터 앞",
-            coordinate = null,
-            distanceMeter = 120,
-            isBookmarked = false,
-        ),
-        CollectionSpot(
-            id = "2",
-            name = "중소형 폐가전 수거함",
-            type = CollectionSpotType.SMALL_E_WASTE_BIN,
-            address = "서울특별시 구로구 구로동",
-            detailLocation = "아파트 관리사무소 옆",
-            coordinate = null,
-            distanceMeter = 350,
-            isBookmarked = false,
-        ),
-        CollectionSpot(
-            id = "3",
-            name = "재활용센터",
-            type = CollectionSpotType.RECYCLING_CENTER,
-            address = "서울특별시 성동구 용답동",
-            detailLocation = null,
-            coordinate = null,
-            distanceMeter = null,
-            isBookmarked = false,
-        ),
-    )
-
     MaterialTheme {
         Surface {
             SpotBottomList(
-                spots = previewSpots,
-                selectedSpot = previewSpots[1],
+                spots = listOf(
+                    CollectionSpot(
+                        id = "1",
+                        name = "폐건전지 수거함",
+                        type = CollectionSpotType.BATTERY_BIN,
+                        address = "서울특별시 영등포구 문래동",
+                        detailLocation = "주민센터 앞",
+                        coordinate = null,
+                        distanceMeter = 120,
+                        isBookmarked = false,
+                    ),
+                    CollectionSpot(
+                        id = "2",
+                        name = "중소형 폐가전 수거함",
+                        type = CollectionSpotType.SMALL_E_WASTE_BIN,
+                        address = "서울특별시 구로구 구로동",
+                        detailLocation = "아파트 관리사무소 옆",
+                        coordinate = null,
+                        distanceMeter = 350,
+                        isBookmarked = false,
+                    ),
+                    CollectionSpot(
+                        id = "3",
+                        name = "재활용센터",
+                        type = CollectionSpotType.RECYCLING_CENTER,
+                        address = "서울특별시 성동구 용답동",
+                        detailLocation = null,
+                        coordinate = null,
+                        distanceMeter = null,
+                        isBookmarked = false,
+                    ),
+                ),
+                selectedSpot = CollectionSpot(
+                    id = "2",
+                    name = "중소형 폐가전 수거함",
+                    type = CollectionSpotType.SMALL_E_WASTE_BIN,
+                    address = "서울특별시 구로구 구로동",
+                    detailLocation = "아파트 관리사무소 옆",
+                    coordinate = null,
+                    distanceMeter = 350,
+                    isBookmarked = false,
+                ),
                 onSpotClick = {},
             )
         }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotFilterChipRow.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotFilterChipRow.kt
@@ -1,0 +1,72 @@
+package com.team.yeogibeoryeo.presentation.map.components
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.presentation.map.mapper.toDisplayName
+
+@Composable
+fun SpotFilterChipRow(
+    selectedTypes: Set<CollectionSpotType>,
+    onTypeClick: (CollectionSpotType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        CollectionSpotType.entries.forEach { type ->
+            FilterChip(
+                selected = type in selectedTypes,
+                onClick = {
+                    onTypeClick(type)
+                },
+                label = {
+                    Text(text = type.toDisplayName())
+                },
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SpotFilterChipRowPreview() {
+    MaterialTheme {
+        Surface {
+            SpotFilterChipRow(
+                selectedTypes = emptySet(),
+                onTypeClick = {},
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SpotFilterChipRowSelectedPreview() {
+    MaterialTheme {
+        Surface {
+            SpotFilterChipRow(
+                selectedTypes = setOf(
+                    CollectionSpotType.BATTERY_BIN,
+                    CollectionSpotType.RECYCLING_CENTER,
+                ),
+                onTypeClick = {},
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/mapper/CollectionSpotTypeUiMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/mapper/CollectionSpotTypeUiMapper.kt
@@ -2,8 +2,8 @@ package com.team.yeogibeoryeo.presentation.map.mapper
 
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 
-fun CollectionSpotType.toDisplayName(): String {
-    return when (this) {
+fun CollectionSpotType.toDisplayName(): String =
+    when (this) {
         CollectionSpotType.SMALL_E_WASTE_BIN -> "중소형 수거함"
         CollectionSpotType.BATTERY_BIN -> "폐건전지"
         CollectionSpotType.PHONE_DROP_OFF -> "폐휴대폰"
@@ -11,4 +11,3 @@ fun CollectionSpotType.toDisplayName(): String {
         CollectionSpotType.STANDARD_BAG_STORE -> "종량제봉투"
         CollectionSpotType.OTHER -> "기타"
     }
-}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/mapper/CollectionSpotTypeUiMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/mapper/CollectionSpotTypeUiMapper.kt
@@ -1,0 +1,14 @@
+package com.team.yeogibeoryeo.presentation.map.mapper
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+
+fun CollectionSpotType.toDisplayName(): String {
+    return when (this) {
+        CollectionSpotType.SMALL_E_WASTE_BIN -> "중소형 수거함"
+        CollectionSpotType.BATTERY_BIN -> "폐건전지"
+        CollectionSpotType.PHONE_DROP_OFF -> "폐휴대폰"
+        CollectionSpotType.RECYCLING_CENTER -> "재활용센터"
+        CollectionSpotType.STANDARD_BAG_STORE -> "종량제봉투"
+        CollectionSpotType.OTHER -> "기타"
+    }
+}


### PR DESCRIPTION
## 작업 내용

- `/getSpot` 기반 수거 장소 데이터를 `presentation/map` 화면에 연결했습니다.
- 검색어 기반 수거 장소 조회 기능을 구현했습니다.
- 현재 위치 기반 수거 장소 조회 기능을 추가했습니다.
- 위치 권한 요청 및 권한 거부/현재 위치 확인 실패 안내 메시지를 처리했습니다.
- Naver Map Compose를 사용하여 수거 장소 마커를 지도에 표시했습니다.
- `CollectionSpot.coordinate != null`인 장소만 지도 마커로 표시하고, 리스트에는 전체 검색 결과를 표시하도록 구성했습니다.
- 검색 결과가 있을 경우 첫 번째 좌표 기준으로 지도 카메라가 이동하도록 처리했습니다.
- 하단 장소 카드 클릭 시 해당 장소를 선택하고 지도 카메라가 해당 위치로 이동하도록 처리했습니다.
- 지도 마커 클릭 시 `selectedSpot`을 갱신하고, 연결된 하단 카드가 자동으로 스크롤되어 보이도록 처리했습니다.
- 선택된 하단 카드와 선택된 지도 마커를 시각적으로 강조했습니다.
- 장소 유형 필터 선택 시 지도 마커와 하단 리스트가 함께 갱신되도록 처리했습니다.
- 검색 전에는 빈 결과 UI가 노출되지 않도록 `hasSearched` 상태를 추가했습니다.
- `CurrentLocationButton` 컴포넌트를 추가했습니다.
- 지도 화면에서 사용하는 Naver Map / 위치 권한 관련 의존성과 Manifest 권한 설정을 반영했습니다.
- 테스트용으로 변경했던 `MainActivity`는 기존 develop 기준 코드로 복구했습니다.

---

## 변경 이유

수거 장소 검색 결과를 단순 리스트가 아니라 지도 기반으로 확인할 수 있도록 `presentation/map` 계층을 구현했습니다.

사용자가 동네명 또는 주소로 검색하거나, 위치 권한을 허용한 경우 현재 위치 주변 수거 장소를 확인할 수 있도록 검색 흐름을 분리했습니다.

또한 지도 마커와 하단 장소 카드를 연결하여, 사용자가 지도와 리스트 사이에서 선택한 장소를 쉽게 확인할 수 있도록 했습니다.

---

## 검증 내용

- [x] 검색어 입력 후 수거 장소 목록이 조회되는지 확인
- [x] 검색 결과가 지도 마커로 표시되는지 확인
- [x] 검색 결과가 있을 때 첫 번째 장소 기준으로 지도 카메라가 이동하는지 확인
- [x] 하단 카드 클릭 시 해당 장소 위치로 지도 카메라가 이동하는지 확인
- [x] 지도 마커 클릭 시 연결된 하단 카드가 자동 스크롤되고 강조되는지 확인
- [x] 선택된 지도 마커가 다른 색상으로 강조되는지 확인
- [x] 장소 유형 필터 선택 시 지도 마커와 하단 리스트가 함께 변경되는지 확인
- [x] 위치 권한 거부 시 키워드 검색은 계속 사용할 수 있는지 확인
- [x] 위치 권한 허용 시 현재 위치 기반 검색이 동작하는지 확인
- [x] 빈 검색어 입력 시 불필요한 빈 결과 UI가 노출되지 않는지 확인
- [x] 실제 기기에서 위치 권한 흐름 및 지도 표시 확인

---

## 테스트

- 실제 기기에서 수동 테스트했습니다.
- 키워드 검색: `문래동`
- 위치 권한 허용 / 거부 케이스 모두 확인했습니다.
- 필터칩, 마커 선택, 카드 선택 흐름을 확인했습니다.

---

## 스크린샷

### 위치 권한 요청 / 권한 거부 안내

| 현재 위치 버튼 클릭 시 권한 요청 | 위치 권한 거부 시 안내 문구 |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/361c6ae3-dac2-49bc-bd60-f392d39634ae" width="260" /> | <img src="https://github.com/user-attachments/assets/452b51e6-39d9-421c-8cb7-4f4a010ffee4" width="260" /> |

### 검색 결과 / 필터링 / 마커-카드 선택 연동

| 검색 결과 마커 및 하단 리스트 표시 | 필터 선택 시 마커/리스트 축소 | 마커 선택 시 카드 자동 스크롤 및 강조 |
| --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/ea51cf52-ba75-433d-940d-4b0b7c9c6b87" width="220" /> | <img src="https://github.com/user-attachments/assets/a387669d-5d78-4b60-b768-90b55b1449d7" width="220" /> | <img src="https://github.com/user-attachments/assets/54d6a0bc-a771-4e3c-9980-4da2c07f2d06" width="220" /> |

---

## 참고 사항

- 지역 가이드 연결은 공통 Navigation 및 `/info` 화면 구조 확정 이후 별도 이슈에서 연결합니다.
- 이번 PR에서는 `selectedSpot` 상태까지만 관리하고, 실제 지역 가이드 화면 이동은 진행하지 않습니다.
- 지도 화면의 시각적 완성도 개선은 후속 이슈에서 진행할 예정입니다.
  - 검색바 / 필터칩 / 현재 위치 버튼 오버레이 배치
  - 하단 리스트 BottomSheet 적용
  - 장소 목록 전체 보기 구조 추가
  - 지도 마커 디자인 커스텀
  - 선택 장소 카드/마커 강조 방식 개선

---

## 관련 이슈

Closes #32