### PR TITLE
feat: 지역별 배출 가이드 presentation 계층 구현

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
@@ -1,0 +1,366 @@
+﻿package com.team.yeogibeoryeo.presentation.regionalguide
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideEmptyResult
+import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideSearchBar
+import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideSummaryCard
+import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalWasteScheduleCard
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalWasteScheduleUiModel
+
+@Composable
+fun RegionalGuideRoute(
+    modifier: Modifier = Modifier,
+    initialKeyword: String? = null,
+    initialAddress: String? = null,
+    viewModel: RegionalGuideViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val searchKeyword by viewModel.searchKeyword.collectAsStateWithLifecycle()
+
+    LaunchedEffect(initialKeyword, initialAddress) {
+        when {
+            !initialAddress.isNullOrBlank() -> viewModel.loadByAddress(initialAddress)
+            !initialKeyword.isNullOrBlank() -> {
+                viewModel.onSearchKeywordChanged(initialKeyword)
+                viewModel.searchByKeyword(initialKeyword)
+            }
+        }
+    }
+
+    RegionalGuideScreen(
+        modifier = modifier,
+        uiState = uiState,
+        searchKeyword = searchKeyword,
+        onSearchKeywordChange = viewModel::onSearchKeywordChanged,
+        onSearchClick = viewModel::searchCurrentKeyword,
+        onRetryClick = viewModel::searchCurrentKeyword
+    )
+}
+
+@Composable
+fun RegionalGuideScreen(
+    uiState: RegionalGuideUiState,
+    searchKeyword: String,
+    onSearchKeywordChange: (String) -> Unit,
+    onSearchClick: () -> Unit,
+    onRetryClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(20.dp)
+    ) {
+        Text(
+            text = "지역별 배출 가이드",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "지역명을 입력하면 생활쓰레기, 음식물쓰레기, 재활용품 배출 정보를 확인할 수 있어요.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        RegionalGuideSearchBar(
+            keyword = searchKeyword,
+            onKeywordChange = onSearchKeywordChange,
+            onSearchClick = onSearchClick
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        RegionalGuideContent(
+            uiState = uiState,
+            onRetryClick = onRetryClick,
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}
+
+@Composable
+private fun RegionalGuideContent(
+    uiState: RegionalGuideUiState,
+    onRetryClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    when (uiState) {
+        RegionalGuideUiState.Idle -> {
+            RegionalGuideIdleContent(modifier = modifier)
+        }
+
+        is RegionalGuideUiState.Loading -> {
+            RegionalGuideLoadingContent(
+                query = uiState.query,
+                modifier = modifier
+            )
+        }
+
+        is RegionalGuideUiState.Success -> {
+            RegionalGuideSuccessContent(
+                guide = uiState.guide,
+                modifier = modifier
+            )
+        }
+
+        is RegionalGuideUiState.Empty -> {
+            RegionalGuideEmptyResult(
+                message = uiState.message,
+                modifier = modifier
+            )
+        }
+
+        is RegionalGuideUiState.Error -> {
+            RegionalGuideErrorContent(
+                message = uiState.message,
+                onRetryClick = onRetryClick,
+                modifier = modifier
+            )
+        }
+    }
+}
+
+@Composable
+private fun RegionalGuideIdleContent(
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "지역을 검색해보세요",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+
+            Text(
+                text = "선택한 지역의 쓰레기 배출 요일, 시간, 방법을 안내해드릴게요.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun RegionalGuideLoadingContent(
+    query: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 40.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        CircularProgressIndicator()
+
+        Text(
+            text = "\"$query\" 배출 가이드를 불러오는 중입니다.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun RegionalGuideSuccessContent(
+    guide: RegionalGuideUiModel,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        item {
+            RegionalGuideSummaryCard(guide = guide)
+        }
+
+        item {
+            Text(
+                text = "배출 요일 및 시간",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+        }
+
+        items(
+            items = guide.schedules,
+            key = { schedule -> schedule.wasteTypeName }
+        ) { schedule ->
+            RegionalWasteScheduleCard(schedule = schedule)
+        }
+    }
+}
+
+@Composable
+private fun RegionalGuideErrorContent(
+    message: String,
+    onRetryClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = "오류가 발생했습니다",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onErrorContainer
+            )
+
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer
+            )
+
+            TextButton(
+                onClick = onRetryClick
+            ) {
+                Text(text = "다시 시도")
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RegionalGuideScreenSuccessPreview() {
+    MaterialTheme {
+        RegionalGuideScreen(
+            uiState = RegionalGuideUiState.Success(
+                query = "영등포구",
+                guide = RegionalGuideUiModel(
+                    regionName = "서울특별시 영등포구 문래동",
+                    managementZoneName = "영등포구",
+                    targetRegionName = "문래동",
+                    disposalPlaceType = "문전수거",
+                    disposalPlaceDescription = "집 앞 지정 장소에 배출",
+                    schedules = listOf(
+                        RegionalWasteScheduleUiModel(
+                            wasteTypeName = "일반쓰레기",
+                            disposalDays = "월, 수, 금",
+                            disposalTime = "18:00 ~ 24:00",
+                            disposalMethod = "종량제 봉투에 담아 배출"
+                        ),
+                        RegionalWasteScheduleUiModel(
+                            wasteTypeName = "음식물쓰레기",
+                            disposalDays = "화, 목, 일",
+                            disposalTime = "18:00 ~ 24:00",
+                            disposalMethod = "음식물 전용 용기에 담아 배출"
+                        ),
+                        RegionalWasteScheduleUiModel(
+                            wasteTypeName = "재활용품",
+                            disposalDays = "목",
+                            disposalTime = "18:00 ~ 24:00",
+                            disposalMethod = "품목별로 분리하여 배출"
+                        )
+                    ),
+                    uncollectedDays = "토요일",
+                    departmentInfo = "청소행정과 02-0000-0000"
+                )
+            ),
+            searchKeyword = "영등포구",
+            onSearchKeywordChange = {},
+            onSearchClick = {},
+            onRetryClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RegionalGuideScreenEmptyPreview() {
+    MaterialTheme {
+        RegionalGuideScreen(
+            uiState = RegionalGuideUiState.Empty(
+                query = "없는 지역",
+                message = "해당 지역의 배출 가이드 정보가 없습니다."
+            ),
+            searchKeyword = "없는 지역",
+            onSearchKeywordChange = {},
+            onSearchClick = {},
+            onRetryClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RegionalGuideScreenLoadingPreview() {
+    MaterialTheme {
+        RegionalGuideScreen(
+            uiState = RegionalGuideUiState.Loading(
+                query = "영등포구"
+            ),
+            searchKeyword = "영등포구",
+            onSearchKeywordChange = {},
+            onSearchClick = {},
+            onRetryClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RegionalGuideScreenErrorPreview() {
+    MaterialTheme {
+        RegionalGuideScreen(
+            uiState = RegionalGuideUiState.Error(
+                query = "영등포구",
+                message = "지역별 배출 가이드를 조회하는 중 오류가 발생했습니다."
+            ),
+            searchKeyword = "영등포구",
+            onSearchKeywordChange = {},
+            onSearchClick = {},
+            onRetryClick = {}
+        )
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
@@ -58,7 +58,7 @@ fun RegionalGuideRoute(
         searchKeyword = searchKeyword,
         onSearchKeywordChange = viewModel::onSearchKeywordChanged,
         onSearchClick = viewModel::searchCurrentKeyword,
-        onRetryClick = viewModel::searchCurrentKeyword
+        onRetryClick = viewModel::retryLastRequest
     )
 }
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideUiState.kt
@@ -1,0 +1,26 @@
+package com.team.yeogibeoryeo.presentation.regionalguide
+
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
+
+sealed interface RegionalGuideUiState {
+    data object Idle : RegionalGuideUiState
+
+    data class Loading(
+        val query: String
+    ) : RegionalGuideUiState
+
+    data class Success(
+        val query: String,
+        val guide: RegionalGuideUiModel
+    ) : RegionalGuideUiState
+
+    data class Empty(
+        val query: String,
+        val message: String = "조회된 지역별 배출 가이드가 없습니다."
+    ) : RegionalGuideUiState
+
+    data class Error(
+        val query: String,
+        val message: String
+    ) : RegionalGuideUiState
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
@@ -1,0 +1,149 @@
+package com.team.yeogibeoryeo.presentation.regionalguide
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.region.usecase.ExtractRegionFromAddressUseCase
+import com.team.yeogibeoryeo.domain.region.usecase.ResolveRegionFromKeywordUseCase
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
+import com.team.yeogibeoryeo.domain.regionalguide.usecase.GetRegionalDisposalGuideUseCase
+import com.team.yeogibeoryeo.presentation.regionalguide.mapper.toUiModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RegionalGuideViewModel @Inject constructor(
+    private val resolveRegionFromKeywordUseCase: ResolveRegionFromKeywordUseCase,
+    private val extractRegionFromAddressUseCase: ExtractRegionFromAddressUseCase,
+    private val getRegionalDisposalGuideUseCase: GetRegionalDisposalGuideUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<RegionalGuideUiState>(RegionalGuideUiState.Idle)
+    val uiState: StateFlow<RegionalGuideUiState> = _uiState.asStateFlow()
+
+    private val _searchKeyword = MutableStateFlow("")
+    val searchKeyword: StateFlow<String> = _searchKeyword.asStateFlow()
+
+    fun onSearchKeywordChanged(keyword: String) {
+        _searchKeyword.value = keyword
+    }
+
+    fun searchCurrentKeyword() {
+        searchByKeyword(_searchKeyword.value)
+    }
+
+    fun searchByKeyword(keyword: String) {
+        val trimmedKeyword = keyword.trim()
+
+        if (trimmedKeyword.isBlank()) {
+            _uiState.value = RegionalGuideUiState.Empty(
+                query = trimmedKeyword,
+                message = "검색할 지역명을 입력해주세요."
+            )
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.value = RegionalGuideUiState.Loading(query = trimmedKeyword)
+
+            try {
+                val region = resolveRegionFromKeywordUseCase(trimmedKeyword)
+
+                if (region == null) {
+                    _uiState.value = RegionalGuideUiState.Empty(
+                        query = trimmedKeyword,
+                        message = "입력한 지역명을 찾을 수 없습니다."
+                    )
+                    return@launch
+                }
+
+                loadRegionalGuide(
+                    query = trimmedKeyword,
+                    region = region
+                )
+            } catch (e: Exception) {
+                _uiState.value = RegionalGuideUiState.Error(
+                    query = trimmedKeyword,
+                    message = e.message ?: "지역별 배출 가이드를 조회하는 중 오류가 발생했습니다."
+                )
+            }
+        }
+    }
+
+    /**
+     * 지도 화면 또는 수거 장소 상세에서 전달받은 addrBase 기반으로
+     * 지역별 배출 가이드를 조회합니다.
+     *
+     * 실제 화면 이동 및 호출 시점은 Navigation 공통 작업에서 연결합니다.
+     */
+    fun loadByAddress(address: String) {
+        val trimmedAddress = address.trim()
+
+        if (trimmedAddress.isBlank()) {
+            _uiState.value = RegionalGuideUiState.Empty(
+                query = trimmedAddress,
+                message = "주소 정보가 없습니다."
+            )
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.value = RegionalGuideUiState.Loading(query = trimmedAddress)
+
+            try {
+                val region = extractRegionFromAddressUseCase(trimmedAddress)
+
+                if (region == null) {
+                    _uiState.value = RegionalGuideUiState.Empty(
+                        query = trimmedAddress,
+                        message = "주소에서 지역 정보를 찾을 수 없습니다."
+                    )
+                    return@launch
+                }
+
+                loadRegionalGuide(
+                    query = trimmedAddress,
+                    region = region
+                )
+            } catch (e: Exception) {
+                _uiState.value = RegionalGuideUiState.Error(
+                    query = trimmedAddress,
+                    message = e.message ?: "주소 기반 지역별 배출 가이드를 조회하는 중 오류가 발생했습니다."
+                )
+            }
+        }
+    }
+
+    fun resetState() {
+        _uiState.value = RegionalGuideUiState.Idle
+    }
+
+    private suspend fun loadRegionalGuide(
+        query: String,
+        region: Region
+    ) {
+        val guide = getRegionalDisposalGuideUseCase(region)
+
+        _uiState.value = guide.toUiState(query)
+    }
+
+    private fun RegionalDisposalGuide?.toUiState(
+        query: String
+    ): RegionalGuideUiState {
+        return if (this == null) {
+            RegionalGuideUiState.Empty(
+                query = query,
+                message = "해당 지역의 배출 가이드 정보가 없습니다."
+            )
+        } else {
+            RegionalGuideUiState.Success(
+                query = query,
+                guide = this.toUiModel()
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
@@ -9,6 +9,8 @@ import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
 import com.team.yeogibeoryeo.domain.regionalguide.usecase.GetRegionalDisposalGuideUseCase
 import com.team.yeogibeoryeo.presentation.regionalguide.mapper.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -28,6 +30,9 @@ class RegionalGuideViewModel @Inject constructor(
     private val _searchKeyword = MutableStateFlow("")
     val searchKeyword: StateFlow<String> = _searchKeyword.asStateFlow()
 
+    private var guideLookupJob: Job? = null
+    private var lastRequest: RegionalGuideRequest? = null
+
     fun onSearchKeywordChanged(keyword: String) {
         _searchKeyword.value = keyword
     }
@@ -36,8 +41,18 @@ class RegionalGuideViewModel @Inject constructor(
         searchByKeyword(_searchKeyword.value)
     }
 
+    fun retryLastRequest() {
+        when (val request = lastRequest) {
+            is RegionalGuideRequest.Keyword -> searchByKeyword(request.keyword)
+            is RegionalGuideRequest.Address -> loadByAddress(request.address)
+            null -> searchCurrentKeyword()
+        }
+    }
+
     fun searchByKeyword(keyword: String) {
         val trimmedKeyword = keyword.trim()
+
+        guideLookupJob?.cancel()
 
         if (trimmedKeyword.isBlank()) {
             _uiState.value = RegionalGuideUiState.Empty(
@@ -47,7 +62,9 @@ class RegionalGuideViewModel @Inject constructor(
             return
         }
 
-        viewModelScope.launch {
+        lastRequest = RegionalGuideRequest.Keyword(trimmedKeyword)
+
+        guideLookupJob = viewModelScope.launch {
             _uiState.value = RegionalGuideUiState.Loading(query = trimmedKeyword)
 
             try {
@@ -65,6 +82,8 @@ class RegionalGuideViewModel @Inject constructor(
                     query = trimmedKeyword,
                     region = region
                 )
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _uiState.value = RegionalGuideUiState.Error(
                     query = trimmedKeyword,
@@ -83,6 +102,8 @@ class RegionalGuideViewModel @Inject constructor(
     fun loadByAddress(address: String) {
         val trimmedAddress = address.trim()
 
+        guideLookupJob?.cancel()
+
         if (trimmedAddress.isBlank()) {
             _uiState.value = RegionalGuideUiState.Empty(
                 query = trimmedAddress,
@@ -91,7 +112,9 @@ class RegionalGuideViewModel @Inject constructor(
             return
         }
 
-        viewModelScope.launch {
+        lastRequest = RegionalGuideRequest.Address(trimmedAddress)
+
+        guideLookupJob = viewModelScope.launch {
             _uiState.value = RegionalGuideUiState.Loading(query = trimmedAddress)
 
             try {
@@ -109,6 +132,8 @@ class RegionalGuideViewModel @Inject constructor(
                     query = trimmedAddress,
                     region = region
                 )
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _uiState.value = RegionalGuideUiState.Error(
                     query = trimmedAddress,
@@ -119,6 +144,8 @@ class RegionalGuideViewModel @Inject constructor(
     }
 
     fun resetState() {
+        guideLookupJob?.cancel()
+        lastRequest = null
         _uiState.value = RegionalGuideUiState.Idle
     }
 
@@ -145,5 +172,15 @@ class RegionalGuideViewModel @Inject constructor(
                 guide = this.toUiModel()
             )
         }
+    }
+
+    private sealed interface RegionalGuideRequest {
+        data class Keyword(
+            val keyword: String
+        ) : RegionalGuideRequest
+
+        data class Address(
+            val address: String
+        ) : RegionalGuideRequest
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideEmptyResult.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideEmptyResult.kt
@@ -11,39 +11,29 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalWasteScheduleUiModel
 
 @Composable
-fun RegionalWasteScheduleCard(
-    schedule: RegionalWasteScheduleUiModel,
+fun RegionalGuideEmptyResult(
+    message: String,
     modifier: Modifier = Modifier
 ) {
     Card(
         modifier = modifier.fillMaxWidth()
     ) {
         Column(
-            modifier = Modifier.padding(20.dp),
+            modifier = Modifier.padding(24.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Text(
-                text = schedule.wasteTypeName,
+                text = "조회 결과가 없습니다",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold
             )
 
-            RegionalGuideInfoRow(
-                title = "요일",
-                value = schedule.disposalDays
-            )
-
-            RegionalGuideInfoRow(
-                title = "시간",
-                value = schedule.disposalTime
-            )
-
-            RegionalGuideInfoRow(
-                title = "방법",
-                value = schedule.disposalMethod
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideInfoRow.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideInfoRow.kt
@@ -1,0 +1,35 @@
+package com.team.yeogibeoryeo.presentation.regionalguide.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun RegionalGuideInfoRow(
+    title: String,
+    value: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.SemiBold
+        )
+
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
@@ -1,0 +1,57 @@
+package com.team.yeogibeoryeo.presentation.regionalguide.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun RegionalGuideSearchBar(
+    keyword: String,
+    onKeywordChange: (String) -> Unit,
+    onSearchClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        OutlinedTextField(
+            modifier = Modifier.weight(1f),
+            value = keyword,
+            onValueChange = onKeywordChange,
+            singleLine = true,
+            label = {
+                Text(text = "지역명")
+            },
+            placeholder = {
+                Text(text = "예: 영등포구, 세종 새롬동")
+            },
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Search
+            ),
+            keyboardActions = KeyboardActions(
+                onSearch = {
+                    onSearchClick()
+                }
+            )
+        )
+
+        Button(
+            onClick = onSearchClick,
+            enabled = keyword.isNotBlank()
+        ) {
+            Text(text = "검색")
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSummaryCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSummaryCard.kt
@@ -1,0 +1,77 @@
+package com.team.yeogibeoryeo.presentation.regionalguide.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
+
+@Composable
+fun RegionalGuideSummaryCard(
+    guide: RegionalGuideUiModel,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Text(
+                text = guide.regionName,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+
+            guide.managementZoneName?.let { managementZoneName ->
+                RegionalGuideInfoRow(
+                    title = "관리구역",
+                    value = managementZoneName
+                )
+            }
+
+            guide.targetRegionName?.let { targetRegionName ->
+                RegionalGuideInfoRow(
+                    title = "대상지역",
+                    value = targetRegionName
+                )
+            }
+
+            guide.disposalPlaceType?.let { placeType ->
+                RegionalGuideInfoRow(
+                    title = "배출장소",
+                    value = placeType
+                )
+            }
+
+            guide.disposalPlaceDescription?.let { placeDescription ->
+                RegionalGuideInfoRow(
+                    title = "장소설명",
+                    value = placeDescription
+                )
+            }
+
+            guide.uncollectedDays?.let { uncollectedDays ->
+                RegionalGuideInfoRow(
+                    title = "미수거일",
+                    value = uncollectedDays
+                )
+            }
+
+            guide.departmentInfo?.let { departmentInfo ->
+                RegionalGuideInfoRow(
+                    title = "문의",
+                    value = departmentInfo
+                )
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/mapper/RegionalGuideUiMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/mapper/RegionalGuideUiMapper.kt
@@ -1,0 +1,77 @@
+package com.team.yeogibeoryeo.presentation.regionalguide.mapper
+
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteSchedule
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteType
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalWasteScheduleUiModel
+
+fun RegionalDisposalGuide.toUiModel(): RegionalGuideUiModel {
+    return RegionalGuideUiModel(
+        regionName = displayRegionName(),
+        managementZoneName = managementZoneName.takeIfNotBlank(),
+        targetRegionName = targetRegionName.takeIfNotBlank(),
+        disposalPlaceType = disposalPlaceType.takeIfNotBlank(),
+        disposalPlaceDescription = disposalPlaceDescription.takeIfNotBlank(),
+        schedules = schedules
+            .sortedBy { schedule ->
+                when (schedule.wasteType) {
+                    RegionalWasteType.GENERAL -> 0
+                    RegionalWasteType.FOOD -> 1
+                    RegionalWasteType.RECYCLABLE -> 2
+                    RegionalWasteType.LARGE_ITEM -> 3
+                    RegionalWasteType.UNKNOWN -> 4
+                }
+            }
+            .map { it.toUiModel() },
+        uncollectedDays = uncollectedDays.takeIfNotBlank(),
+        departmentInfo = listOfNotNull(
+            departmentName.takeIfNotBlank(),
+            departmentPhoneNumber.takeIfNotBlank()
+        ).joinToString(" ").takeIf { it.isNotBlank() }
+    )
+}
+
+private fun RegionalWasteSchedule.toUiModel(): RegionalWasteScheduleUiModel {
+    return RegionalWasteScheduleUiModel(
+        wasteTypeName = wasteType.description,
+        disposalDays = disposalDays.orInfoEmpty(),
+        disposalTime = displayTime(),
+        disposalMethod = disposalMethod.orInfoEmpty()
+    )
+}
+
+private fun RegionalDisposalGuide.displayRegionName(): String {
+    val regionName = listOfNotNull(
+        region.sido,
+        region.sigungu,
+        region.eupmyeondong
+    ).filter { it.isNotBlank() }
+        .joinToString(" ")
+
+    return regionName.ifBlank {
+        targetRegionName
+            ?: managementZoneName
+            ?: "지역 정보"
+    }
+}
+
+private fun RegionalWasteSchedule.displayTime(): String {
+    val startTime = disposalStartTime
+    val endTime = disposalEndTime
+
+    return when {
+        !startTime.isNullOrBlank() && !endTime.isNullOrBlank() -> "$startTime ~ $endTime"
+        !startTime.isNullOrBlank() -> "$startTime 이후"
+        !endTime.isNullOrBlank() -> "$endTime 이전"
+        else -> "시간 정보 없음"
+    }
+}
+
+private fun String?.orInfoEmpty(): String {
+    return if (isNullOrBlank()) "정보 없음" else this
+}
+
+private fun String?.takeIfNotBlank(): String? {
+    return this?.takeIf { it.isNotBlank() }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/mapper/RegionalGuideUiMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/mapper/RegionalGuideUiMapper.kt
@@ -68,10 +68,8 @@ private fun RegionalWasteSchedule.displayTime(): String {
     }
 }
 
-private fun String?.orInfoEmpty(): String {
-    return if (isNullOrBlank()) "정보 없음" else this
-}
+private fun String?.orInfoEmpty(): String =
+    if (isNullOrBlank()) "정보 없음" else this
 
-private fun String?.takeIfNotBlank(): String? {
-    return this?.takeIf { it.isNotBlank() }
-}
+private fun String?.takeIfNotBlank(): String? =
+    this?.takeIf { it.isNotBlank() }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideUiModel.kt
@@ -1,0 +1,12 @@
+package com.team.yeogibeoryeo.presentation.regionalguide.model
+
+data class RegionalGuideUiModel(
+    val regionName: String,
+    val managementZoneName: String?,
+    val targetRegionName: String?,
+    val disposalPlaceType: String?,
+    val disposalPlaceDescription: String?,
+    val schedules: List<RegionalWasteScheduleUiModel>,
+    val uncollectedDays: String?,
+    val departmentInfo: String?
+)

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalWasteScheduleUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalWasteScheduleUiModel.kt
@@ -1,0 +1,8 @@
+package com.team.yeogibeoryeo.presentation.regionalguide.model
+
+data class RegionalWasteScheduleUiModel(
+    val wasteTypeName: String,
+    val disposalDays: String,
+    val disposalTime: String,
+    val disposalMethod: String
+)


### PR DESCRIPTION
## 작업 내용
- `RegionalGuideScreen`, `RegionalGuideViewModel`, `RegionalGuideUiState` 구현
- domain 모델을 화면 표시용 UI 모델로 변환하는 `RegionalGuideUiMapper` 추가
- 지역 검색, 요약 카드, 배출 스케줄 카드, 빈 결과 컴포넌트 구현
- 초기 안내, 로딩, 성공, 빈 결과, 에러 UI 상태 처리
- 지역명 검색 및 주소 기반 `/info` 조회 진입점 구성
- Success / Empty / Loading / Error 상태 Preview 추가

## 테스트
- [x] 에뮬레이터에서 지역명 기반 조회 동작 확인
- [x] `영등포구` 검색 시 `/info` 응답이 화면에 표시되는 것 확인
- [x] Success / Empty / Loading / Error 상태 화면 확인
- [x] GitHub Actions CI 통과 확인

## 스크린샷

| 성공 | 빈 결과 |
|---|---|
|<img width="100%" alt="Screenshot_20260525_212104" src="https://github.com/user-attachments/assets/1d2c4bed-b7a5-4fe1-a07a-a4880f74c813" />|<img width="100%" alt="Screenshot_20260525_232229" src="https://github.com/user-attachments/assets/c2c2d1aa-5c61-4f37-804a-379c1beb427d" />|

| 로딩 | 에러 |
|---|---|
|<img width="100%" alt="Screenshot_20260525_233103" src="https://github.com/user-attachments/assets/e778d685-1247-4d07-b7f1-f5de001cbd98" />|<img width="100%" alt="Screenshot_20260525_232759" src="https://github.com/user-attachments/assets/63372d60-4beb-459c-bc38-2f4aed2e3bd8" />|

## 후속 작업

- 지도 화면에서 선택된 `CollectionSpot.address`를 지역 가이드 화면으로 전달하는 Navigation 연결
- 동 단독 검색 시 `/getSpot` 응답의 `addrBase` 또는 주소 검색 API를 활용한 시군구 보완
- `/info` 응답 후보 선택 로직을 domain usecase로 이동하는 구조 개선
- API 실패와 실제 조회 결과 없음 상태 구분
- 디자인 시스템 기반 UI 고도화

## 관련 이슈
- Closes #34 