### PR TITLE
[Setting] common 모듈 Android CI 트리거 보강

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - '.github/workflows/android-ci.yml'
       - 'app/**'
+      - 'common/**'
       - 'data/**'
       - 'domain/**'
       - 'presentation/**'
@@ -23,6 +24,7 @@ on:
     paths:
       - '.github/workflows/android-ci.yml'
       - 'app/**'
+      - 'common/**'
       - 'data/**'
       - 'domain/**'
       - 'presentation/**'
@@ -67,4 +69,4 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Run unit tests and build debug APK
-        run: ./gradlew :data:testDebugUnitTest :presentation:testDebugUnitTest :domain:test :app:assembleDebug --no-daemon --stacktrace
+        run: ./gradlew :common:testDebugUnitTest :data:testDebugUnitTest :presentation:testDebugUnitTest :domain:test :app:assembleDebug --no-daemon --stacktrace


### PR DESCRIPTION
## 작업 내용

- Android CI의 `pull_request.paths`에 `common/**`을 추가했습니다.
- Android CI의 `push.paths`에 `common/**`을 추가했습니다.
- CI Gradle 명령에 `:common:testDebugUnitTest`를 추가해 common 모듈 테스트 task도 명시적으로 검증하도록 했습니다.
- 기존 data / presentation / domain 테스트와 app debug 빌드 검증은 유지했습니다.

## 진행 체크리스트

- [x] `common/**` 변경 시 Android CI 트리거
- [x] common 모듈 unit test task 명시
- [x] 기존 Android CI 검증 범위 유지
- [x] 변경된 CI 명령 로컬 검증

## 테스트

- [x] `./gradlew.bat :common:testDebugUnitTest :data:testDebugUnitTest :presentation:testDebugUnitTest :domain:test :app:assembleDebug --no-daemon --stacktrace`

## 참고 사항

- 현재 `common` 모듈에는 테스트 소스가 없어 `:common:testDebugUnitTest`는 `NO-SOURCE`로 통과합니다.
- `:app:assembleDebug`가 common 컴파일을 간접 검증하지만, common-only 변경 PR에서도 CI가 실행되도록 paths 필터를 보강했습니다.

## 관련 이슈

Closes #64