### PR TITLE
[Refactor] common navigation 의존성 정리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ import java.util.Properties
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.google.ksp)
     alias(libs.plugins.hilt.android)
 }
@@ -90,6 +91,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
+    implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.bundles.coroutines)
     implementation(libs.bundles.naver.map)

--- a/app/src/main/java/com/team/yeogibeoryeo/MainActivity.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/MainActivity.kt
@@ -5,7 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.team.yeogibeoryeo.common.design.theme.YeogiBeoryeoTheme
-import com.team.yeogibeoryeo.common.navigation.YeogiBeoryeoNavHost
+import com.team.yeogibeoryeo.navigation.YeogiBeoryeoNavHost
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
@@ -1,4 +1,4 @@
-package com.team.yeogibeoryeo.common.navigation
+package com.team.yeogibeoryeo.navigation
 
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/FavoritesScreen.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/FavoritesScreen.kt
@@ -1,4 +1,4 @@
-package com.team.yeogibeoryeo.common.navigation
+package com.team.yeogibeoryeo.navigation
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/HomeScreen.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/HomeScreen.kt
@@ -1,4 +1,4 @@
-package com.team.yeogibeoryeo.common.navigation
+package com.team.yeogibeoryeo.navigation
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -1,4 +1,4 @@
-package com.team.yeogibeoryeo.common.navigation
+package com.team.yeogibeoryeo.navigation
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -6,21 +6,20 @@ import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material.icons.outlined.Today
-import androidx.compose.material3.Icon
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavDestination
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
+import com.team.yeogibeoryeo.common.navigation.AppBottomNavigationBar
+import com.team.yeogibeoryeo.common.navigation.BottomNavigationItem
+import com.team.yeogibeoryeo.common.navigation.hasRouteName
+import com.team.yeogibeoryeo.common.navigation.navigateBottomTab
 import com.team.yeogibeoryeo.presentation.map.CollectionSpotMapScreen
 import com.team.yeogibeoryeo.presentation.regionalguide.RegionalGuideRoute as RegionalGuideScreenRoute
 import com.team.yeogibeoryeo.presentation.search.ItemGuideDetailRoute as ItemGuideDetailScreenRoute
@@ -38,13 +37,33 @@ fun YeogiBeoryeoNavHost(
         modifier = modifier,
         bottomBar = {
             AppBottomNavigationBar(
-                currentDestination = currentDestination,
-                onHomeClick = { navController.navigateBottomTab(HomeRoute) },
-                onMapClick = { navController.navigateBottomTab(MapRoute) },
-                onRegionalGuideClick = {
-                    navController.navigateBottomTab(RegionalGuideRoute())
-                },
-                onFavoritesClick = { navController.navigateBottomTab(FavoritesRoute) },
+                items =
+                    listOf(
+                        BottomNavigationItem(
+                            label = "Home",
+                            icon = Icons.Outlined.Home,
+                            selected = currentDestination.isHomeSelected(),
+                            onClick = { navController.navigateBottomTab(HomeRoute) },
+                        ),
+                        BottomNavigationItem(
+                            label = "Map",
+                            icon = Icons.Outlined.LocationOn,
+                            selected = currentDestination.hasRouteName<MapRoute>(),
+                            onClick = { navController.navigateBottomTab(MapRoute) },
+                        ),
+                        BottomNavigationItem(
+                            label = "Guide",
+                            icon = Icons.Outlined.Today,
+                            selected = currentDestination.hasRouteName<RegionalGuideRoute>(),
+                            onClick = { navController.navigateBottomTab(RegionalGuideRoute()) },
+                        ),
+                        BottomNavigationItem(
+                            label = "Favorites",
+                            icon = Icons.Outlined.FavoriteBorder,
+                            selected = currentDestination.hasRouteName<FavoritesRoute>(),
+                            onClick = { navController.navigateBottomTab(FavoritesRoute) },
+                        ),
+                    ),
             )
         },
     ) { innerPadding ->
@@ -103,56 +122,7 @@ fun YeogiBeoryeoNavHost(
     }
 }
 
-@Composable
-private fun AppBottomNavigationBar(
-    currentDestination: NavDestination?,
-    onHomeClick: () -> Unit,
-    onMapClick: () -> Unit,
-    onRegionalGuideClick: () -> Unit,
-    onFavoritesClick: () -> Unit,
-) {
-    NavigationBar {
-        NavigationBarItem(
-            selected = currentDestination.isHomeSelected(),
-            onClick = onHomeClick,
-            icon = { Icon(Icons.Outlined.Home, contentDescription = null) },
-            label = { Text("Home") },
-        )
-        NavigationBarItem(
-            selected = currentDestination.hasRouteName<MapRoute>(),
-            onClick = onMapClick,
-            icon = { Icon(Icons.Outlined.LocationOn, contentDescription = null) },
-            label = { Text("Map") },
-        )
-        NavigationBarItem(
-            selected = currentDestination.hasRouteName<RegionalGuideRoute>(),
-            onClick = onRegionalGuideClick,
-            icon = { Icon(Icons.Outlined.Today, contentDescription = null) },
-            label = { Text("Guide") },
-        )
-        NavigationBarItem(
-            selected = currentDestination.hasRouteName<FavoritesRoute>(),
-            onClick = onFavoritesClick,
-            icon = { Icon(Icons.Outlined.FavoriteBorder, contentDescription = null) },
-            label = { Text("Favorites") },
-        )
-    }
-}
-
 private fun NavDestination?.isHomeSelected(): Boolean =
     hasRouteName<HomeRoute>() ||
         hasRouteName<ItemSearchRoute>() ||
         hasRouteName<ItemGuideDetailRoute>()
-
-private inline fun <reified T : Any> NavDestination?.hasRouteName(): Boolean =
-    this?.route?.substringBefore("?") == requireNotNull(T::class.qualifiedName)
-
-private inline fun <reified T : Any> NavHostController.navigateBottomTab(route: T) {
-    navigate(route) {
-        popUpTo(graph.findStartDestination().id) {
-            saveState = true
-        }
-        launchSingleTop = true
-        restoreState = true
-    }
-}

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -33,10 +32,6 @@ kotlin {
 }
 
 dependencies {
-    implementation(project(":domain"))
-    implementation(project(":presentation"))
-
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.compose)
-    implementation(libs.kotlinx.serialization.json)
 }

--- a/common/src/main/java/com/team/yeogibeoryeo/common/navigation/AppBottomNavigationBar.kt
+++ b/common/src/main/java/com/team/yeogibeoryeo/common/navigation/AppBottomNavigationBar.kt
@@ -1,0 +1,31 @@
+package com.team.yeogibeoryeo.common.navigation
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+
+data class BottomNavigationItem(
+    val label: String,
+    val icon: ImageVector,
+    val selected: Boolean,
+    val onClick: () -> Unit,
+)
+
+@Composable
+fun AppBottomNavigationBar(
+    items: List<BottomNavigationItem>,
+) {
+    NavigationBar {
+        items.forEach { item ->
+            NavigationBarItem(
+                selected = item.selected,
+                onClick = item.onClick,
+                icon = { Icon(item.icon, contentDescription = null) },
+                label = { Text(item.label) },
+            )
+        }
+    }
+}

--- a/common/src/main/java/com/team/yeogibeoryeo/common/navigation/NavControllerExtensions.kt
+++ b/common/src/main/java/com/team/yeogibeoryeo/common/navigation/NavControllerExtensions.kt
@@ -1,0 +1,18 @@
+package com.team.yeogibeoryeo.common.navigation
+
+import androidx.navigation.NavDestination
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
+
+inline fun <reified T : Any> NavDestination?.hasRouteName(): Boolean =
+    this?.route?.substringBefore("?") == requireNotNull(T::class.qualifiedName)
+
+inline fun <reified T : Any> NavHostController.navigateBottomTab(route: T) {
+    navigate(route) {
+        popUpTo(graph.findStartDestination().id) {
+            saveState = true
+        }
+        launchSingleTop = true
+        restoreState = true
+    }
+}

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
 }
 
 dependencies {
+    implementation(project(":common"))
     implementation(project(":domain"))
 
     // Compose


### PR DESCRIPTION
## 작업 내용

- #52 공통 Navigation 구조 구현 이후 `common -> presentation` 의존성이 생긴 문제를 정리했습니다.
- `YeogiBeoryeoNavHost`, `AppRoute`, `HomeScreen`, `FavoritesScreen`처럼 feature 화면을 실제로 조립하는 app shell 코드는 `app` 모듈로 이동했습니다.
- `AppBottomNavigationBar`, `BottomNavigationItem`, `NavControllerExtensions`처럼 feature 화면을 직접 import하지 않는 공통 Navigation helper는 `common` 모듈에 유지했습니다.
- `common` 모듈에서 `presentation`, `domain`, serialization 의존성을 제거해 feature-independent 공통 UI/helper와 theme 역할만 남겼습니다.
- `presentation` 모듈이 `common` 모듈을 의존하도록 변경해 후속 `AppAccentColors` 제거와 theme 기반 리팩토링이 가능하도록 준비했습니다.
- `MainActivity`의 NavHost import 경로를 app 모듈 기준으로 수정했습니다.

## 배경

어제 navigation에서 공통된 요소들을 옮기는 과정에서 navigation과 관련된 모든 파일이 common 모듈에 이동되어 버렸는데 제대로 검토하지 못했다는 문제가 있습니다...!!!!!!😱😱😱

PR #56에서는 앱 전체 NavHost 조립 코드까지 `common`에 배치되면서 `common -> presentation` 의존성이 생겼습니다. 이 상태에서는 presentation에서 common의 theme/design system을 직접 사용하려고 할 때 아래 순환 참조 위험이 있습니다.

```text
common -> presentation
presentation -> common
```

이번 PR은 #52의 의미를 아래처럼 다시 맞추는 구조 리팩토링입니다.

```mermaid
flowchart TD
    app["app module"] --> common["common module"]
    app --> presentation["presentation module"]
    app --> data["data module"]
    app --> domain["domain module"]

    presentation --> common
    presentation --> domain
    data --> domain
```

## 현재 배치 기준

```mermaid
flowchart LR
    subgraph common["common/src/main/java/com/team/yeogibeoryeo/common"]
        theme["theme/*"]
        bottomBar["navigation/AppBottomNavigationBar.kt"]
        navHelper["navigation/NavControllerExtensions.kt"]
    end

    subgraph app["app/src/main/java/com/team/yeogibeoryeo"]
        navHost["navigation/YeogiBeoryeoNavHost.kt"]
        appRoute["navigation/AppRoute.kt"]
        home["navigation/HomeScreen.kt"]
        favorites["navigation/FavoritesScreen.kt"]
        main["MainActivity.kt"]
    end

    navHost --> bottomBar
    navHost --> navHelper
    navHost --> appRoute
    navHost --> home
    navHost --> favorites
    main --> navHost
```

## 진행 체크리스트

- [x] app shell/navigation 조립 코드를 app 모듈로 이동
- [x] feature-independent Navigation helper를 common 모듈에 유지
- [x] common 모듈의 presentation/domain 의존성 제거
- [x] presentation 모듈의 common 의존성 추가
- [x] 기존 NavHost 화면 이동 흐름 유지
- [x] 관련 빌드/테스트 검증

## 다른 PR 영향

- #63은 data 계층 `/getItem` 제거 작업이라 직접 충돌 가능성은 낮습니다.
- #65는 GitHub Actions workflow 작업이라 직접 충돌 가능성은 낮습니다.
- 후속 `AppAccentColors` 제거 작업은 이 PR 이후 진행하는 것이 안전합니다.

## 테스트

- [x] `./gradlew.bat :common:testDebugUnitTest :data:testDebugUnitTest :presentation:testDebugUnitTest :domain:test :app:assembleDebug --no-daemon --stacktrace`

## 관련 이슈

Related #52