### PR TITLE
refactor: 현재 위치 조회 구조 및 권한 처리 개선

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -1,12 +1,5 @@
 package com.team.yeogibeoryeo.presentation.map
 
-import android.Manifest
-import android.annotation.SuppressLint
-import android.content.Context
-import android.content.pm.PackageManager
-import android.location.LocationManager
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,68 +13,38 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
-import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.presentation.map.components.CollectionSpotNaverMap
 import com.team.yeogibeoryeo.presentation.map.components.CurrentLocationButton
 import com.team.yeogibeoryeo.presentation.map.components.EmptySpotResult
 import com.team.yeogibeoryeo.presentation.map.components.MapSearchBar
 import com.team.yeogibeoryeo.presentation.map.components.SpotBottomList
 import com.team.yeogibeoryeo.presentation.map.components.SpotFilterChipRow
+import com.team.yeogibeoryeo.presentation.map.location.rememberCurrentLocationSearchRequester
 
 @Composable
 fun CollectionSpotMapScreen(
     modifier: Modifier = Modifier,
     viewModel: CollectionSpotMapViewModel = hiltViewModel(),
 ) {
-    val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    val locationPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestPermission(),
-    ) { isGranted ->
-        if (isGranted) {
-            val coordinate = getLastKnownCoordinate(context)
-
-            if (coordinate != null) {
-                viewModel.searchByCurrentLocation(
-                    latitude = coordinate.latitude,
-                    longitude = coordinate.longitude,
-                )
-            } else {
-                viewModel.onCurrentLocationNotFound()
-            }
-        } else {
-            viewModel.onLocationPermissionDenied()
-        }
-    }
+    val requestCurrentLocationSearch = rememberCurrentLocationSearchRequester(
+        onGranted = viewModel::searchByCurrentLocation,
+        onDenied = viewModel::onLocationPermissionDenied,
+    )
 
     CollectionSpotMapContent(
         uiState = uiState,
         onKeywordChanged = viewModel::onSearchKeywordChanged,
         onSearchClick = viewModel::searchByKeyword,
         onCurrentLocationClick = {
-            if (hasFineLocationPermission(context)) {
-                val coordinate = getLastKnownCoordinate(context)
-
-                if (coordinate != null) {
-                    viewModel.searchByCurrentLocation(
-                        latitude = coordinate.latitude,
-                        longitude = coordinate.longitude,
-                    )
-                } else {
-                    viewModel.onCurrentLocationNotFound()
-                }
-            } else {
-                locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
-            }
+            requestCurrentLocationSearch()
         },
         onTypeClick = viewModel::onSpotTypeClick,
         onSpotClick = viewModel::onSpotClick,
@@ -171,43 +134,6 @@ private fun CollectionSpotMapContent(
                 )
             }
         }
-    }
-}
-
-private fun hasFineLocationPermission(
-    context: Context,
-): Boolean {
-    return ContextCompat.checkSelfPermission(
-        context,
-        Manifest.permission.ACCESS_FINE_LOCATION,
-    ) == PackageManager.PERMISSION_GRANTED
-}
-
-@SuppressLint("MissingPermission")
-private fun getLastKnownCoordinate(
-    context: Context,
-): Coordinate? {
-    val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
-
-    return try {
-        val providers = locationManager.getProviders(true)
-
-        providers
-            .asSequence()
-            .mapNotNull { provider ->
-                locationManager.getLastKnownLocation(provider)
-            }
-            .maxByOrNull { location ->
-                location.time
-            }
-            ?.let { location ->
-                Coordinate(
-                    latitude = location.latitude,
-                    longitude = location.longitude,
-                )
-            }
-    } catch (exception: SecurityException) {
-        null
     }
 }
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -8,6 +8,8 @@ import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByKeywordUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByLocationUseCase
+import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationProvider
+import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,6 +23,7 @@ class CollectionSpotMapViewModel @Inject constructor(
     private val searchCollectionSpotsByKeywordUseCase: SearchCollectionSpotsByKeywordUseCase,
     private val searchCollectionSpotsByLocationUseCase: SearchCollectionSpotsByLocationUseCase,
     private val filterCollectionSpotsUseCase: FilterCollectionSpotsUseCase,
+    private val currentLocationProvider: CurrentLocationProvider,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CollectionSpotMapUiState())
@@ -85,10 +88,7 @@ class CollectionSpotMapViewModel @Inject constructor(
         }
     }
 
-    fun searchByCurrentLocation(
-        latitude: Double,
-        longitude: Double,
-    ) {
+    fun searchByCurrentLocation() {
         viewModelScope.launch {
             _uiState.update {
                 it.copy(
@@ -101,22 +101,38 @@ class CollectionSpotMapViewModel @Inject constructor(
                 )
             }
 
-            runCatching {
-                searchCollectionSpotsByLocationUseCase(
-                    coordinate = Coordinate(
-                        latitude = latitude,
-                        longitude = longitude,
-                    ),
-                    radiusMeter = DEFAULT_RADIUS_METER,
-                    types = emptySet(),
-                )
-            }.onSuccess { spots ->
-                updateSpotResult(spots)
-            }.onFailure { throwable ->
-                updateSpotFailure(
-                    message = throwable.message ?: "현재 위치 주변 수거 장소를 불러오지 못했습니다.",
-                )
+
+            when (val result = currentLocationProvider.getCurrentLocation()) {
+                is CurrentLocationResult.Found -> {
+                    searchByLocation(result.coordinate)
+                }
+
+                CurrentLocationResult.NotFound -> {
+                    onCurrentLocationNotFound()
+                }
+
+                CurrentLocationResult.PermissionDenied -> {
+                    onLocationPermissionDenied()
+                }
             }
+        }
+    }
+
+    private suspend fun searchByLocation(
+        coordinate: Coordinate,
+    ) {
+        runCatching {
+            searchCollectionSpotsByLocationUseCase(
+                coordinate = coordinate,
+                radiusMeter = DEFAULT_RADIUS_METER,
+                types = emptySet(),
+            )
+        }.onSuccess { spots ->
+            updateSpotResult(spots)
+        }.onFailure { throwable ->
+            updateSpotFailure(
+                message = throwable.message ?: "현재 위치 주변 수거 장소를 불러오지 못했습니다.",
+            )
         }
     }
 
@@ -155,7 +171,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isLoading = false,
                 hasSearched = false,
                 errorMessage = null,
-                locationNoticeMessage = "현재 위치 검색은 위치 권한을 허용하면 사용할 수 있어요. 직접 동네나 주소를 검색할 수도 있습니다.",
+                locationNoticeMessage = "현재 위치 검색은 정확한 위치 권한을 허용하면 사용할 수 있어요. 직접 동네나 주소를 검색할 수도 있습니다.",
                 searchMode = MapSearchMode.KEYWORD,
             )
         }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -12,6 +12,8 @@ import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationProvider
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -30,6 +32,7 @@ class CollectionSpotMapViewModel @Inject constructor(
     val uiState: StateFlow<CollectionSpotMapUiState> = _uiState.asStateFlow()
 
     private var originalSpots: List<CollectionSpot> = emptyList()
+    private var spotSearchJob: Job? = null
 
     fun onSearchKeywordChanged(keyword: String) {
         _uiState.update {
@@ -45,6 +48,7 @@ class CollectionSpotMapViewModel @Inject constructor(
         val keyword = uiState.value.searchKeyword.trim()
 
         if (keyword.isBlank()) {
+            spotSearchJob?.cancel()
             originalSpots = emptyList()
 
             _uiState.update {
@@ -61,7 +65,8 @@ class CollectionSpotMapViewModel @Inject constructor(
             return
         }
 
-        viewModelScope.launch {
+        spotSearchJob?.cancel()
+        spotSearchJob = viewModelScope.launch {
             _uiState.update {
                 it.copy(
                     isLoading = true,
@@ -81,6 +86,8 @@ class CollectionSpotMapViewModel @Inject constructor(
             }.onSuccess { spots ->
                 updateSpotResult(spots)
             }.onFailure { throwable ->
+                if (throwable is CancellationException) throw throwable
+
                 updateSpotFailure(
                     message = throwable.message ?: "수거 장소를 불러오지 못했습니다.",
                 )
@@ -89,7 +96,8 @@ class CollectionSpotMapViewModel @Inject constructor(
     }
 
     fun searchByCurrentLocation() {
-        viewModelScope.launch {
+        spotSearchJob?.cancel()
+        spotSearchJob = viewModelScope.launch {
             _uiState.update {
                 it.copy(
                     isLoading = true,
@@ -100,7 +108,6 @@ class CollectionSpotMapViewModel @Inject constructor(
                     searchMode = MapSearchMode.CURRENT_LOCATION,
                 )
             }
-
 
             when (val result = currentLocationProvider.getCurrentLocation()) {
                 is CurrentLocationResult.Found -> {
@@ -130,6 +137,8 @@ class CollectionSpotMapViewModel @Inject constructor(
         }.onSuccess { spots ->
             updateSpotResult(spots)
         }.onFailure { throwable ->
+            if (throwable is CancellationException) throw throwable
+
             updateSpotFailure(
                 message = throwable.message ?: "현재 위치 주변 수거 장소를 불러오지 못했습니다.",
             )
@@ -166,8 +175,12 @@ class CollectionSpotMapViewModel @Inject constructor(
     }
 
     fun onLocationPermissionDenied() {
+        originalSpots = emptyList()
+
         _uiState.update {
             it.copy(
+                spots = emptyList(),
+                selectedSpot = null,
                 isLoading = false,
                 hasSearched = false,
                 errorMessage = null,
@@ -178,9 +191,14 @@ class CollectionSpotMapViewModel @Inject constructor(
     }
 
     fun onCurrentLocationNotFound() {
+        originalSpots = emptyList()
+
         _uiState.update {
             it.copy(
+                spots = emptyList(),
+                selectedSpot = null,
                 isLoading = false,
+                hasSearched = false,
                 errorMessage = null,
                 locationNoticeMessage = "현재 위치를 확인하지 못했습니다. 직접 동네나 주소를 검색해 주세요.",
                 searchMode = MapSearchMode.KEYWORD,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/di/LocationModule.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/di/LocationModule.kt
@@ -1,0 +1,46 @@
+package com.team.yeogibeoryeo.presentation.map.di
+
+import android.content.Context
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationServices
+import com.team.yeogibeoryeo.presentation.map.location.AndroidCurrentLocationProvider
+import com.team.yeogibeoryeo.presentation.map.location.AndroidLocationPermissionChecker
+import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationProvider
+import com.team.yeogibeoryeo.presentation.map.location.LocationPermissionChecker
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class LocationBindModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindCurrentLocationProvider(
+        androidCurrentLocationProvider: AndroidCurrentLocationProvider,
+    ): CurrentLocationProvider
+
+    @Binds
+    @Singleton
+    abstract fun bindLocationPermissionChecker(
+        androidLocationPermissionChecker: AndroidLocationPermissionChecker,
+    ): LocationPermissionChecker
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object LocationProvideModule {
+
+    @Provides
+    @Singleton
+    fun provideFusedLocationProviderClient(
+        @ApplicationContext context: Context,
+    ): FusedLocationProviderClient {
+        return LocationServices.getFusedLocationProviderClient(context)
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/AndroidCurrentLocationProvider.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/AndroidCurrentLocationProvider.kt
@@ -1,0 +1,53 @@
+package com.team.yeogibeoryeo.presentation.map.location
+
+import android.annotation.SuppressLint
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import javax.inject.Inject
+import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+class AndroidCurrentLocationProvider @Inject constructor(
+    private val fusedLocationProviderClient: FusedLocationProviderClient,
+    private val locationPermissionChecker: LocationPermissionChecker,
+) : CurrentLocationProvider {
+
+    @SuppressLint("MissingPermission")
+    override suspend fun getCurrentLocation(): CurrentLocationResult {
+        if (!locationPermissionChecker.hasFineLocationPermission()) {
+            return CurrentLocationResult.PermissionDenied
+        }
+
+        return try {
+            suspendCancellableCoroutine { continuation ->
+                fusedLocationProviderClient.lastLocation
+                    .addOnSuccessListener { location ->
+                        val result = location?.let {
+                            CurrentLocationResult.Found(
+                                coordinate = Coordinate(
+                                    latitude = it.latitude,
+                                    longitude = it.longitude,
+                                ),
+                            )
+                        } ?: CurrentLocationResult.NotFound
+
+                        if (continuation.isActive) {
+                            continuation.resume(result)
+                        }
+                    }
+                    .addOnFailureListener {
+                        if (continuation.isActive) {
+                            continuation.resume(CurrentLocationResult.NotFound)
+                        }
+                    }
+                    .addOnCanceledListener {
+                        if (continuation.isActive) {
+                            continuation.resume(CurrentLocationResult.NotFound)
+                        }
+                    }
+            }
+        } catch (exception: SecurityException) {
+            CurrentLocationResult.PermissionDenied
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/CurrentLocationProvider.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/CurrentLocationProvider.kt
@@ -1,0 +1,17 @@
+package com.team.yeogibeoryeo.presentation.map.location
+
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+
+interface CurrentLocationProvider {
+    suspend fun getCurrentLocation(): CurrentLocationResult
+}
+
+sealed interface CurrentLocationResult {
+    data class Found(
+        val coordinate: Coordinate,
+    ) : CurrentLocationResult
+
+    data object PermissionDenied : CurrentLocationResult
+
+    data object NotFound : CurrentLocationResult
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/LocationPermissionChecker.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/LocationPermissionChecker.kt
@@ -1,0 +1,24 @@
+package com.team.yeogibeoryeo.presentation.map.location
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+interface LocationPermissionChecker {
+    fun hasFineLocationPermission(): Boolean
+}
+
+class AndroidLocationPermissionChecker @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : LocationPermissionChecker {
+
+    override fun hasFineLocationPermission(): Boolean {
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/LocationPermissionRequester.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/LocationPermissionRequester.kt
@@ -1,0 +1,55 @@
+package com.team.yeogibeoryeo.presentation.map.location
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+
+@Composable
+fun rememberCurrentLocationSearchRequester(
+    onGranted: () -> Unit,
+    onDenied: () -> Unit,
+): () -> Unit {
+    val context = LocalContext.current
+    val currentOnGranted by rememberUpdatedState(onGranted)
+    val currentOnDenied by rememberUpdatedState(onDenied)
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions(),
+    ) { permissions ->
+        if (permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true) {
+            currentOnGranted()
+        } else {
+            currentOnDenied()
+        }
+    }
+
+    return remember(launcher) {
+        {
+            if (context.hasFineLocationPermission()) {
+                currentOnGranted()
+            } else {
+                launcher.launch(LOCATION_PERMISSIONS)
+            }
+        }
+    }
+}
+
+private fun Context.hasFineLocationPermission(): Boolean {
+    return ContextCompat.checkSelfPermission(
+        this,
+        Manifest.permission.ACCESS_FINE_LOCATION,
+    ) == PackageManager.PERMISSION_GRANTED
+}
+
+private val LOCATION_PERMISSIONS = arrayOf(
+    Manifest.permission.ACCESS_FINE_LOCATION,
+    Manifest.permission.ACCESS_COARSE_LOCATION,
+)

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -1,0 +1,215 @@
+package com.team.yeogibeoryeo.presentation.map
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
+import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
+import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByKeywordUseCase
+import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByLocationUseCase
+import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationProvider
+import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationResult
+import com.team.yeogibeoryeo.presentation.search.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CollectionSpotMapViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `현재 위치 권한이 거부되면 직접 검색 안내를 표시하고 위치 검색을 실행하지 않는다`() =
+        runTest {
+            val repository = FakeCollectionSpotRepository()
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.PermissionDenied,
+            )
+
+            viewModel.searchByCurrentLocation()
+
+            assertEquals(0, repository.locationSearchCallCount)
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
+            assertEquals(
+                "현재 위치 검색은 정확한 위치 권한을 허용하면 사용할 수 있어요. 직접 동네나 주소를 검색할 수도 있습니다.",
+                viewModel.uiState.value.locationNoticeMessage,
+            )
+        }
+
+    @Test
+    fun `최근 위치 캐시가 없으면 현재 위치 조회 실패 안내를 표시한다`() =
+        runTest {
+            val repository = FakeCollectionSpotRepository()
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.searchByCurrentLocation()
+
+            assertEquals(0, repository.locationSearchCallCount)
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
+            assertEquals(
+                "현재 위치를 확인하지 못했습니다. 직접 동네나 주소를 검색해 주세요.",
+                viewModel.uiState.value.locationNoticeMessage,
+            )
+        }
+
+    @Test
+    fun `현재 위치 조회가 성공하면 위치 기반 수거 장소를 검색한다`() =
+        runTest {
+            val currentCoordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881)
+            val expectedSpots = listOf(sampleSpot("1", CollectionSpotType.STANDARD_BAG_STORE))
+            val repository = FakeCollectionSpotRepository(
+                locationSpots = expectedSpots,
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(currentCoordinate),
+            )
+
+            viewModel.searchByCurrentLocation()
+
+            assertEquals(currentCoordinate, repository.lastLocationCoordinate)
+            assertEquals(500, repository.lastRadiusMeter)
+            assertEquals(expectedSpots, viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.CURRENT_LOCATION, viewModel.uiState.value.searchMode)
+            assertNull(viewModel.uiState.value.locationNoticeMessage)
+            assertNull(viewModel.uiState.value.errorMessage)
+            assertFalse(viewModel.uiState.value.isLoading)
+        }
+
+    @Test
+    fun `현재 위치 검색 결과도 필터칩 선택 시 정상 필터링된다`() =
+        runTest {
+            val standardBagSpot = sampleSpot("1", CollectionSpotType.STANDARD_BAG_STORE)
+            val recyclingCenterSpot = sampleSpot("2", CollectionSpotType.RECYCLING_CENTER)
+            val repository = FakeCollectionSpotRepository(
+                locationSpots = listOf(standardBagSpot, recyclingCenterSpot),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+            )
+
+            viewModel.searchByCurrentLocation()
+            viewModel.onSpotTypeClick(CollectionSpotType.RECYCLING_CENTER)
+
+            assertEquals(setOf(CollectionSpotType.RECYCLING_CENTER), viewModel.uiState.value.selectedTypes)
+            assertEquals(listOf(recyclingCenterSpot), viewModel.uiState.value.spots)
+        }
+
+    @Test
+    fun `선택된 장소는 현재 위치 검색 결과에서도 유지된다`() =
+        runTest {
+            val selectedSpot = sampleSpot("1", CollectionSpotType.STANDARD_BAG_STORE)
+            val repository = FakeCollectionSpotRepository(
+                locationSpots = listOf(selectedSpot),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+            )
+
+            viewModel.searchByCurrentLocation()
+            viewModel.onSpotClick(selectedSpot)
+
+            assertEquals(selectedSpot, viewModel.uiState.value.selectedSpot)
+        }
+
+    @Test
+    fun `위치 권한 거부 후에도 키워드 검색은 정상 동작한다`() =
+        runTest {
+            val expectedSpot = sampleSpot("keyword", CollectionSpotType.OTHER)
+            val repository = FakeCollectionSpotRepository(keywordSpots = listOf(expectedSpot))
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.PermissionDenied,
+            )
+
+            viewModel.searchByCurrentLocation()
+            viewModel.onSearchKeywordChanged("문래동")
+            viewModel.searchByKeyword()
+
+            assertEquals(listOf("문래동"), repository.keywords)
+            assertEquals(listOf(expectedSpot), viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
+            assertNull(viewModel.uiState.value.locationNoticeMessage)
+        }
+
+    private fun createViewModel(
+        repository: FakeCollectionSpotRepository,
+        currentLocationResult: CurrentLocationResult,
+    ): CollectionSpotMapViewModel {
+        return CollectionSpotMapViewModel(
+            searchCollectionSpotsByKeywordUseCase = SearchCollectionSpotsByKeywordUseCase(repository),
+            searchCollectionSpotsByLocationUseCase = SearchCollectionSpotsByLocationUseCase(repository),
+            filterCollectionSpotsUseCase = FilterCollectionSpotsUseCase(),
+            currentLocationProvider = FakeCurrentLocationProvider(currentLocationResult),
+        )
+    }
+
+    private fun sampleSpot(
+        id: String,
+        type: CollectionSpotType,
+    ): CollectionSpot {
+        return CollectionSpot(
+            id = id,
+            name = "수거 장소 $id",
+            type = type,
+            address = "서울시 중구",
+            detailLocation = null,
+            coordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+        )
+    }
+
+    private class FakeCurrentLocationProvider(
+        private val result: CurrentLocationResult,
+    ) : CurrentLocationProvider {
+
+        override suspend fun getCurrentLocation(): CurrentLocationResult = result
+    }
+
+    private class FakeCollectionSpotRepository(
+        private val keywordSpots: List<CollectionSpot> = emptyList(),
+        private val locationSpots: List<CollectionSpot> = emptyList(),
+    ) : CollectionSpotRepository {
+        val keywords = mutableListOf<String>()
+        var locationSearchCallCount = 0
+        var lastLocationCoordinate: Coordinate? = null
+        var lastRadiusMeter: Int? = null
+
+        override suspend fun searchByKeyword(
+            keyword: String,
+            types: Set<CollectionSpotType>,
+        ): List<CollectionSpot> {
+            keywords += keyword
+            return keywordSpots
+        }
+
+        override suspend fun searchByLocation(
+            coordinate: Coordinate,
+            radiusMeter: Int,
+            types: Set<CollectionSpotType>,
+        ): List<CollectionSpot> {
+            locationSearchCallCount += 1
+            lastLocationCoordinate = coordinate
+            lastRadiusMeter = radiusMeter
+            return locationSpots
+        }
+
+        override suspend fun geocodeSpot(spot: CollectionSpot): CollectionSpot = spot
+    }
+}

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -10,7 +10,9 @@ import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByLocation
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationProvider
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationResult
 import com.team.yeogibeoryeo.presentation.search.MainDispatcherRule
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -35,6 +37,7 @@ class CollectionSpotMapViewModelTest {
             viewModel.searchByCurrentLocation()
 
             assertEquals(0, repository.locationSearchCallCount)
+            assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
             assertFalse(viewModel.uiState.value.isLoading)
             assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
             assertEquals(
@@ -55,6 +58,7 @@ class CollectionSpotMapViewModelTest {
             viewModel.searchByCurrentLocation()
 
             assertEquals(0, repository.locationSearchCallCount)
+            assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
             assertFalse(viewModel.uiState.value.isLoading)
             assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
             assertEquals(
@@ -130,6 +134,38 @@ class CollectionSpotMapViewModelTest {
         }
 
     @Test
+    fun `현재 위치 검색 중 키워드 검색을 실행하면 최신 키워드 검색 결과를 유지한다`() =
+        runTest {
+            val locationResult = CompletableDeferred<CurrentLocationResult>()
+            val keywordSpot = sampleSpot("keyword", CollectionSpotType.OTHER)
+            val locationSpot = sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)
+            val repository = FakeCollectionSpotRepository(
+                keywordSpots = listOf(keywordSpot),
+                locationSpots = listOf(locationSpot),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationProvider = FakeCurrentLocationProvider {
+                    locationResult.await()
+                },
+            )
+
+            viewModel.searchByCurrentLocation()
+            viewModel.onSearchKeywordChanged("문래동")
+            viewModel.searchByKeyword()
+
+            locationResult.complete(
+                CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(listOf(keywordSpot), viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
+        }
+
+    @Test
     fun `위치 권한 거부 후에도 키워드 검색은 정상 동작한다`() =
         runTest {
             val expectedSpot = sampleSpot("keyword", CollectionSpotType.OTHER)
@@ -153,11 +189,21 @@ class CollectionSpotMapViewModelTest {
         repository: FakeCollectionSpotRepository,
         currentLocationResult: CurrentLocationResult,
     ): CollectionSpotMapViewModel {
+        return createViewModel(
+            repository = repository,
+            currentLocationProvider = FakeCurrentLocationProvider(currentLocationResult),
+        )
+    }
+
+    private fun createViewModel(
+        repository: FakeCollectionSpotRepository,
+        currentLocationProvider: CurrentLocationProvider,
+    ): CollectionSpotMapViewModel {
         return CollectionSpotMapViewModel(
             searchCollectionSpotsByKeywordUseCase = SearchCollectionSpotsByKeywordUseCase(repository),
             searchCollectionSpotsByLocationUseCase = SearchCollectionSpotsByLocationUseCase(repository),
             filterCollectionSpotsUseCase = FilterCollectionSpotsUseCase(),
-            currentLocationProvider = FakeCurrentLocationProvider(currentLocationResult),
+            currentLocationProvider = currentLocationProvider,
         )
     }
 
@@ -176,10 +222,12 @@ class CollectionSpotMapViewModelTest {
     }
 
     private class FakeCurrentLocationProvider(
-        private val result: CurrentLocationResult,
+        private val resultProvider: suspend () -> CurrentLocationResult,
     ) : CurrentLocationProvider {
 
-        override suspend fun getCurrentLocation(): CurrentLocationResult = result
+        constructor(result: CurrentLocationResult) : this({ result })
+
+        override suspend fun getCurrentLocation(): CurrentLocationResult = resultProvider()
     }
 
     private class FakeCollectionSpotRepository(


### PR DESCRIPTION
- CollectionSpotMapScreen의 LocationManager 기반 현재 위치 조회 로직 제거
- CurrentLocationProvider, LocationPermissionChecker 구조 추가
- 정확 위치 권한 허용 시에만 현재 위치 검색 실행
- 권한 거부, 대략 위치만 허용, 위치 조회 실패 케이스 분리
- CollectionSpotMapViewModelTest 추가

검증:
- 실기기에서 정확 위치/대략 위치/권한 거부 플로우 확인
- CollectionSpotMapViewModelTest 6개 통과

Related #51


리뷰 시 확인 부탁드릴 부분

- `CollectionSpotMapScreen`에서 위치 조회 책임이 충분히 분리되었는지
- `CurrentLocationProvider`, `LocationPermissionChecker`, `rememberCurrentLocationSearchRequester` 역할 분리가 자연스러운지
- 정확 위치 권한만 현재 위치 검색에 허용하는 정책이 괜찮은지
- 대략 위치만 허용/권한 거부/최근 위치 없음 케이스 안내 문구가 적절한지
- 기존 지도 검색, 마커, 필터칩, 하단 리스트, 카드 선택 연동에 영향이 없어 보이는지
- 추가한 `CollectionSpotMapViewModelTest`가 #51 검증 항목을 충분히 커버하는지

참고:
- 지도 현재 위치 overlay, `FusedLocationSource`, `locationTrackingMode`, “현재 지도에서 검색” UX는 #73 후속 범위로 분리했습니다.