### PR TITLE
refactor: 기존 지역 주소 파싱 로직 검증 및 지도 연결 준비

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionNormalizer.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionNormalizer.kt
@@ -8,28 +8,64 @@ import com.team.yeogibeoryeo.domain.region.model.Region
  */
 object RegionNormalizer {
 
-    private val sidoMap = mapOf(
-        "서울" to "서울특별시", "서울시" to "서울특별시",
-        "부산" to "부산광역시", "부산시" to "부산광역시",
-        "대구" to "대구광역시", "대구시" to "대구광역시",
-        "인천" to "인천광역시", "인천시" to "인천광역시",
-        "광주" to "광주광역시", "광주시" to "광주광역시",
-        "대전" to "대전광역시", "대전시" to "대전광역시",
-        "울산" to "울산광역시", "울산시" to "울산광역시",
-        "세종" to "세종특별자치시", "세종시" to "세종특별자치시",
+    private val officialSidoNames = setOf(
+        "서울특별시",
+        "부산광역시",
+        "대구광역시",
+        "인천광역시",
+        "광주광역시",
+        "대전광역시",
+        "울산광역시",
+        "세종특별자치시",
+        "경기도",
+        "강원특별자치도",
+        "강원도",
+        "충청북도",
+        "충청남도",
+        "전북특별자치도",
+        "전라북도",
+        "전라남도",
+        "경상북도",
+        "경상남도",
+        "제주특별자치도",
+        "제주도"
+    )
+
+    private val sidoAliasMap = mapOf(
+        "서울" to "서울특별시",
+        "서울시" to "서울특별시",
+        "부산" to "부산광역시",
+        "부산시" to "부산광역시",
+        "대구" to "대구광역시",
+        "대구시" to "대구광역시",
+        "인천" to "인천광역시",
+        "인천시" to "인천광역시",
+        "광주" to "광주광역시",
+        "대전" to "대전광역시",
+        "대전시" to "대전광역시",
+        "울산" to "울산광역시",
+        "울산시" to "울산광역시",
+        "세종" to "세종특별자치시",
+        "세종시" to "세종특별자치시",
         "경기" to "경기도",
         "강원" to "강원특별자치도",
+        "강원도" to "강원특별자치도",
         "충북" to "충청북도",
         "충남" to "충청남도",
         "전북" to "전북특별자치도",
+        "전라북도" to "전북특별자치도",
         "전남" to "전라남도",
         "경북" to "경상북도",
         "경남" to "경상남도",
-        "제주" to "제주특별자치도"
+        "제주" to "제주특별자치도",
+        "제주도" to "제주특별자치도"
     )
 
+    internal fun isSidoName(name: String): Boolean =
+        name in officialSidoNames || name in sidoAliasMap
+
     fun normalize(region: Region): Region {
-        val normalizedSido = region.sido?.let { sidoMap[it] ?: it }
+        val normalizedSido = region.sido?.let { sidoAliasMap[it] ?: it }
 
         // [도메인 지식]: 세종특별자치시는 하위 구가 없으므로 API 오류 방지를 위해 sigungu 제거
         val normalizedSigungu = if (normalizedSido == "세종특별자치시") {

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package com.team.yeogibeoryeo.data.region
 
 import com.team.yeogibeoryeo.data.region.local.RegionOptionsLocalDataSource
+import com.team.yeogibeoryeo.data.region.local.dto.AdministrativeRegionDto
+import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.region.repository.RegionOptionsRepository
 import javax.inject.Inject
 
@@ -36,10 +38,43 @@ class RegionOptionsRepositoryImpl @Inject constructor(
         return localDataSource.getRegions()
             .filter { region ->
                 region.sidoName == sido &&
-                        region.sigunguName.ifBlank { region.sidoName } == sigungu
+                    region.sigunguName.ifBlank { region.sidoName } == sigungu
             }
             .map { region -> region.eupmyeondongName }
             .filter { eupmyeondong -> eupmyeondong.isNotBlank() }
             .distinct()
+    }
+
+    override suspend fun findRegionsByEupmyeondongKeyword(
+        keyword: String
+    ): List<Region> {
+        val targetKeyword = keyword.trim()
+        if (targetKeyword.isBlank()) return emptyList()
+
+        val regions = localDataSource.getRegions()
+        val exactMatches = regions
+            .filter { region -> region.eupmyeondongName == targetKeyword }
+
+        val matchedRegions = exactMatches.ifEmpty {
+            regions.filter { region ->
+                region.eupmyeondongName.startsWith(targetKeyword)
+            }
+        }
+
+        return matchedRegions
+            .mapToRegion()
+            .distinct()
+    }
+
+    private fun List<AdministrativeRegionDto>.mapToRegion(): List<Region> {
+        return map { region ->
+            RegionNormalizer.normalize(
+                Region(
+                    sido = region.sidoName,
+                    sigungu = region.sigunguName.ifBlank { null },
+                    eupmyeondong = region.eupmyeondongName
+                )
+            )
+        }
     }
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsRepositoryImpl.kt
@@ -15,6 +15,7 @@ class RegionOptionsRepositoryImpl @Inject constructor(
             .map { region -> region.sidoName }
             .filter { sido -> sido.isNotBlank() }
             .distinct()
+            .sorted()
     }
 
     override suspend fun getSigunguOptions(
@@ -29,6 +30,7 @@ class RegionOptionsRepositoryImpl @Inject constructor(
             }
             .filter { sigungu -> sigungu.isNotBlank() }
             .distinct()
+            .sorted()
     }
 
     override suspend fun getEupmyeondongOptions(
@@ -43,6 +45,7 @@ class RegionOptionsRepositoryImpl @Inject constructor(
             .map { region -> region.eupmyeondongName }
             .filter { eupmyeondong -> eupmyeondong.isNotBlank() }
             .distinct()
+            .sorted()
     }
 
     override suspend fun findRegionsByEupmyeondongKeyword(
@@ -64,6 +67,7 @@ class RegionOptionsRepositoryImpl @Inject constructor(
         return matchedRegions
             .mapToRegion()
             .distinct()
+            .sortedWith(REGION_NAME_COMPARATOR)
     }
 
     private fun List<AdministrativeRegionDto>.mapToRegion(): List<Region> {
@@ -76,5 +80,13 @@ class RegionOptionsRepositoryImpl @Inject constructor(
                 )
             )
         }
+    }
+
+    companion object {
+        private val REGION_NAME_COMPARATOR = compareBy<Region>(
+            { region -> region.sido.orEmpty() },
+            { region -> region.sigungu.orEmpty() },
+            { region -> region.eupmyeondong.orEmpty() }
+        )
     }
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionRepositoryImpl.kt
@@ -5,26 +5,32 @@ import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.region.repository.RegionRepository
 import javax.inject.Inject
 
-/**
- * [RegionRepository]의 실질적인 동작을 정의하는 Data 계층의 구현체
- * 초기 1단계에서는 로컬 주소 파서만 활용하며, 향후 Geocoder API 등 외부 데이터 소스를 추가하여 확장합니다.
- */
 class RegionRepositoryImpl @Inject constructor(
     private val addressParser: RegionAddressParser
 ) : RegionRepository {
 
     override fun extractRegionFromAddress(address: String): Region? {
         if (address.isBlank()) return null
+
         return addressParser.parse(address)
+            .takeIf { region -> region.hasAnyRegionComponent() }
     }
 
     override suspend fun resolveRegionFromKeyword(keyword: String): Region? {
         if (keyword.isBlank()) return null
+
         return addressParser.parse(keyword)
+            .takeIf { region -> region.hasAnyRegionComponent() }
     }
 
     override suspend fun resolveRegionFromCoordinate(latitude: Double, longitude: Double): Region? {
         // TODO: 향후 외부 API 기반 Reverse Geocoding 연동 시 구현
         return null
+    }
+
+    private fun Region.hasAnyRegionComponent(): Boolean {
+        return !sido.isNullOrBlank() ||
+            !sigungu.isNullOrBlank() ||
+            !eupmyeondong.isNullOrBlank()
     }
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/parser/RegionAddressParser.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/parser/RegionAddressParser.kt
@@ -4,14 +4,14 @@ import com.team.yeogibeoryeo.data.region.RegionNormalizer
 import com.team.yeogibeoryeo.domain.region.model.Region
 import javax.inject.Inject
 
-/**
- * 주소 문자열을 분석하여 [Region] 객체로 매핑하는 파서 (Parser)
- * 띄어쓰기 및 접미사 단위로 행정구역을 추출한 뒤, [RegionNormalizer]를 거쳐 최종 반환합니다.
- */
 class RegionAddressParser @Inject constructor() {
 
     fun parse(address: String): Region {
-        val parts = address.trim().split("\\s+".toRegex())
+        val normalizedAddress = address.trim()
+        val parts = normalizedAddress
+            .split(WHITESPACE_REGEX)
+            .map { part -> part.cleanRegionToken() }
+            .filter { part -> part.isNotBlank() }
 
         var sido: String? = null
         var sigungu: String? = null
@@ -19,27 +19,52 @@ class RegionAddressParser @Inject constructor() {
 
         parts.forEach { part ->
             when {
-                (part.endsWith("도") || part.endsWith("시") || part in SIDO_ABBR) && sido == null -> {
+                part.isSidoName() && sido == null -> {
                     sido = part
                 }
-                (part.endsWith("시") || part.endsWith("군") || part.endsWith("구")) && part != sido -> {
+
+                part.isSigunguName() && part != sido -> {
                     if (sigungu == null) sigungu = part
                 }
-                part.endsWith("읍") || part.endsWith("면") || part.endsWith("동") -> {
+
+                part.isEupmyeondongName() -> {
                     if (eupmyeondong == null) eupmyeondong = part
                 }
             }
         }
 
-        // 1차 파싱된 데이터를 정규화 유틸리티를 거쳐 최종 포맷으로 변환
-        val parsedRegion = Region(sido = sido, sigungu = sigungu, eupmyeondong = eupmyeondong)
+        val parsedRegion = Region(
+            sido = sido,
+            sigungu = sigungu,
+            eupmyeondong = eupmyeondong ?: normalizedAddress.extractParenthesizedEupmyeondong()
+        )
+
         return RegionNormalizer.normalize(parsedRegion)
     }
 
+    private fun String.cleanRegionToken(): String =
+        trim().trim('(', ')', '[', ']', ',', '.', ' ')
+
+    private fun String.extractParenthesizedEupmyeondong(): String? {
+        return PARENTHESIZED_REGION_REGEX
+            .findAll(this)
+            .mapNotNull { matchResult ->
+                matchResult.groupValues.getOrNull(1)?.cleanRegionToken()
+            }
+            .firstOrNull { token -> token.isEupmyeondongName() }
+    }
+
+    private fun String.isSidoName(): Boolean =
+        RegionNormalizer.isSidoName(this)
+
+    private fun String.isSigunguName(): Boolean =
+        endsWith("시") || endsWith("군") || endsWith("구")
+
+    private fun String.isEupmyeondongName(): Boolean =
+        endsWith("읍") || endsWith("면") || endsWith("동")
+
     companion object {
-        private val SIDO_ABBR = setOf(
-            "서울", "부산", "대구", "인천", "광주", "대전", "울산", "세종",
-            "경기", "강원", "충북", "충남", "전북", "전남", "경북", "경남", "제주"
-        )
+        private val WHITESPACE_REGEX = "\\s+".toRegex()
+        private val PARENTHESIZED_REGION_REGEX = "\\(([^)]+)\\)".toRegex()
     }
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalGuideMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalGuideMapper.kt
@@ -1,5 +1,6 @@
 package com.team.yeogibeoryeo.data.regionalguide.mapper
 
+import com.team.yeogibeoryeo.data.region.RegionNormalizer
 import com.team.yeogibeoryeo.data.regionalguide.remote.dto.RegionalGuideItemDto
 import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
@@ -10,14 +11,23 @@ import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
  */
 object RegionalGuideMapper {
     fun mapToDomain(baseRegion: Region, dto: RegionalGuideItemDto): RegionalDisposalGuide {
-        val accurateRegion = baseRegion.copy(
-            eupmyeondong = dto.dongName?.trim() ?: baseRegion.eupmyeondong
+        val targetRegionName = dto.dongName?.trim()
+        val accurateRegion = RegionNormalizer.normalize(
+            baseRegion.copy(
+                sido = baseRegion.sido ?: dto.sidoName?.trim(),
+                sigungu = baseRegion.sigungu ?: dto.sigunguName
+                    ?.trim()
+                    ?.takeIf { sigunguName -> sigunguName.isSpecificRegionName() },
+                eupmyeondong = targetRegionName
+                    ?.takeIf { regionName -> regionName.isSpecificRegionName() }
+                    ?: baseRegion.eupmyeondong
+            )
         )
 
         return RegionalDisposalGuide(
             region = accurateRegion,
             managementZoneName = dto.managementZoneName?.trim(),
-            targetRegionName = dto.dongName?.trim(),
+            targetRegionName = targetRegionName,
             disposalPlaceType = dto.disposalPlaceType?.trim(),
             disposalPlaceDescription = dto.placeDescription?.trim(),
             schedules = RegionalWasteScheduleMapper.mapToSchedules(dto),
@@ -26,4 +36,28 @@ object RegionalGuideMapper {
             departmentPhoneNumber = dto.departmentPhoneNumber?.trim()
         )
     }
+
+    private fun String.isSpecificRegionName(): Boolean {
+        return isNotBlank() &&
+            this !in NON_SPECIFIC_TARGET_REGION_NAMES &&
+            !endsWith("전체") &&
+            !endsWith("전역") &&
+            containsEupmyeondongName()
+    }
+
+    private fun String.containsEupmyeondongName(): Boolean {
+        return split("+", ",").any { regionName ->
+            val trimmedRegionName = regionName.trim()
+            trimmedRegionName.endsWith("읍") ||
+                trimmedRegionName.endsWith("면") ||
+                trimmedRegionName.endsWith("동")
+        }
+    }
+
+    private val NON_SPECIFIC_TARGET_REGION_NAMES = setOf(
+        "없음",
+        "전체",
+        "전역",
+        "관내"
+    )
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalGuideMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalGuideMapper.kt
@@ -17,10 +17,8 @@ object RegionalGuideMapper {
                 sido = baseRegion.sido ?: dto.sidoName?.trim(),
                 sigungu = baseRegion.sigungu ?: dto.sigunguName
                     ?.trim()
-                    ?.takeIf { sigunguName -> sigunguName.isSpecificRegionName() },
-                eupmyeondong = targetRegionName
-                    ?.takeIf { regionName -> regionName.isSpecificRegionName() }
-                    ?: baseRegion.eupmyeondong
+                    ?.takeIf { sigunguName -> sigunguName.isSpecificSigunguName() },
+                eupmyeondong = baseRegion.eupmyeondong
             )
         )
 
@@ -37,27 +35,6 @@ object RegionalGuideMapper {
         )
     }
 
-    private fun String.isSpecificRegionName(): Boolean {
-        return isNotBlank() &&
-            this !in NON_SPECIFIC_TARGET_REGION_NAMES &&
-            !endsWith("전체") &&
-            !endsWith("전역") &&
-            containsEupmyeondongName()
-    }
-
-    private fun String.containsEupmyeondongName(): Boolean {
-        return split("+", ",").any { regionName ->
-            val trimmedRegionName = regionName.trim()
-            trimmedRegionName.endsWith("읍") ||
-                trimmedRegionName.endsWith("면") ||
-                trimmedRegionName.endsWith("동")
-        }
-    }
-
-    private val NON_SPECIFIC_TARGET_REGION_NAMES = setOf(
-        "없음",
-        "전체",
-        "전역",
-        "관내"
-    )
+    private fun String.isSpecificSigunguName(): Boolean =
+        isNotBlank() && this != "없음"
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.team.yeogibeoryeo.data.regionalguide.repository
 
 import com.team.yeogibeoryeo.data.regionalguide.mapper.RegionalGuideMapper
 import com.team.yeogibeoryeo.data.regionalguide.remote.RegionalGuideDataSource
+import com.team.yeogibeoryeo.data.regionalguide.remote.dto.RegionalGuideItemDto
 import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
 import com.team.yeogibeoryeo.domain.regionalguide.repository.RegionalDisposalGuideRepository
@@ -16,7 +17,7 @@ class RegionalDisposalGuideRepositoryImpl @Inject constructor(
 ) : RegionalDisposalGuideRepository {
 
     override suspend fun getRegionalDisposalGuide(region: Region): RegionalDisposalGuide? {
-        val sigungu = if (region.sido == "세종특별자치시") "없음" else  region.sigungu
+        val sigungu = if (region.sido == "세종특별자치시") "없음" else region.sigungu
 
         if (sigungu.isNullOrBlank()) return null
 
@@ -26,18 +27,31 @@ class RegionalDisposalGuideRepositoryImpl @Inject constructor(
             val dtoList = result.getOrNull() ?: emptyList()
             if (dtoList.isEmpty()) return null
 
+            val candidateDtos = dtoList.filterBySido(region.sido)
+            if (candidateDtos.isEmpty()) return null
+
             val eupmyeondong = region.eupmyeondong
 
             val targetDto = if (!eupmyeondong.isNullOrBlank()) {
-                dtoList.find { it.dongName?.trim() == eupmyeondong.trim() }
-                    ?: dtoList.find { it.dongName?.contains(eupmyeondong) == true }
-                    ?: dtoList.first()
+                candidateDtos.find { it.dongName?.trim() == eupmyeondong.trim() }
+                    ?: candidateDtos.find { it.dongName?.contains(eupmyeondong) == true }
+                    ?: candidateDtos.first()
             } else {
-                dtoList.first()
+                candidateDtos.first()
             }
             return RegionalGuideMapper.mapToDomain(region, targetDto)
         } else {
             return null
+        }
+    }
+
+    private fun List<RegionalGuideItemDto>.filterBySido(
+        sido: String?
+    ): List<RegionalGuideItemDto> {
+        if (sido.isNullOrBlank()) return this
+
+        return filter { dto ->
+            dto.sidoName?.trim() == sido.trim()
         }
     }
 }

--- a/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionRepositoryImplTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionRepositoryImplTest.kt
@@ -26,11 +26,21 @@ class RegionRepositoryImplTest {
 
         assertEquals("서울특별시", result?.sido)
         assertEquals("영등포구", result?.sigungu)
+        assertEquals("당산동", result?.eupmyeondong)
     }
 
     @Test
-    fun `빈 주소는 null 반환`() {
+    fun `빈 주소는 null을 반환한다`() {
         val result = repository.extractRegionFromAddress("")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `지역 정보를 찾을 수 없는 주소는 null을 반환한다`() {
+        val result = repository.extractRegionFromAddress(
+            "주소 정보 없음"
+        )
 
         assertNull(result)
     }
@@ -41,6 +51,49 @@ class RegionRepositoryImplTest {
             "서울 영등포구"
         )
 
+        assertEquals("서울특별시", result?.sido)
         assertEquals("영등포구", result?.sigungu)
+    }
+
+    @Test
+    fun `시 단독 검색어는 시군구로 변환된다`() = runBlocking {
+        val result = repository.resolveRegionFromKeyword(
+            "수원시"
+        )
+
+        assertNull(result?.sido)
+        assertEquals("수원시", result?.sigungu)
+        assertNull(result?.eupmyeondong)
+    }
+
+    @Test
+    fun `광주시 단독 검색어는 광주광역시가 아닌 시군구로 변환된다`() = runBlocking {
+        val result = repository.resolveRegionFromKeyword(
+            "광주시"
+        )
+
+        assertNull(result?.sido)
+        assertEquals("광주시", result?.sigungu)
+        assertNull(result?.eupmyeondong)
+    }
+
+    @Test
+    fun `광주 축약 시도명은 광주광역시로 변환된다`() = runBlocking {
+        val result = repository.resolveRegionFromKeyword(
+            "광주 북구"
+        )
+
+        assertEquals("광주광역시", result?.sido)
+        assertEquals("북구", result?.sigungu)
+    }
+
+    @Test
+    fun `과거 시도명은 현재 공식 시도명으로 변환된다`() = runBlocking {
+        val result = repository.resolveRegionFromKeyword(
+            "전라북도 전주시"
+        )
+
+        assertEquals("전북특별자치도", result?.sido)
+        assertEquals("전주시", result?.sigungu)
     }
 }

--- a/data/src/test/java/com/team/yeogibeoryeo/data/region/parser/RegionAddressParserTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/region/parser/RegionAddressParserTest.kt
@@ -15,7 +15,7 @@ class RegionAddressParserTest {
     }
 
     @Test
-    fun `표준 주소가 정상 파싱된다`() {
+    fun `표준 주소에서 시도 시군구 읍면동을 추출한다`() {
         val result = parser.parse(
             "서울특별시 강남구 역삼동 123-45"
         )
@@ -26,38 +26,102 @@ class RegionAddressParserTest {
     }
 
     @Test
-    fun `getSpot addrBase 포맷이 정상 파싱된다`() {
+    fun `getSpot 도로명 주소에서 시도와 시군구를 추출하고 읍면동은 null 처리한다`() {
         val result = parser.parse(
             "서울특별시 영등포구 당산로 42"
         )
 
         assertEquals("서울특별시", result.sido)
         assertEquals("영등포구", result.sigungu)
-
-        // 도로명 주소이므로 읍면동 없음
         assertNull(result.eupmyeondong)
     }
 
     @Test
-    fun `세종특별자치시는 sigungu가 null 처리된다`() {
+    fun `괄호 안 동명이 있는 getSpot 주소에서 읍면동을 추출한다`() {
         val result = parser.parse(
-            "세종특별자치시 한솔동 123"
+            "서울특별시 영등포구 문래로 110 (문래동)"
+        )
+
+        assertEquals("서울특별시", result.sido)
+        assertEquals("영등포구", result.sigungu)
+        assertEquals("문래동", result.eupmyeondong)
+    }
+
+    @Test
+    fun `일반 주소에서 시도 시군구 읍면동을 추출한다`() {
+        val result = parser.parse(
+            "서울특별시 영등포구 문래동 55-1"
+        )
+
+        assertEquals("서울특별시", result.sido)
+        assertEquals("영등포구", result.sigungu)
+        assertEquals("문래동", result.eupmyeondong)
+    }
+
+    @Test
+    fun `세종특별자치시는 sigungu가 null 처리되고 읍면동을 추출한다`() {
+        val result = parser.parse(
+            "세종특별자치시 조치원읍 새내로 122"
         )
 
         assertEquals("세종특별자치시", result.sido)
         assertNull(result.sigungu)
-        assertEquals("한솔동", result.eupmyeondong)
+        assertEquals("조치원읍", result.eupmyeondong)
     }
 
     @Test
-    fun `축약 시도명이 정상 정규화된다`() {
+    fun `축약 시도명을 정식 시도명으로 정규화한다`() {
         val result = parser.parse(
-            "서울 강남구 역삼동"
+            "서울 영등포구 문래동"
         )
 
         assertEquals("서울특별시", result.sido)
-        assertEquals("강남구", result.sigungu)
-        assertEquals("역삼동", result.eupmyeondong)
+        assertEquals("영등포구", result.sigungu)
+        assertEquals("문래동", result.eupmyeondong)
+    }
+
+    @Test
+    fun `시 단독 검색어는 시도가 아닌 시군구로 파싱된다`() {
+        val result = parser.parse(
+            "수원시"
+        )
+
+        assertNull(result.sido)
+        assertEquals("수원시", result.sigungu)
+        assertNull(result.eupmyeondong)
+    }
+
+    @Test
+    fun `광주시 단독 검색어는 광주광역시가 아닌 시군구로 파싱된다`() {
+        val result = parser.parse(
+            "광주시"
+        )
+
+        assertNull(result.sido)
+        assertEquals("광주시", result.sigungu)
+        assertNull(result.eupmyeondong)
+    }
+
+    @Test
+    fun `광주 축약 시도명은 광주광역시로 정규화된다`() {
+        val result = parser.parse(
+            "광주 북구 문흥동"
+        )
+
+        assertEquals("광주광역시", result.sido)
+        assertEquals("북구", result.sigungu)
+        assertEquals("문흥동", result.eupmyeondong)
+    }
+
+    @Test
+    fun `과거 시도명은 현재 공식 시도명으로 정규화된다`() {
+        val result = parser.parse(
+            "강원도 춘천시 후평동"
+        )
+
+        assertEquals("강원특별자치도", result.sido)
+        assertEquals("춘천시", result.sigungu)
+        assertEquals("후평동", result.eupmyeondong)
     }
 
     @Test

--- a/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalGuideMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalGuideMapperTest.kt
@@ -87,7 +87,7 @@ class RegionalGuideMapperTest {
     }
 
     @Test
-    fun `대상지역이 구체적인 읍면동이면 Region 읍면동에 반영한다`() {
+    fun `대상지역이 구체적인 읍면동이어도 Region 읍면동을 덮어쓰지 않는다`() {
         val result = RegionalGuideMapper.mapToDomain(
             baseRegion = Region(
                 sido = "서울특별시",
@@ -101,8 +101,28 @@ class RegionalGuideMapperTest {
             )
         )
 
-        assertEquals("문래동", result.region.eupmyeondong)
+        assertNull(result.region.eupmyeondong)
         assertEquals("문래동", result.targetRegionName)
+    }
+
+    @Test
+    fun `기존 Region 읍면동이 있으면 대상지역 설명과 분리하여 유지한다`() {
+        val result = RegionalGuideMapper.mapToDomain(
+            baseRegion = Region(
+                sido = "인천광역시",
+                sigungu = "중구",
+                eupmyeondong = "신흥동",
+            ),
+            dto = RegionalGuideItemDto(
+                sidoName = "인천광역시",
+                sigunguName = "중구",
+                managementZoneName = "중구",
+                dongName = "신흥동+율목동+영종동+영종1동+영종2동+용유동",
+            )
+        )
+
+        assertEquals("신흥동", result.region.eupmyeondong)
+        assertEquals("신흥동+율목동+영종동+영종1동+영종2동+용유동", result.targetRegionName)
     }
 
     @Test

--- a/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalGuideMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/mapper/RegionalGuideMapperTest.kt
@@ -1,10 +1,128 @@
 package com.team.yeogibeoryeo.data.regionalguide.mapper
 
+import com.team.yeogibeoryeo.data.regionalguide.remote.dto.RegionalGuideItemDto
+import com.team.yeogibeoryeo.domain.region.model.Region
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 class RegionalGuideMapperTest {
+
+    @Test
+    fun `대상지역이 없음이면 Region 읍면동을 덮어쓰지 않는다`() {
+        val result = RegionalGuideMapper.mapToDomain(
+            baseRegion = Region(
+                sigungu = "수원시",
+            ),
+            dto = RegionalGuideItemDto(
+                sidoName = "경기도",
+                sigunguName = "수원시",
+                managementZoneName = "수원시",
+                dongName = "없음",
+            )
+        )
+
+        assertEquals("경기도", result.region.sido)
+        assertEquals("수원시", result.region.sigungu)
+        assertNull(result.region.eupmyeondong)
+        assertEquals("없음", result.targetRegionName)
+    }
+
+    @Test
+    fun `baseRegion에 시도가 없으면 DTO 시도명으로 보완한다`() {
+        val result = RegionalGuideMapper.mapToDomain(
+            baseRegion = Region(
+                sigungu = "성남시",
+            ),
+            dto = RegionalGuideItemDto(
+                sidoName = "경기도",
+                sigunguName = "성남시",
+                managementZoneName = "성남시",
+                dongName = "성남시 전체",
+            )
+        )
+
+        assertEquals("경기도", result.region.sido)
+        assertEquals("성남시", result.region.sigungu)
+        assertNull(result.region.eupmyeondong)
+    }
+
+    @Test
+    fun `세종특별자치시는 DTO 시군구명이 없음이어도 시군구를 null로 유지한다`() {
+        val result = RegionalGuideMapper.mapToDomain(
+            baseRegion = Region(
+                sido = "세종특별자치시",
+                eupmyeondong = "조치원읍",
+            ),
+            dto = RegionalGuideItemDto(
+                sidoName = "세종특별자치시",
+                sigunguName = "없음",
+                managementZoneName = "세종특별자치시",
+                dongName = "없음",
+            )
+        )
+
+        assertEquals("세종특별자치시", result.region.sido)
+        assertNull(result.region.sigungu)
+        assertEquals("조치원읍", result.region.eupmyeondong)
+    }
+
+    @Test
+    fun `세종특별자치시는 읍면동이 없으면 시도만 유지한다`() {
+        val result = RegionalGuideMapper.mapToDomain(
+            baseRegion = Region(
+                sido = "세종특별자치시",
+            ),
+            dto = RegionalGuideItemDto(
+                sidoName = "세종특별자치시",
+                sigunguName = "없음",
+                managementZoneName = "세종특별자치시",
+                dongName = "없음",
+            )
+        )
+
+        assertEquals("세종특별자치시", result.region.sido)
+        assertNull(result.region.sigungu)
+        assertNull(result.region.eupmyeondong)
+    }
+
+    @Test
+    fun `대상지역이 구체적인 읍면동이면 Region 읍면동에 반영한다`() {
+        val result = RegionalGuideMapper.mapToDomain(
+            baseRegion = Region(
+                sido = "서울특별시",
+                sigungu = "영등포구",
+            ),
+            dto = RegionalGuideItemDto(
+                sidoName = "서울특별시",
+                sigunguName = "영등포구",
+                managementZoneName = "영등포구",
+                dongName = "문래동",
+            )
+        )
+
+        assertEquals("문래동", result.region.eupmyeondong)
+        assertEquals("문래동", result.targetRegionName)
+    }
+
+    @Test
+    fun `대상지역이 시군구 설명이면 Region 읍면동으로 사용하지 않는다`() {
+        val result = RegionalGuideMapper.mapToDomain(
+            baseRegion = Region(
+                sido = "서울특별시",
+                sigungu = "중구",
+            ),
+            dto = RegionalGuideItemDto(
+                sidoName = "서울특별시",
+                sigunguName = "중구",
+                managementZoneName = "서울시 중구",
+                dongName = "서울시 중구",
+            )
+        )
+
+        assertNull(result.region.eupmyeondong)
+        assertEquals("서울시 중구", result.targetRegionName)
+    }
 
     @Test
     fun `시간파싱_유효하지 않은 입력은 null 반환한다`() {

--- a/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImplTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImplTest.kt
@@ -5,6 +5,7 @@ import com.team.yeogibeoryeo.data.regionalguide.remote.dto.RegionalGuideItemDto
 import com.team.yeogibeoryeo.domain.region.model.Region
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 
@@ -48,9 +49,9 @@ class RegionalDisposalGuideRepositoryImplTest {
     fun `동일한 동명칭 포함 시 정확히 일치하는 데이터를 최우선으로 선택한다`() = runBlocking {
         val region = Region(sido = "서울특별시", sigungu = "종로구", eupmyeondong = "인사동")
         val mockData = listOf(
-            RegionalGuideItemDto(dongName = "인사동1가"),
-            RegionalGuideItemDto(dongName = "인사동"),
-            RegionalGuideItemDto(dongName = "인사동2가")
+            RegionalGuideItemDto(sidoName = "서울특별시", dongName = "인사동1가"),
+            RegionalGuideItemDto(sidoName = "서울특별시", dongName = "인사동"),
+            RegionalGuideItemDto(sidoName = "서울특별시", dongName = "인사동2가")
         )
         fakeDataSource.mockResult = Result.success(mockData)
 
@@ -58,5 +59,47 @@ class RegionalDisposalGuideRepositoryImplTest {
 
         assertEquals("종로구", fakeDataSource.calledSigunguName)
         assertEquals("인사동", result?.region?.eupmyeondong)
+    }
+
+    @Test
+    fun `시도가 선택되어 있으면 같은 시도의 후보만 선택한다`() = runBlocking {
+        val region = Region(sido = "서울특별시", sigungu = "중구")
+        val mockData = listOf(
+            RegionalGuideItemDto(
+                sidoName = "대구광역시",
+                sigunguName = "중구",
+                dongName = "대봉2동"
+            ),
+            RegionalGuideItemDto(
+                sidoName = "서울특별시",
+                sigunguName = "중구",
+                dongName = "서울시 중구"
+            )
+        )
+        fakeDataSource.mockResult = Result.success(mockData)
+
+        val result = repository.getRegionalDisposalGuide(region)
+
+        assertEquals("중구", fakeDataSource.calledSigunguName)
+        assertEquals("서울특별시", result?.region?.sido)
+        assertEquals("중구", result?.region?.sigungu)
+        assertEquals("서울시 중구", result?.targetRegionName)
+    }
+
+    @Test
+    fun `선택한 시도와 일치하는 후보가 없으면 다른 시도 데이터를 반환하지 않는다`() = runBlocking {
+        val region = Region(sido = "서울특별시", sigungu = "중구")
+        val mockData = listOf(
+            RegionalGuideItemDto(
+                sidoName = "대구광역시",
+                sigunguName = "중구",
+                dongName = "대봉2동"
+            )
+        )
+        fakeDataSource.mockResult = Result.success(mockData)
+
+        val result = repository.getRegionalDisposalGuide(region)
+
+        assertNull(result)
     }
 }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/repository/RegionOptionsRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/repository/RegionOptionsRepository.kt
@@ -1,5 +1,7 @@
 package com.team.yeogibeoryeo.domain.region.repository
 
+import com.team.yeogibeoryeo.domain.region.model.Region
+
 interface RegionOptionsRepository {
 
     suspend fun getSidoOptions(): List<String>
@@ -12,4 +14,8 @@ interface RegionOptionsRepository {
         sido: String,
         sigungu: String
     ): List<String>
+
+    suspend fun findRegionsByEupmyeondongKeyword(
+        keyword: String
+    ): List<Region>
 }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCase.kt
@@ -1,13 +1,42 @@
 package com.team.yeogibeoryeo.domain.region.usecase
 
 import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.region.repository.RegionOptionsRepository
 import com.team.yeogibeoryeo.domain.region.repository.RegionRepository
 import javax.inject.Inject
 
 class ResolveRegionFromKeywordUseCase @Inject constructor(
-    private val repository: RegionRepository
+    private val repository: RegionRepository,
+    private val regionOptionsRepository: RegionOptionsRepository
 ) {
-    suspend operator fun invoke(keyword: String): Region? {
-        return repository.resolveRegionFromKeyword(keyword)
+    suspend operator fun invoke(keyword: String): ResolveRegionFromKeywordResult {
+        val parsedRegion = repository.resolveRegionFromKeyword(keyword)
+
+        if (parsedRegion?.hasUpperRegion() == true) {
+            return ResolveRegionFromKeywordResult.Resolved(parsedRegion)
+        }
+
+        val eupmyeondongKeyword = parsedRegion?.eupmyeondong ?: keyword
+        val candidates = regionOptionsRepository.findRegionsByEupmyeondongKeyword(eupmyeondongKeyword)
+
+        return when {
+            candidates.size == 1 -> ResolveRegionFromKeywordResult.Resolved(candidates.first())
+            candidates.size > 1 -> ResolveRegionFromKeywordResult.Ambiguous
+            parsedRegion != null -> ResolveRegionFromKeywordResult.Resolved(parsedRegion)
+            else -> ResolveRegionFromKeywordResult.NotFound
+        }
     }
+
+    private fun Region.hasUpperRegion(): Boolean =
+        !sido.isNullOrBlank() || !sigungu.isNullOrBlank()
+}
+
+sealed interface ResolveRegionFromKeywordResult {
+    data class Resolved(
+        val region: Region
+    ) : ResolveRegionFromKeywordResult
+
+    data object Ambiguous : ResolveRegionFromKeywordResult
+
+    data object NotFound : ResolveRegionFromKeywordResult
 }

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCaseTest.kt
@@ -1,0 +1,196 @@
+package com.team.yeogibeoryeo.domain.region.usecase
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.region.repository.RegionOptionsRepository
+import com.team.yeogibeoryeo.domain.region.repository.RegionRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ResolveRegionFromKeywordUseCaseTest {
+
+    @Test
+    fun `읍면동 단독 검색어가 유일하면 상위 지역을 보완한다`() = runBlocking {
+        val useCase = ResolveRegionFromKeywordUseCase(
+            repository = FakeRegionRepository(
+                resolvedRegion = Region(eupmyeondong = "전의면")
+            ),
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                regions = listOf(
+                    Region(
+                        sido = "세종특별자치시",
+                        eupmyeondong = "전의면"
+                    )
+                )
+            )
+        )
+
+        val result = useCase("전의면")
+
+        val region = (result as ResolveRegionFromKeywordResult.Resolved).region
+
+        assertEquals("세종특별자치시", region.sido)
+        assertEquals(null, region.sigungu)
+        assertEquals("전의면", region.eupmyeondong)
+    }
+
+    @Test
+    fun `접미사 없는 읍면동 검색어가 유일하면 상위 지역을 보완한다`() = runBlocking {
+        val useCase = ResolveRegionFromKeywordUseCase(
+            repository = FakeRegionRepository(
+                resolvedRegion = null
+            ),
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                regions = listOf(
+                    Region(
+                        sido = "울산광역시",
+                        sigungu = "울주군",
+                        eupmyeondong = "언양읍"
+                    )
+                )
+            )
+        )
+
+        val result = useCase("언양")
+
+        val region = (result as ResolveRegionFromKeywordResult.Resolved).region
+
+        assertEquals("울산광역시", region.sido)
+        assertEquals("울주군", region.sigungu)
+        assertEquals("언양읍", region.eupmyeondong)
+    }
+
+    @Test
+    fun `읍면동 단독 검색어 후보가 여러 개면 임의로 보완하지 않는다`() = runBlocking {
+        val parsedRegion = Region(eupmyeondong = "중앙동")
+        val useCase = ResolveRegionFromKeywordUseCase(
+            repository = FakeRegionRepository(
+                resolvedRegion = parsedRegion
+            ),
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                regions = listOf(
+                    Region(
+                        sido = "경기도",
+                        sigungu = "성남시",
+                        eupmyeondong = "중앙동"
+                    ),
+                    Region(
+                        sido = "경상남도",
+                        sigungu = "창원시",
+                        eupmyeondong = "중앙동"
+                    )
+                )
+            )
+        )
+
+        val result = useCase("중앙동")
+
+        assertEquals(ResolveRegionFromKeywordResult.Ambiguous, result)
+    }
+
+    @Test
+    fun `접미사 없는 읍면동 검색어 후보가 여러 개면 임의로 보완하지 않는다`() = runBlocking {
+        val useCase = ResolveRegionFromKeywordUseCase(
+            repository = FakeRegionRepository(
+                resolvedRegion = null
+            ),
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                regions = listOf(
+                    Region(
+                        sido = "울산광역시",
+                        sigungu = "울주군",
+                        eupmyeondong = "온양읍"
+                    ),
+                    Region(
+                        sido = "충청남도",
+                        sigungu = "아산시",
+                        eupmyeondong = "온양1동"
+                    )
+                )
+            )
+        )
+
+        val result = useCase("온양")
+
+        assertEquals(ResolveRegionFromKeywordResult.Ambiguous, result)
+    }
+
+    @Test
+    fun `검색어로 해석할 지역이 없으면 NotFound를 반환한다`() = runBlocking {
+        val useCase = ResolveRegionFromKeywordUseCase(
+            repository = FakeRegionRepository(
+                resolvedRegion = null
+            ),
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                regions = emptyList()
+            )
+        )
+
+        val result = useCase("없는지역")
+
+        assertEquals(ResolveRegionFromKeywordResult.NotFound, result)
+    }
+
+    @Test
+    fun `시군구가 이미 있으면 지역 옵션 후보로 덮어쓰지 않는다`() = runBlocking {
+        val parsedRegion = Region(sigungu = "수원시")
+        val useCase = ResolveRegionFromKeywordUseCase(
+            repository = FakeRegionRepository(
+                resolvedRegion = parsedRegion
+            ),
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                regions = listOf(
+                    Region(
+                        sido = "경기도",
+                        sigungu = "수원시",
+                        eupmyeondong = "수원시"
+                    )
+                )
+            )
+        )
+
+        val result = useCase("수원시")
+
+        assertEquals(ResolveRegionFromKeywordResult.Resolved(parsedRegion), result)
+    }
+
+    private class FakeRegionRepository(
+        private val resolvedRegion: Region?
+    ) : RegionRepository {
+
+        override fun extractRegionFromAddress(address: String): Region? = resolvedRegion
+
+        override suspend fun resolveRegionFromKeyword(keyword: String): Region? = resolvedRegion
+
+        override suspend fun resolveRegionFromCoordinate(
+            latitude: Double,
+            longitude: Double
+        ): Region? = null
+    }
+
+    private class FakeRegionOptionsRepository(
+        private val regions: List<Region>
+    ) : RegionOptionsRepository {
+
+        override suspend fun getSidoOptions(): List<String> = emptyList()
+
+        override suspend fun getSigunguOptions(sido: String): List<String> = emptyList()
+
+        override suspend fun getEupmyeondongOptions(
+            sido: String,
+            sigungu: String
+        ): List<String> = emptyList()
+
+        override suspend fun findRegionsByEupmyeondongKeyword(
+            keyword: String
+        ): List<Region> {
+            val exactMatches = regions.filter { region -> region.eupmyeondong == keyword }
+
+            return exactMatches.ifEmpty {
+                regions.filter { region ->
+                    region.eupmyeondong?.startsWith(keyword) == true
+                }
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionSelectorSection
+import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideAmbiguousResult
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideEmptyResult
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideSearchBar
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideSummaryCard
@@ -167,6 +168,7 @@ private fun RegionalGuideUiState.queryOrNull(): String? =
         is RegionalGuideUiState.Loading -> query
         is RegionalGuideUiState.Success -> query
         is RegionalGuideUiState.Empty -> query
+        is RegionalGuideUiState.Ambiguous -> query
         is RegionalGuideUiState.Error -> query
     }?.takeIf { query -> query.isNotBlank() }
 
@@ -197,6 +199,13 @@ private fun RegionalGuideContent(
 
         is RegionalGuideUiState.Empty -> {
             RegionalGuideEmptyResult(
+                message = uiState.message,
+                modifier = modifier
+            )
+        }
+
+        is RegionalGuideUiState.Ambiguous -> {
+            RegionalGuideAmbiguousResult(
                 message = uiState.message,
                 modifier = modifier
             )
@@ -418,6 +427,30 @@ private fun RegionalGuideScreenEmptyPreview() {
                 message = "해당 지역의 배출 가이드 정보가 없습니다."
             ),
             searchKeyword = "없는 지역",
+            regionSelectorUiState = RegionSelectorUiState(
+                sidoOptions = listOf("서울특별시", "경기도", "인천광역시"),
+            ),
+            onSearchKeywordChange = {},
+            onSearchClick = {},
+            onRetryClick = {},
+            onSidoSelected = {},
+            onSigunguSelected = {},
+            onEupmyeondongSelected = {},
+            onRegionSelectionSearchClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RegionalGuideScreenAmbiguousPreview() {
+    MaterialTheme {
+        RegionalGuideScreen(
+            uiState = RegionalGuideUiState.Ambiguous(
+                query = "신흥동",
+                message = "여러 지역이 검색됩니다. 시도나 시군구를 함께 입력해주세요."
+            ),
+            searchKeyword = "신흥동",
             regionSelectorUiState = RegionSelectorUiState(
                 sidoOptions = listOf("서울특별시", "경기도", "인천광역시"),
             ),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
@@ -90,10 +90,11 @@ fun RegionalGuideScreen(
     modifier: Modifier = Modifier,
 ) {
     var isRegionSelectorExpanded by rememberSaveable { mutableStateOf(false) }
+    val compactRegionText = uiState.queryOrNull()
     val isRegionSelectorCompact =
         uiState !is RegionalGuideUiState.Idle &&
             !isRegionSelectorExpanded &&
-            regionSelectorUiState.selectedRegionText != null
+            compactRegionText != null
 
     Column(
         modifier = modifier
@@ -134,6 +135,7 @@ fun RegionalGuideScreen(
             RegionSelectorSection(
                 uiState = regionSelectorUiState,
                 compact = isRegionSelectorCompact,
+                compactRegionText = compactRegionText,
                 onSidoSelected = onSidoSelected,
                 onSigunguSelected = onSigunguSelected,
                 onEupmyeondongSelected = onEupmyeondongSelected,
@@ -158,6 +160,15 @@ fun RegionalGuideScreen(
         )
     }
 }
+
+private fun RegionalGuideUiState.queryOrNull(): String? =
+    when (this) {
+        RegionalGuideUiState.Idle -> null
+        is RegionalGuideUiState.Loading -> query
+        is RegionalGuideUiState.Success -> query
+        is RegionalGuideUiState.Empty -> query
+        is RegionalGuideUiState.Error -> query
+    }?.takeIf { query -> query.isNotBlank() }
 
 @Composable
 private fun RegionalGuideContent(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideUiState.kt
@@ -19,6 +19,11 @@ sealed interface RegionalGuideUiState {
         val message: String = "조회된 지역별 배출 가이드가 없습니다."
     ) : RegionalGuideUiState
 
+    data class Ambiguous(
+        val query: String,
+        val message: String
+    ) : RegionalGuideUiState
+
     data class Error(
         val query: String,
         val message: String

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
@@ -8,6 +8,7 @@ import com.team.yeogibeoryeo.domain.region.usecase.GetEupmyeondongOptionsUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.GetSidoOptionsUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.GetSigunguOptionsUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.ResolveRegionFromKeywordUseCase
+import com.team.yeogibeoryeo.domain.region.usecase.ResolveRegionFromKeywordResult
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
 import com.team.yeogibeoryeo.domain.regionalguide.usecase.GetRegionalDisposalGuideUseCase
 import com.team.yeogibeoryeo.presentation.regionalguide.mapper.toUiModel
@@ -155,20 +156,28 @@ class RegionalGuideViewModel @Inject constructor(
             _uiState.value = RegionalGuideUiState.Loading(query = trimmedKeyword)
 
             try {
-                val region = resolveRegionFromKeywordUseCase(trimmedKeyword)
+                when (val result = resolveRegionFromKeywordUseCase(trimmedKeyword)) {
+                    ResolveRegionFromKeywordResult.Ambiguous -> {
+                        _uiState.value = RegionalGuideUiState.Empty(
+                            query = trimmedKeyword,
+                            message = "여러 지역이 검색됩니다. 시도나 시군구를 함께 입력해주세요."
+                        )
+                    }
 
-                if (region == null) {
-                    _uiState.value = RegionalGuideUiState.Empty(
-                        query = trimmedKeyword,
-                        message = "입력한 지역명을 찾을 수 없습니다."
-                    )
-                    return@launch
+                    ResolveRegionFromKeywordResult.NotFound -> {
+                        _uiState.value = RegionalGuideUiState.Empty(
+                            query = trimmedKeyword,
+                            message = "입력한 지역명을 찾을 수 없습니다."
+                        )
+                    }
+
+                    is ResolveRegionFromKeywordResult.Resolved -> {
+                        loadRegionalGuide(
+                            query = trimmedKeyword,
+                            region = result.region
+                        )
+                    }
                 }
-
-                loadRegionalGuide(
-                    query = trimmedKeyword,
-                    region = region
-                )
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
@@ -158,7 +158,7 @@ class RegionalGuideViewModel @Inject constructor(
             try {
                 when (val result = resolveRegionFromKeywordUseCase(trimmedKeyword)) {
                     ResolveRegionFromKeywordResult.Ambiguous -> {
-                        _uiState.value = RegionalGuideUiState.Empty(
+                        _uiState.value = RegionalGuideUiState.Ambiguous(
                             query = trimmedKeyword,
                             message = "여러 지역이 검색됩니다. 시도나 시군구를 함께 입력해주세요."
                         )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionSelectorSection.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionSelectorSection.kt
@@ -35,6 +35,7 @@ import com.team.yeogibeoryeo.presentation.regionalguide.RegionSelectorUiState
 fun RegionSelectorSection(
     uiState: RegionSelectorUiState,
     compact: Boolean = false,
+    compactRegionText: String? = uiState.selectedRegionText,
     onSidoSelected: (String) -> Unit,
     onSigunguSelected: (String) -> Unit,
     onEupmyeondongSelected: (String) -> Unit,
@@ -42,11 +43,9 @@ fun RegionSelectorSection(
     onChangeClick: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    val selectedRegionText = uiState.selectedRegionText
-
-    if (compact && selectedRegionText != null) {
+    if (compact && compactRegionText != null) {
         RegionSelectorCompactCard(
-            selectedRegionText = selectedRegionText,
+            selectedRegionText = compactRegionText,
             onChangeClick = onChangeClick,
             modifier = modifier,
         )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideAmbiguousResult.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideAmbiguousResult.kt
@@ -1,0 +1,62 @@
+package com.team.yeogibeoryeo.presentation.regionalguide.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun RegionalGuideAmbiguousResult(
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        ),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "지역을 더 구체적으로 입력해주세요",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RegionalGuideAmbiguousResultPreview() {
+    MaterialTheme {
+        RegionalGuideAmbiguousResult(
+            message = "여러 지역이 검색됩니다. 시도나 시군구를 함께 입력해주세요.",
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 기존 `RegionAddressParser`와 `ExtractRegionFromAddressUseCase` 흐름을 지도 선택 장소 주소에서도 재사용할 수 있도록 파싱 기준을 보강했습니다.
- 시도 판별 기준을 `RegionNormalizer`로 통합하고, 축약/과거 시도명을 공식 시도명으로 정규화했습니다.
- `수원시`, `광주시` 같은 시군구 단독 검색어가 시도명으로 오인되지 않도록 수정했습니다.
- `/getSpot` 주소 형식에 대비해 도로명 주소와 괄호 안 동명 포함 주소 파싱 케이스를 보강했습니다.
- `전의면`, `언양`처럼 읍면동 단독 또는 접미사 없는 검색어가 유일 후보인 경우 상위 지역 정보를 보완하도록 처리했습니다.
- `온양`처럼 여러 지역 후보가 존재하는 검색어는 임의 선택하지 않고, 시도/시군구를 함께 입력하도록 안내 상태를 분리했습니다.
- 지역명 검색 결과를 `Resolved / Ambiguous / NotFound`로 구분하여 다중 후보 검색어에 대한 안내 메시지를 표시하도록 수정했습니다.
- 모호한 지역명 검색 결과가 “조회 결과 없음”처럼 보이지 않도록 `Ambiguous` 상태와 별도 안내 UI를 추가했습니다.
- 지역 선택 옵션과 검색 후보 목록을 지역명 기준으로 정렬했습니다.
- 선택한 시도와 다른 `/info` 응답 후보가 화면에 표시되지 않도록 현재 구조 안에서 `CTPV_NM` 기준 최소 필터링을 추가했습니다.
- `MNG_ZONE_TRGT_RGN_NM`의 설명형 값이 `Region.eupmyeondong`을 덮어쓰지 않도록 보강했습니다.
- 직접 검색 후 지역 선택 compact 영역에 이전 선택값이 남지 않도록 표시 텍스트를 조회 query 기준으로 보정했습니다.
- 주소 파싱, 지역 검색, 지역 가이드 매핑 관련 단위 테스트를 추가/보강했습니다.

## 테스트

- [x] 관련 단위 테스트 통과 확인
  - `com.team.yeogibeoryeo.domain.region.*`
  - `com.team.yeogibeoryeo.data.region.*`
  - `com.team.yeogibeoryeo.data.regionalguide.*`
- [x] 에뮬레이터에서 주요 검색 케이스 확인
  - `언양` 검색 성공
  - `온양` 다중 후보 안내
  - `서울특별시 > 중구` 선택 조회
- [x] GitHub Actions CI 통과 확인

## 확인한 주요 케이스

- `수원시` 검색 시 시도명이 아닌 시군구로 파싱되는 것 확인
- `광주시` 검색 시 시도명이 아닌 시군구로 파싱되는 것 확인
- `언양` 검색 시 유일 후보인 `언양읍`으로 지역 보완되는 것 확인
- `온양` 검색 시 조회 결과 없음이 아니라 구체적인 지역 입력 안내 UI가 표시되는 것 확인
- 지역 선택 옵션과 검색 후보 목록이 지역명 기준으로 정렬되는 것 확인
- `서울특별시 > 중구` 선택 시 다른 시도의 `중구` 데이터가 섞이지 않도록 후보 필터링되는 것 확인
- `MNG_ZONE_TRGT_RGN_NM=없음`, `서울시 중구`, `수원시 전체` 같은 값이 `Region.eupmyeondong`을 덮어쓰지 않는 것 확인

## 스크린샷

| 접미사 없는 검색 성공<br/>(`언양` 검색 결과 화면) | 다중 후보 안내<br/>(`온양` 검색 안내 화면) | 동일 시군구명 필터링<br/>(`서울특별시 > 중구` 선택 조회 화면) |
|---|---|---|
| <img width="100%" alt="Screenshot_20260529_181135" src="https://github.com/user-attachments/assets/d36d0367-a15d-4ce3-b313-2cad8f8d5743" /> | <img width="100%" alt="Screenshot_20260531_174033" src="https://github.com/user-attachments/assets/1a23dc7b-e3e6-477b-a3d0-5896646aae8a" /> | <img width="100%" alt="Screenshot_20260529_182234" src="https://github.com/user-attachments/assets/81006c7c-1f70-4fe9-b3df-d5f8b4d0658f" /> |

## 후속 작업

- `/info` 조회용 `SGG_NM` key 정규화와 후보 선택 책임 분리는 #60에서 진행합니다.
- 네트워크 실패 / API 오류 / 실제 조회 결과 없음 / 후보 필터링 결과 없음 상태 구분은 #60에서 정리합니다.
- 지도 화면에서 선택한 장소 주소를 지역 가이드 화면으로 전달하는 Navigation 연결은 #61에서 진행합니다.
- 다중 후보 검색어에 대해 후보 리스트를 보여주고 선택할 수 있는 UI는 별도 후속 작업으로 검토합니다.

## 관련 이슈

- Related #59