### PR TITLE
[Feat] 품목 가이드 즐겨찾기 기능 구현

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -20,7 +20,7 @@ import com.team.yeogibeoryeo.common.navigation.AppBottomNavigationBar
 import com.team.yeogibeoryeo.common.navigation.BottomNavigationItem
 import com.team.yeogibeoryeo.common.navigation.hasRouteName
 import com.team.yeogibeoryeo.common.navigation.navigateBottomTab
-import com.team.yeogibeoryeo.presentation.favorites.FavoritesScreen
+import com.team.yeogibeoryeo.presentation.favorites.FavoritesRoute as FavoritesScreenRoute
 import com.team.yeogibeoryeo.presentation.map.CollectionSpotMapScreen
 import com.team.yeogibeoryeo.presentation.regionalguide.RegionalGuideRoute as RegionalGuideScreenRoute
 import com.team.yeogibeoryeo.presentation.search.ItemGuideDetailRoute as ItemGuideDetailScreenRoute
@@ -86,7 +86,11 @@ fun YeogiBeoryeoNavHost(
             }
 
             composable<FavoritesRoute> {
-                FavoritesScreen()
+                FavoritesScreenRoute(
+                    onItemGuideClick = { guideId ->
+                        navController.navigate(ItemGuideDetailRoute(guideId = guideId))
+                    },
+                )
             }
 
             composable<ItemSearchRoute> { backStackEntry ->

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -40,6 +40,10 @@ dependencies {
     // Coroutine
     implementation(libs.bundles.coroutines)
 
+    // Room
+    implementation(libs.bundles.room)
+    ksp(libs.androidx.room.compiler)
+
     // Network
     implementation(libs.bundles.network)
 

--- a/data/src/androidTest/java/com/team/yeogibeoryeo/data/favorite/local/FavoriteDaoTest.kt
+++ b/data/src/androidTest/java/com/team/yeogibeoryeo/data/favorite/local/FavoriteDaoTest.kt
@@ -1,0 +1,99 @@
+package com.team.yeogibeoryeo.data.favorite.local
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FavoriteDaoTest {
+    private lateinit var database: FavoriteDatabase
+    private lateinit var dao: FavoriteDao
+
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        database =
+            Room.inMemoryDatabaseBuilder(
+                context,
+                FavoriteDatabase::class.java,
+            ).build()
+        dao = database.favoriteDao()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun toggleFavorite_addsFavorite_whenTargetIsNotSaved() =
+        runBlocking {
+            val entity = favoriteEntity(type = "ITEM_GUIDE", targetId = "paper-pack")
+
+            val isFavorite = dao.toggleFavorite(entity)
+
+            assertTrue(isFavorite)
+            assertTrue(dao.isFavorite(type = "ITEM_GUIDE", targetId = "paper-pack"))
+        }
+
+    @Test
+    fun toggleFavorite_removesFavorite_whenTargetIsAlreadySaved() =
+        runBlocking {
+            val entity = favoriteEntity(type = "ITEM_GUIDE", targetId = "paper-pack")
+            dao.upsertFavorite(entity)
+
+            val isFavorite = dao.toggleFavorite(entity)
+
+            assertFalse(isFavorite)
+            assertFalse(dao.isFavorite(type = "ITEM_GUIDE", targetId = "paper-pack"))
+        }
+
+    @Test
+    fun observeFavorites_ordersFavoritesBySavedAtDescending() =
+        runBlocking {
+            val oldFavorite = favoriteEntity(type = "ITEM_GUIDE", targetId = "old", savedAtMillis = 1L)
+            val newFavorite = favoriteEntity(type = "ITEM_GUIDE", targetId = "new", savedAtMillis = 2L)
+
+            dao.upsertFavorite(oldFavorite)
+            dao.upsertFavorite(newFavorite)
+
+            assertEquals(listOf(newFavorite, oldFavorite), dao.observeFavorites().first())
+        }
+
+    @Test
+    fun favoritesWithSameTargetIdCanBeSavedForDifferentTypes() =
+        runBlocking {
+            val itemGuideFavorite = favoriteEntity(type = "ITEM_GUIDE", targetId = "shared-id")
+            val collectionSpotFavorite = favoriteEntity(type = "COLLECTION_SPOT", targetId = "shared-id")
+
+            dao.upsertFavorite(itemGuideFavorite)
+            dao.upsertFavorite(collectionSpotFavorite)
+
+            assertEquals(
+                setOf(itemGuideFavorite, collectionSpotFavorite),
+                dao.observeFavorites().first().toSet(),
+            )
+            assertTrue(dao.isFavorite(type = "ITEM_GUIDE", targetId = "shared-id"))
+            assertTrue(dao.isFavorite(type = "COLLECTION_SPOT", targetId = "shared-id"))
+        }
+
+    private fun favoriteEntity(
+        type: String,
+        targetId: String,
+        savedAtMillis: Long = 1L,
+    ): FavoriteEntity =
+        FavoriteEntity(
+            type = type,
+            targetId = targetId,
+            savedAtMillis = savedAtMillis,
+        )
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/di/FavoriteDataModule.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/di/FavoriteDataModule.kt
@@ -1,0 +1,42 @@
+package com.team.yeogibeoryeo.data.favorite.di
+
+import android.content.Context
+import androidx.room.Room
+import com.team.yeogibeoryeo.data.favorite.local.FavoriteDao
+import com.team.yeogibeoryeo.data.favorite.local.FavoriteDatabase
+import com.team.yeogibeoryeo.data.favorite.repository.FavoriteRepositoryImpl
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object FavoriteDatabaseModule {
+    @Provides
+    @Singleton
+    fun provideFavoriteDatabase(
+        @ApplicationContext context: Context,
+    ): FavoriteDatabase =
+        Room.databaseBuilder(
+            context,
+            FavoriteDatabase::class.java,
+            "yeogi_beoryeo_favorites.db",
+        ).build()
+
+    @Provides
+    @Singleton
+    fun provideFavoriteDao(database: FavoriteDatabase): FavoriteDao = database.favoriteDao()
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class FavoriteBindModule {
+    @Binds
+    @Singleton
+    abstract fun bindFavoriteRepository(repository: FavoriteRepositoryImpl): FavoriteRepository
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/FavoriteDao.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/FavoriteDao.kt
@@ -1,0 +1,59 @@
+package com.team.yeogibeoryeo.data.favorite.local
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface FavoriteDao {
+    @Query("SELECT * FROM favorites ORDER BY savedAtMillis DESC")
+    fun observeFavorites(): Flow<List<FavoriteEntity>>
+
+    @Query(
+        """
+        SELECT EXISTS(
+            SELECT 1 FROM favorites
+            WHERE type = :type AND targetId = :targetId
+        )
+        """,
+    )
+    fun observeFavorite(
+        type: String,
+        targetId: String,
+    ): Flow<Boolean>
+
+    @Query(
+        """
+        SELECT EXISTS(
+            SELECT 1 FROM favorites
+            WHERE type = :type AND targetId = :targetId
+        )
+        """,
+    )
+    suspend fun isFavorite(
+        type: String,
+        targetId: String,
+    ): Boolean
+
+    @Upsert
+    suspend fun upsertFavorite(entity: FavoriteEntity)
+
+    @Transaction
+    suspend fun toggleFavorite(entity: FavoriteEntity): Boolean {
+        return if (isFavorite(entity.type, entity.targetId)) {
+            deleteFavorite(entity.type, entity.targetId)
+            false
+        } else {
+            upsertFavorite(entity)
+            true
+        }
+    }
+
+    @Query("DELETE FROM favorites WHERE type = :type AND targetId = :targetId")
+    suspend fun deleteFavorite(
+        type: String,
+        targetId: String,
+    )
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/FavoriteDatabase.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/FavoriteDatabase.kt
@@ -1,0 +1,13 @@
+package com.team.yeogibeoryeo.data.favorite.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [FavoriteEntity::class],
+    version = 1,
+    exportSchema = false,
+)
+abstract class FavoriteDatabase : RoomDatabase() {
+    abstract fun favoriteDao(): FavoriteDao
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/FavoriteEntity.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/FavoriteEntity.kt
@@ -1,0 +1,13 @@
+package com.team.yeogibeoryeo.data.favorite.local
+
+import androidx.room.Entity
+
+@Entity(
+    tableName = "favorites",
+    primaryKeys = ["type", "targetId"],
+)
+data class FavoriteEntity(
+    val type: String,
+    val targetId: String,
+    val savedAtMillis: Long,
+)

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/mapper/FavoriteMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/mapper/FavoriteMapper.kt
@@ -1,0 +1,25 @@
+package com.team.yeogibeoryeo.data.favorite.mapper
+
+import com.team.yeogibeoryeo.data.favorite.local.FavoriteEntity
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+
+fun Favorite.toEntity(): FavoriteEntity =
+    FavoriteEntity(
+        type = type.name,
+        targetId = targetId,
+        savedAtMillis = savedAtMillis,
+    )
+
+fun FavoriteEntity.toDomain(): Favorite? {
+    val targetType =
+        runCatching {
+            FavoriteTargetType.valueOf(type)
+        }.getOrNull() ?: return null
+
+    return Favorite(
+        type = targetType,
+        targetId = targetId,
+        savedAtMillis = savedAtMillis,
+    )
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/repository/FavoriteRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/repository/FavoriteRepositoryImpl.kt
@@ -1,0 +1,45 @@
+package com.team.yeogibeoryeo.data.favorite.repository
+
+import com.team.yeogibeoryeo.data.favorite.local.FavoriteDao
+import com.team.yeogibeoryeo.data.favorite.mapper.toDomain
+import com.team.yeogibeoryeo.data.favorite.mapper.toEntity
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class FavoriteRepositoryImpl
+    @Inject
+    constructor(
+        private val favoriteDao: FavoriteDao,
+    ) : FavoriteRepository {
+        override fun observeFavorites(): Flow<List<Favorite>> =
+            favoriteDao.observeFavorites()
+                .map { entities -> entities.mapNotNull { it.toDomain() } }
+
+        override fun observeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Flow<Boolean> = favoriteDao.observeFavorite(type.name, targetId)
+
+        override suspend fun isFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Boolean = favoriteDao.isFavorite(type.name, targetId)
+
+        override suspend fun toggleFavorite(favorite: Favorite): Boolean =
+            favoriteDao.toggleFavorite(favorite.toEntity())
+
+        override suspend fun addFavorite(favorite: Favorite) {
+            favoriteDao.upsertFavorite(favorite.toEntity())
+        }
+
+        override suspend fun removeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ) {
+            favoriteDao.deleteFavorite(type.name, targetId)
+        }
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/Favorite.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/Favorite.kt
@@ -1,0 +1,7 @@
+package com.team.yeogibeoryeo.domain.favorite.model
+
+data class Favorite(
+    val type: FavoriteTargetType,
+    val targetId: String,
+    val savedAtMillis: Long,
+)

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/FavoriteTargetType.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/FavoriteTargetType.kt
@@ -1,0 +1,7 @@
+package com.team.yeogibeoryeo.domain.favorite.model
+
+enum class FavoriteTargetType {
+    ITEM_GUIDE,
+    COLLECTION_SPOT,
+    REGIONAL_GUIDE,
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/repository/FavoriteRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/repository/FavoriteRepository.kt
@@ -1,0 +1,28 @@
+package com.team.yeogibeoryeo.domain.favorite.repository
+
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import kotlinx.coroutines.flow.Flow
+
+interface FavoriteRepository {
+    fun observeFavorites(): Flow<List<Favorite>>
+
+    fun observeFavorite(
+        type: FavoriteTargetType,
+        targetId: String,
+    ): Flow<Boolean>
+
+    suspend fun isFavorite(
+        type: FavoriteTargetType,
+        targetId: String,
+    ): Boolean
+
+    suspend fun toggleFavorite(favorite: Favorite): Boolean
+
+    suspend fun addFavorite(favorite: Favorite)
+
+    suspend fun removeFavorite(
+        type: FavoriteTargetType,
+        targetId: String,
+    )
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ObserveFavoriteUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ObserveFavoriteUseCase.kt
@@ -1,0 +1,16 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import javax.inject.Inject
+
+class ObserveFavoriteUseCase
+    @Inject
+    constructor(
+        private val repository: FavoriteRepository,
+    ) {
+        operator fun invoke(
+            type: FavoriteTargetType,
+            targetId: String,
+        ) = repository.observeFavorite(type, targetId)
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ObserveFavoritesUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ObserveFavoritesUseCase.kt
@@ -1,0 +1,22 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.map
+
+class ObserveFavoritesUseCase
+    @Inject
+    constructor(
+        private val repository: FavoriteRepository,
+    ) {
+        operator fun invoke(type: FavoriteTargetType? = null) =
+            repository.observeFavorites()
+                .map { favorites ->
+                    if (type == null) {
+                        favorites
+                    } else {
+                        favorites.filter { it.type == type }
+                    }
+                }
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ToggleFavoriteUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ToggleFavoriteUseCase.kt
@@ -1,0 +1,13 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import javax.inject.Inject
+
+class ToggleFavoriteUseCase
+    @Inject
+    constructor(
+        private val repository: FavoriteRepository,
+    ) {
+        suspend operator fun invoke(favorite: Favorite): Boolean = repository.toggleFavorite(favorite)
+    }

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/usecase/FavoriteUseCasesTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/usecase/FavoriteUseCasesTest.kt
@@ -1,0 +1,143 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FavoriteUseCasesTest {
+    @Test
+    fun `ObserveFavoritesUseCase는 저장소의 즐겨찾기 목록을 반환한다`() =
+        runBlocking {
+            val favorite = sampleFavorite("종이")
+            val repository = FakeFavoriteRepository(initialFavorites = listOf(favorite))
+
+            val result = ObserveFavoritesUseCase(repository).invoke().first()
+
+            assertEquals(listOf(favorite), result)
+        }
+
+    @Test
+    fun `ObserveFavoritesUseCase는 대상 타입으로 즐겨찾기 목록을 필터링한다`() =
+        runBlocking {
+            val itemGuideFavorite = sampleFavorite("종이")
+            val collectionSpotFavorite =
+                sampleFavorite(
+                    targetId = "spot-1",
+                    type = FavoriteTargetType.COLLECTION_SPOT,
+                )
+            val repository =
+                FakeFavoriteRepository(
+                    initialFavorites = listOf(itemGuideFavorite, collectionSpotFavorite),
+                )
+
+            val result =
+                ObserveFavoritesUseCase(repository)
+                    .invoke(FavoriteTargetType.COLLECTION_SPOT)
+                    .first()
+
+            assertEquals(listOf(collectionSpotFavorite), result)
+        }
+
+    @Test
+    fun `ObserveFavoriteUseCase는 특정 대상의 즐겨찾기 여부를 반환한다`() =
+        runBlocking {
+            val favorite = sampleFavorite("종이")
+            val repository = FakeFavoriteRepository(initialFavorites = listOf(favorite))
+
+            val result =
+                ObserveFavoriteUseCase(repository)
+                    .invoke(FavoriteTargetType.ITEM_GUIDE, "종이")
+                    .first()
+
+            assertTrue(result)
+        }
+
+    @Test
+    fun `ToggleFavoriteUseCase는 즐겨찾기가 아니면 추가한다`() =
+        runBlocking {
+            val favorite = sampleFavorite("종이")
+            val repository = FakeFavoriteRepository()
+
+            val result = ToggleFavoriteUseCase(repository).invoke(favorite)
+
+            assertTrue(result)
+            assertEquals(listOf(favorite), repository.observeFavorites().first())
+        }
+
+    @Test
+    fun `ToggleFavoriteUseCase는 이미 즐겨찾기면 제거한다`() =
+        runBlocking {
+            val favorite = sampleFavorite("종이")
+            val repository = FakeFavoriteRepository(initialFavorites = listOf(favorite))
+
+            val result = ToggleFavoriteUseCase(repository).invoke(favorite)
+
+            assertFalse(result)
+            assertFalse(repository.isFavorite(FavoriteTargetType.ITEM_GUIDE, "종이"))
+        }
+
+    private fun sampleFavorite(
+        targetId: String,
+        type: FavoriteTargetType = FavoriteTargetType.ITEM_GUIDE,
+    ): Favorite =
+        Favorite(
+            type = type,
+            targetId = targetId,
+            savedAtMillis = 1L,
+        )
+
+    private class FakeFavoriteRepository(
+        initialFavorites: List<Favorite> = emptyList(),
+    ) : FavoriteRepository {
+        private val favorites = MutableStateFlow(initialFavorites)
+
+        override fun observeFavorites(): Flow<List<Favorite>> = favorites
+
+        override fun observeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Flow<Boolean> =
+            favorites.map { items ->
+                items.any { it.type == type && it.targetId == targetId }
+            }
+
+        override suspend fun isFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Boolean =
+            favorites.value.any { it.type == type && it.targetId == targetId }
+
+        override suspend fun toggleFavorite(favorite: Favorite): Boolean {
+            return if (isFavorite(favorite.type, favorite.targetId)) {
+                removeFavorite(favorite.type, favorite.targetId)
+                false
+            } else {
+                addFavorite(favorite)
+                true
+            }
+        }
+
+        override suspend fun addFavorite(favorite: Favorite) {
+            favorites.value =
+                favorites.value
+                    .filterNot { it.type == favorite.type && it.targetId == favorite.targetId } + favorite
+        }
+
+        override suspend fun removeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ) {
+            favorites.value =
+                favorites.value.filterNot { it.type == type && it.targetId == targetId }
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesRoute.kt
@@ -1,0 +1,22 @@
+package com.team.yeogibeoryeo.presentation.favorites
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.ui.Modifier
+
+@Composable
+fun FavoritesRoute(
+    onItemGuideClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: FavoritesViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    FavoritesScreen(
+        uiState = uiState,
+        onItemGuideClick = onItemGuideClick,
+        modifier = modifier,
+    )
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreen.kt
@@ -3,57 +3,75 @@ package com.team.yeogibeoryeo.presentation.favorites
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.presentation.favorites.components.EmptyFavoritesCard
+import com.team.yeogibeoryeo.presentation.favorites.components.FavoriteCard
 
 @Composable
 fun FavoritesScreen(
+    uiState: FavoritesUiState,
+    onItemGuideClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
+    LazyColumn(
         modifier =
             modifier
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background)
-                .padding(horizontal = 20.dp)
-                .padding(top = 20.dp),
+                .padding(horizontal = 20.dp),
+        contentPadding = PaddingValues(top = 20.dp, bottom = 24.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        Text(
-            text = "즐겨찾기",
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-        )
+        item {
+            Text(
+                text = "즐겨찾기",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+            )
+        }
 
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant,
-            ),
-        ) {
-            Column(
-                modifier = Modifier.padding(20.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Text(
-                    text = "즐겨찾기 화면은 준비 중입니다",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                Text(
-                    text = "저장된 장소와 품목 가이드 확인 기능은 후속 작업에서 연결할 예정입니다.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+        when {
+            uiState.isLoading -> {
+                item {
+                    Column(
+                        modifier = Modifier
+                            .fillParentMaxSize()
+                            .padding(top = 96.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+            }
+
+            uiState.favorites.isEmpty() -> {
+                item {
+                    EmptyFavoritesCard()
+                }
+            }
+
+            else -> {
+                items(
+                    items = uiState.favorites,
+                    key = { it.targetId },
+                ) { favorite ->
+                    FavoriteCard(
+                        favorite = favorite,
+                        onClick = { onItemGuideClick(favorite.targetId) },
+                    )
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreenPreview.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreenPreview.kt
@@ -1,0 +1,69 @@
+package com.team.yeogibeoryeo.presentation.favorites
+
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.team.yeogibeoryeo.common.design.theme.YeogiBeoryeoTheme
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteItemUiModel
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+private fun FavoritesScreenLoadingPreview() {
+    FavoriteScreenPreviewContainer {
+        FavoritesScreen(
+            uiState = FavoritesUiState(isLoading = true),
+            onItemGuideClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+private fun FavoritesScreenEmptyPreview() {
+    FavoriteScreenPreviewContainer {
+        FavoritesScreen(
+            uiState = FavoritesUiState(),
+            onItemGuideClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+private fun FavoritesScreenListPreview() {
+    FavoriteScreenPreviewContainer {
+        FavoritesScreen(
+            uiState =
+                FavoritesUiState(
+                    favorites =
+                        listOf(
+                            FavoriteItemUiModel(
+                                targetId = "paper-pack",
+                                title = "종이팩",
+                                subtitle = "종이팩",
+                            ),
+                            FavoriteItemUiModel(
+                                targetId = "large-waste",
+                                title = "대형폐기물",
+                                subtitle = "대형폐기물",
+                            ),
+                            FavoriteItemUiModel(
+                                targetId = "very-long-title",
+                                title = "아주 긴 이름의 즐겨찾기 품목 가이드",
+                                subtitle = "생활계 유해폐기물",
+                            ),
+                        ),
+                ),
+            onItemGuideClick = {},
+        )
+    }
+}
+
+@Composable
+private fun FavoriteScreenPreviewContainer(content: @Composable () -> Unit) {
+    YeogiBeoryeoTheme {
+        Surface {
+            content()
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesUiState.kt
@@ -1,0 +1,8 @@
+package com.team.yeogibeoryeo.presentation.favorites
+
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteItemUiModel
+
+data class FavoritesUiState(
+    val isLoading: Boolean = false,
+    val favorites: List<FavoriteItemUiModel> = emptyList(),
+)

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModel.kt
@@ -1,0 +1,45 @@
+package com.team.yeogibeoryeo.presentation.favorites
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
+import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalItemGuideUseCase
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteItemUiModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel
+class FavoritesViewModel
+    @Inject
+    constructor(
+        observeFavoritesUseCase: ObserveFavoritesUseCase,
+        private val getDisposalItemGuideUseCase: GetDisposalItemGuideUseCase,
+    ) : ViewModel() {
+        val uiState: StateFlow<FavoritesUiState> =
+            observeFavoritesUseCase(FavoriteTargetType.ITEM_GUIDE)
+                .map { favorites ->
+                    FavoritesUiState(
+                        favorites =
+                            favorites.mapNotNull { favorite ->
+                                val guide = getDisposalItemGuideUseCase(favorite.targetId)
+                                guide?.let {
+                                    FavoriteItemUiModel(
+                                        targetId = favorite.targetId,
+                                        title = it.name,
+                                        subtitle = it.subCategory?.displayName ?: it.category.displayName,
+                                    )
+                                }
+                            },
+                    )
+                }
+                .stateIn(
+                    scope = viewModelScope,
+                    started = SharingStarted.WhileSubscribed(5_000),
+                    initialValue = FavoritesUiState(isLoading = true),
+                )
+    }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/components/EmptyFavoritesCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/components/EmptyFavoritesCard.kt
@@ -1,0 +1,53 @@
+package com.team.yeogibeoryeo.presentation.favorites.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun EmptyFavoritesCard(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.FavoriteBorder,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.tertiary,
+            )
+            Text(
+                text = "아직 즐겨찾기한 품목이 없어요",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = "품목 가이드 상세 화면에서 하트를 누르면 여기에 모아볼 수 있어요.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/components/FavoriteCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/components/FavoriteCard.kt
@@ -1,0 +1,98 @@
+package com.team.yeogibeoryeo.presentation.favorites.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteItemUiModel
+
+@Composable
+fun FavoriteCard(
+    favorite: FavoriteItemUiModel,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = favorite.title,
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 18.sp,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                favorite.subtitle?.let { subtitle ->
+                    FavoriteMetadataChip(text = subtitle)
+                }
+            }
+
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.outlineVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FavoriteMetadataChip(text: String) {
+    Text(
+        text = text,
+        modifier =
+            Modifier
+                .background(
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                    shape = RoundedCornerShape(8.dp),
+                )
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.onSecondaryContainer,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+    )
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/components/FavoriteSnackbar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/components/FavoriteSnackbar.kt
@@ -1,0 +1,61 @@
+package com.team.yeogibeoryeo.presentation.favorites.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.common.design.theme.YeogiBeoryeoTheme
+
+@Composable
+fun FavoriteSnackbar(
+    message: String,
+    modifier: Modifier = Modifier,
+) {
+    Snackbar(
+        modifier = modifier.padding(16.dp),
+        shape = RoundedCornerShape(12.dp),
+        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.Filled.Favorite,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.tertiary,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+private fun FavoriteSnackbarPreview() {
+    YeogiBeoryeoTheme {
+        Box(
+            modifier = Modifier.size(width = 360.dp, height = 160.dp),
+            contentAlignment = Alignment.BottomCenter,
+        ) {
+            FavoriteSnackbar(message = "즐겨찾기에 추가되었습니다")
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/model/FavoriteItemUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/model/FavoriteItemUiModel.kt
@@ -1,0 +1,7 @@
+package com.team.yeogibeoryeo.presentation.favorites.model
+
+data class FavoriteItemUiModel(
+    val targetId: String,
+    val title: String,
+    val subtitle: String?,
+)

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailRoute.kt
@@ -3,14 +3,19 @@ package com.team.yeogibeoryeo.presentation.search
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -18,6 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.team.yeogibeoryeo.presentation.favorites.components.FavoriteSnackbar
 
 @Composable
 fun ItemGuideDetailRoute(
@@ -27,49 +33,72 @@ fun ItemGuideDetailRoute(
     viewModel: ItemGuideDetailViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(guideId) {
         viewModel.loadGuide(guideId)
     }
 
-    when (val state = uiState) {
-        ItemGuideDetailUiState.Loading -> {
-            Box(
-                modifier = modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator()
+    val favoriteMessage = (uiState as? ItemGuideDetailUiState.Success)?.favoriteMessage
+    LaunchedEffect(favoriteMessage) {
+        val message = favoriteMessage ?: return@LaunchedEffect
+        snackbarHostState.showSnackbar(message)
+        viewModel.clearFavoriteMessage()
+    }
+
+    Scaffold(
+        modifier = modifier,
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState) { snackbarData ->
+                FavoriteSnackbar(message = snackbarData.visuals.message)
             }
-        }
+        },
+        contentWindowInsets = WindowInsets(0.dp),
+    ) { innerPadding ->
+        when (val state = uiState) {
+            ItemGuideDetailUiState.Loading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
 
-        is ItemGuideDetailUiState.Success -> {
-            ItemGuideDetailScreen(
-                guide = state.guide,
-                onBackClick = onBackClick,
-                modifier = modifier,
-            )
-        }
+            is ItemGuideDetailUiState.Success -> {
+                ItemGuideDetailScreen(
+                    guide = state.guide,
+                    isFavorite = state.isFavorite,
+                    onBackClick = onBackClick,
+                    onFavoriteClick = viewModel::toggleFavorite,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
 
-        is ItemGuideDetailUiState.Error -> {
-            Column(
-                modifier = modifier
-                    .fillMaxSize()
-                    .padding(24.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Text(
-                    text = "품목 가이드를 찾을 수 없습니다",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                Text(
-                    text = state.message,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Button(onClick = onBackClick) {
-                    Text("돌아가기")
+            is ItemGuideDetailUiState.Error -> {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding)
+                        .padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = "품목 가이드를 찾을 수 없습니다",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        text = state.message,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Button(onClick = onBackClick) {
+                        Text("돌아가기")
+                    }
                 }
             }
         }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -43,10 +45,13 @@ import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCatego
 @Composable
 fun ItemGuideDetailScreen(
     guide: DisposalItemGuide,
+    isFavorite: Boolean,
     onBackClick: () -> Unit,
+    onFavoriteClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val backActionDescription = stringResource(R.string.back_action)
+    val favoriteActionDescription = if (isFavorite) "즐겨찾기 해제" else "즐겨찾기 추가"
     val representativeCategory =
         RepresentativeGuideCategory.fromGuideName(guide.name)
             ?: RepresentativeGuideCategory.fromDisposalCategory(guide.category)
@@ -64,15 +69,37 @@ fun ItemGuideDetailScreen(
             ),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        IconButton(onClick = onBackClick) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
-                contentDescription = backActionDescription,
-                modifier = Modifier.semantics {
-                    contentDescription = backActionDescription
-                },
-                tint = MaterialTheme.colorScheme.onSurface,
-            )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onBackClick) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                    contentDescription = backActionDescription,
+                    modifier = Modifier.semantics {
+                        contentDescription = backActionDescription
+                    },
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+
+            IconButton(onClick = onFavoriteClick) {
+                Icon(
+                    imageVector = if (isFavorite) {
+                        Icons.Filled.Favorite
+                    } else {
+                        Icons.Outlined.FavoriteBorder
+                    },
+                    contentDescription = favoriteActionDescription,
+                    tint = if (isFavorite) {
+                        MaterialTheme.colorScheme.tertiary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                )
+            }
         }
 
         Row(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModel.kt
@@ -2,14 +2,20 @@ package com.team.yeogibeoryeo.presentation.search
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoriteUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ToggleFavoriteUseCase
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalItemGuideUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -17,29 +23,92 @@ class ItemGuideDetailViewModel
 @Inject
 constructor(
     private val getDisposalItemGuideUseCase: GetDisposalItemGuideUseCase,
+    private val observeFavoriteUseCase: ObserveFavoriteUseCase,
+    private val toggleFavoriteUseCase: ToggleFavoriteUseCase,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<ItemGuideDetailUiState>(ItemGuideDetailUiState.Loading)
     val uiState: StateFlow<ItemGuideDetailUiState> = _uiState.asStateFlow()
+    private var loadGuideJob: Job? = null
+    private var favoriteJob: Job? = null
 
     fun loadGuide(guideId: String) {
-        viewModelScope.launch {
-            _uiState.value = ItemGuideDetailUiState.Loading
+        loadGuideJob?.cancel()
+        loadGuideJob =
+            viewModelScope.launch {
+                favoriteJob?.cancel()
+                _uiState.value = ItemGuideDetailUiState.Loading
 
-            try {
-                val guide = getDisposalItemGuideUseCase(guideId)
+                try {
+                    val guide = getDisposalItemGuideUseCase(guideId)
 
-                _uiState.value =
                     if (guide != null) {
-                        ItemGuideDetailUiState.Success(guide)
+                        _uiState.value = ItemGuideDetailUiState.Success(guide = guide)
+                        observeFavorite(guide)
                     } else {
-                        ItemGuideDetailUiState.Error("다시 검색해서 품목을 선택해주세요.")
+                        _uiState.value = ItemGuideDetailUiState.Error("다시 검색해서 품목을 선택해주세요.")
                     }
-            } catch (exception: CancellationException) {
-                throw exception
-            } catch (exception: Throwable) {
-                _uiState.value = ItemGuideDetailUiState.Error("품목 정보를 불러오는 중 오류가 발생했습니다.")
+                } catch (exception: CancellationException) {
+                    throw exception
+                } catch (exception: Throwable) {
+                    _uiState.value = ItemGuideDetailUiState.Error("품목 정보를 불러오는 중 오류가 발생했습니다.")
+                }
+            }
+    }
+
+    fun toggleFavorite() {
+        val currentState = _uiState.value as? ItemGuideDetailUiState.Success ?: return
+        val guide = currentState.guide
+
+        viewModelScope.launch {
+            val isFavorite =
+                toggleFavoriteUseCase(
+                    Favorite(
+                        type = FavoriteTargetType.ITEM_GUIDE,
+                        targetId = guide.id,
+                        savedAtMillis = System.currentTimeMillis(),
+                    ),
+                )
+            _uiState.update { state ->
+                if (state is ItemGuideDetailUiState.Success && state.guide.id == guide.id) {
+                    state.copy(
+                        favoriteMessage =
+                            if (isFavorite) {
+                                "즐겨찾기에 추가되었습니다"
+                            } else {
+                                "즐겨찾기에서 제외되었습니다"
+                            },
+                    )
+                } else {
+                    state
+                }
             }
         }
+    }
+
+    fun clearFavoriteMessage() {
+        _uiState.update { state ->
+            if (state is ItemGuideDetailUiState.Success) {
+                state.copy(favoriteMessage = null)
+            } else {
+                state
+            }
+        }
+    }
+
+    private fun observeFavorite(guide: DisposalItemGuide) {
+        favoriteJob =
+            viewModelScope.launch {
+                observeFavoriteUseCase(FavoriteTargetType.ITEM_GUIDE, guide.id)
+                    .collect { isFavorite ->
+                        _uiState.update { state ->
+                            if (state is ItemGuideDetailUiState.Success && state.guide.id == guide.id) {
+                                state.copy(isFavorite = isFavorite)
+                            } else {
+                                state
+                            }
+                        }
+                    }
+            }
     }
 }
 
@@ -48,6 +117,8 @@ sealed interface ItemGuideDetailUiState {
 
     data class Success(
         val guide: DisposalItemGuide,
+        val isFavorite: Boolean = false,
+        val favoriteMessage: String? = null,
     ) : ItemGuideDetailUiState
 
     data class Error(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -54,11 +55,12 @@ import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCatego
 @Composable
 fun ItemSearchRoute(
     initialQuery: String? = null,
-    onGuideSelected: ((DisposalItemGuide) -> Unit)? = null,
+    onGuideSelected: (DisposalItemGuide) -> Unit,
     viewModel: ItemSearchViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val selectedGuide = uiState.selectedGuide
+    val pendingGuideToOpen = uiState.pendingGuideToOpen
+    val currentOnGuideSelected by rememberUpdatedState(onGuideSelected)
 
     val searchResultListState = rememberLazyListState()
     val categoryListState = rememberLazyListState()
@@ -75,20 +77,11 @@ fun ItemSearchRoute(
         }
     }
 
-    LaunchedEffect(selectedGuide?.id, onGuideSelected) {
-        if (selectedGuide != null && onGuideSelected != null) {
-            onGuideSelected(selectedGuide)
-            viewModel.clearSelectedGuide()
+    LaunchedEffect(pendingGuideToOpen?.id) {
+        if (pendingGuideToOpen != null) {
+            currentOnGuideSelected(pendingGuideToOpen)
+            viewModel.clearPendingGuideToOpen()
         }
-    }
-
-    if (selectedGuide != null && onGuideSelected == null) {
-        BackHandler(onBack = viewModel::clearSelectedGuide)
-        ItemGuideDetailScreen(
-            guide = selectedGuide,
-            onBackClick = viewModel::clearSelectedGuide,
-        )
-        return
     }
 
     if (uiState.hasSearched) {
@@ -99,13 +92,7 @@ fun ItemSearchRoute(
         uiState = uiState,
         onQueryChange = viewModel::onQueryChange,
         onSearchClick = viewModel::search,
-        onGuideClick = {
-            if (onGuideSelected != null) {
-                onGuideSelected(it)
-            } else {
-                viewModel.selectGuide(it)
-            }
-        },
+        onGuideClick = onGuideSelected,
         onQuickCategoryClick = viewModel::openCategoryGuide,
         searchResultListState = searchResultListState,
         categoryListState = categoryListState,
@@ -294,6 +281,7 @@ fun ItemSearchScreen(
                             DisposalItemCard(
                                 guide = guide,
                                 onClick = { onGuideClick(guide) },
+                                isFavorite = guide.id in uiState.favoriteGuideIds,
                             )
                         }
                     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchUiState.kt
@@ -6,7 +6,8 @@ import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 data class ItemSearchUiState(
     val query: String = "",
     val guides: List<DisposalItemGuide> = emptyList(),
-    val selectedGuide: DisposalItemGuide? = null,
+    val favoriteGuideIds: Set<String> = emptySet(),
+    val pendingGuideToOpen: DisposalItemGuide? = null,
     val isLoading: Boolean = false,
     val hasSearched: Boolean = false,
     @param:StringRes val errorMessageResId: Int? = null,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModel.kt
@@ -2,6 +2,8 @@ package com.team.yeogibeoryeo.presentation.search
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalCategoryGuidesUseCase
 import com.team.yeogibeoryeo.domain.item.usecase.SearchDisposalItemGuidesUseCase
@@ -23,10 +25,27 @@ class ItemSearchViewModel
 constructor(
     private val searchDisposalItemGuidesUseCase: SearchDisposalItemGuidesUseCase,
     private val getDisposalCategoryGuidesUseCase: GetDisposalCategoryGuidesUseCase,
+    observeFavoritesUseCase: ObserveFavoritesUseCase,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(ItemSearchUiState())
     val uiState: StateFlow<ItemSearchUiState> = _uiState.asStateFlow()
     private var searchJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            observeFavoritesUseCase(FavoriteTargetType.ITEM_GUIDE)
+                .collect { favorites ->
+                    _uiState.update { state ->
+                        state.copy(
+                            favoriteGuideIds =
+                                favorites
+                                    .map { it.targetId }
+                                    .toSet(),
+                        )
+                    }
+                }
+        }
+    }
 
     fun onQueryChange(query: String) {
         searchJob?.cancel()
@@ -34,7 +53,7 @@ constructor(
             it.copy(
                 query = query,
                 guides = emptyList(),
-                selectedGuide = null,
+                pendingGuideToOpen = null,
                 isLoading = false,
                 hasSearched = false,
                 errorMessageResId = null,
@@ -42,12 +61,8 @@ constructor(
         }
     }
 
-    fun selectGuide(guide: DisposalItemGuide) {
-        _uiState.update { it.copy(selectedGuide = guide) }
-    }
-
-    fun clearSelectedGuide() {
-        _uiState.update { it.copy(selectedGuide = null) }
+    fun clearPendingGuideToOpen() {
+        _uiState.update { it.copy(pendingGuideToOpen = null) }
     }
 
     fun clearSearch() {
@@ -74,7 +89,7 @@ constructor(
             _uiState.update {
                 it.copy(
                     guides = emptyList(),
-                    selectedGuide = null,
+                    pendingGuideToOpen = null,
                     hasSearched = false,
                     errorMessageResId = null,
                 )
@@ -88,7 +103,7 @@ constructor(
                 _uiState.update {
                     it.copy(
                         isLoading = true,
-                        selectedGuide = null,
+                        pendingGuideToOpen = null,
                         hasSearched = true,
                         errorMessageResId = null,
                     )
@@ -107,7 +122,7 @@ constructor(
                         _uiState.update {
                             it.copy(
                                 guides = emptyList(),
-                                selectedGuide = null,
+                                pendingGuideToOpen = null,
                                 isLoading = false,
                                 errorMessageResId = R.string.search_load_failed_message,
                             )
@@ -123,7 +138,7 @@ constructor(
                 _uiState.update {
                     it.copy(
                         isLoading = true,
-                        selectedGuide = null,
+                        pendingGuideToOpen = null,
                         errorMessageResId = null,
                     )
                 }
@@ -137,7 +152,7 @@ constructor(
                         _uiState.update {
                             it.copy(
                                 isLoading = false,
-                                selectedGuide = representativeGuide,
+                                pendingGuideToOpen = representativeGuide,
                             )
                         }
                     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
@@ -3,13 +3,16 @@ package com.team.yeogibeoryeo.presentation.search.components
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -18,28 +21,32 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.foundation.layout.size
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.team.yeogibeoryeo.domain.item.model.DisposalInstruction
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
-import com.team.yeogibeoryeo.domain.item.model.DisposalSubCategory
 
-/**
- * 검색 결과 리스트에 표시되는 개별 품목 카드입니다.
- * 흰색 배경과 연한 테두리를 적용하여 가독성과 클릭 유도성을 높였습니다.
- */
 @Composable
 fun DisposalItemCard(
     guide: DisposalItemGuide,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isFavorite: Boolean = false,
 ) {
     Card(
         modifier = modifier
             .fillMaxWidth()
+            .semantics {
+                stateDescription =
+                    if (isFavorite) {
+                        "즐겨찾기됨"
+                    } else {
+                        "즐겨찾기 안 됨"
+                    }
+            }
             .clickable(onClick = onClick),
         shape = RoundedCornerShape(20.dp),
         colors = CardDefaults.cardColors(
@@ -48,49 +55,67 @@ fun DisposalItemCard(
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
-        Row(
+        Box(
             modifier = Modifier
                 .padding(20.dp)
                 .fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Text(
-                    text = guide.name,
-                    style = MaterialTheme.typography.titleMedium.copy(
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 18.sp,
-                        color = MaterialTheme.colorScheme.onSurface
-                    ),
+            if (isFavorite) {
+                Icon(
+                    imageVector = Icons.Filled.Favorite,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .size(20.dp),
+                    tint = MaterialTheme.colorScheme.tertiary,
                 )
-
-                DisposalGuideMetadataChips(guide = guide)
-
-                if (guide.instructions.isNotEmpty()) {
-                    val firstInstruction = guide.instructions.first().method.toDisplayLabel()
-                    Text(
-                        text = firstInstruction,
-                        style = MaterialTheme.typography.bodyMedium.copy(
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            fontSize = 14.sp,
-                            lineHeight = 22.sp
-                        ),
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
             }
 
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = null,
-                modifier = Modifier.size(20.dp),
-                tint = MaterialTheme.colorScheme.outlineVariant
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = guide.name,
+                        modifier = Modifier.fillMaxWidth(),
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 18.sp,
+                            color = MaterialTheme.colorScheme.onSurface
+                        ),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+
+                    DisposalGuideMetadataChips(guide = guide)
+
+                    if (guide.instructions.isNotEmpty()) {
+                        val firstInstruction = guide.instructions.first().method.toDisplayLabel()
+                        Text(
+                            text = firstInstruction,
+                            style = MaterialTheme.typography.bodyMedium.copy(
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                fontSize = 14.sp,
+                                lineHeight = 22.sp
+                            ),
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.outlineVariant
+                )
+            }
         }
     }
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModelTest.kt
@@ -1,0 +1,186 @@
+package com.team.yeogibeoryeo.presentation.favorites
+
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
+import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
+import com.team.yeogibeoryeo.domain.item.model.DisposalInstruction
+import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
+import com.team.yeogibeoryeo.domain.item.model.DisposalSubCategory
+import com.team.yeogibeoryeo.domain.item.repository.DisposalItemGuideRepository
+import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalItemGuideUseCase
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteItemUiModel
+import com.team.yeogibeoryeo.presentation.search.MainDispatcherRule
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FavoritesViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `즐겨찾기 원본 가이드를 조회해 UI 모델로 변환한다`() =
+        runTest {
+            val guide =
+                sampleGuide(
+                    id = "paper-pack",
+                    name = "종이팩",
+                    subCategory = DisposalSubCategory.MILK_CARTON,
+                )
+            val viewModel =
+                createViewModel(
+                    favoriteRepository =
+                        FakeFavoriteRepository(
+                            initialFavorites =
+                                listOf(
+                                    Favorite(
+                                        type = FavoriteTargetType.ITEM_GUIDE,
+                                        targetId = guide.id,
+                                        savedAtMillis = 1L,
+                                    ),
+                                ),
+                        ),
+                    itemRepository = FakeItemRepository(guides = listOf(guide)),
+                )
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.uiState.collect()
+            }
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(
+                    FavoriteItemUiModel(
+                        targetId = "paper-pack",
+                        title = "종이팩",
+                        subtitle = "우유팩",
+                    ),
+                ),
+                viewModel.uiState.value.favorites,
+            )
+        }
+
+    @Test
+    fun `원본 가이드를 찾을 수 없는 즐겨찾기는 UI 목록에서 제외한다`() =
+        runTest {
+            val viewModel =
+                createViewModel(
+                    favoriteRepository =
+                        FakeFavoriteRepository(
+                            initialFavorites =
+                                listOf(
+                                    Favorite(
+                                        type = FavoriteTargetType.ITEM_GUIDE,
+                                        targetId = "missing-guide",
+                                        savedAtMillis = 1L,
+                                    ),
+                                ),
+                        ),
+                    itemRepository = FakeItemRepository(guides = emptyList()),
+                )
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.uiState.collect()
+            }
+            advanceUntilIdle()
+
+            assertEquals(emptyList<FavoriteItemUiModel>(), viewModel.uiState.value.favorites)
+        }
+
+    private fun createViewModel(
+        favoriteRepository: FakeFavoriteRepository,
+        itemRepository: FakeItemRepository,
+    ): FavoritesViewModel =
+        FavoritesViewModel(
+            observeFavoritesUseCase = ObserveFavoritesUseCase(favoriteRepository),
+            getDisposalItemGuideUseCase = GetDisposalItemGuideUseCase(itemRepository),
+        )
+
+    private fun sampleGuide(
+        id: String,
+        name: String,
+        subCategory: DisposalSubCategory? = null,
+    ): DisposalItemGuide =
+        DisposalItemGuide(
+            id = id,
+            name = name,
+            category = DisposalCategory.PAPER_PACK,
+            subCategory = subCategory,
+            instructions = listOf(DisposalInstruction(method = "재활용폐기물")),
+            steps = emptyList(),
+            cautions = emptyList(),
+            tip = null,
+            isRecyclable = true,
+            relatedSpotTypes = emptyList(),
+        )
+
+    private class FakeItemRepository(
+        guides: List<DisposalItemGuide>,
+    ) : DisposalItemGuideRepository {
+        private val guidesById = guides.associateBy { it.id }
+
+        override suspend fun searchItemGuides(query: String): List<DisposalItemGuide> = emptyList()
+
+        override suspend fun getItemGuide(guideId: String): DisposalItemGuide? = guidesById[guideId]
+
+        override suspend fun getCategoryGuides(category: DisposalCategory): List<DisposalItemGuide> = emptyList()
+
+        override fun getCategories(): List<DisposalCategory> = emptyList()
+    }
+
+    private class FakeFavoriteRepository(
+        initialFavorites: List<Favorite> = emptyList(),
+    ) : FavoriteRepository {
+        private val favorites = MutableStateFlow(initialFavorites)
+
+        override fun observeFavorites(): Flow<List<Favorite>> = favorites
+
+        override fun observeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Flow<Boolean> =
+            favorites.map { items ->
+                items.any { it.type == type && it.targetId == targetId }
+            }
+
+        override suspend fun isFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Boolean =
+            favorites.value.any { it.type == type && it.targetId == targetId }
+
+        override suspend fun toggleFavorite(favorite: Favorite): Boolean {
+            return if (isFavorite(favorite.type, favorite.targetId)) {
+                removeFavorite(favorite.type, favorite.targetId)
+                false
+            } else {
+                addFavorite(favorite)
+                true
+            }
+        }
+
+        override suspend fun addFavorite(favorite: Favorite) {
+            favorites.value =
+                favorites.value
+                    .filterNot { it.type == favorite.type && it.targetId == favorite.targetId } + favorite
+        }
+
+        override suspend fun removeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ) {
+            favorites.value =
+                favorites.value.filterNot { it.type == type && it.targetId == targetId }
+        }
+    }
+}

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModelTest.kt
@@ -1,0 +1,227 @@
+package com.team.yeogibeoryeo.presentation.search
+
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoriteUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ToggleFavoriteUseCase
+import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
+import com.team.yeogibeoryeo.domain.item.model.DisposalInstruction
+import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
+import com.team.yeogibeoryeo.domain.item.repository.DisposalItemGuideRepository
+import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalItemGuideUseCase
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ItemGuideDetailViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `가이드 로드 성공 시 상세 상태와 즐겨찾기 여부를 반영한다`() =
+        runTest {
+            val guide = sampleGuide("유리병")
+            val favoriteRepository =
+                FakeFavoriteRepository(
+                    initialFavorites =
+                        listOf(
+                            Favorite(
+                                type = FavoriteTargetType.ITEM_GUIDE,
+                                targetId = guide.id,
+                                savedAtMillis = 1L,
+                            ),
+                        ),
+                )
+            val viewModel =
+                createViewModel(
+                    itemRepository = FakeItemRepository(guide = guide),
+                    favoriteRepository = favoriteRepository,
+                )
+
+            viewModel.loadGuide(guide.id)
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value as ItemGuideDetailUiState.Success
+            assertEquals(guide, state.guide)
+            assertTrue(state.isFavorite)
+        }
+
+    @Test
+    fun `즐겨찾기를 추가하면 최종 상태 기준 메시지를 저장한다`() =
+        runTest {
+            val guide = sampleGuide("유리병")
+            val viewModel =
+                createViewModel(
+                    itemRepository = FakeItemRepository(guide = guide),
+                    favoriteRepository = FakeFavoriteRepository(),
+                )
+
+            viewModel.loadGuide(guide.id)
+            advanceUntilIdle()
+            viewModel.toggleFavorite()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value as ItemGuideDetailUiState.Success
+            assertTrue(state.isFavorite)
+            assertEquals("즐겨찾기에 추가되었습니다", state.favoriteMessage)
+        }
+
+    @Test
+    fun `즐겨찾기를 해제하면 최종 상태 기준 메시지를 저장한다`() =
+        runTest {
+            val guide = sampleGuide("유리병")
+            val favoriteRepository =
+                FakeFavoriteRepository(
+                    initialFavorites =
+                        listOf(
+                            Favorite(
+                                type = FavoriteTargetType.ITEM_GUIDE,
+                                targetId = guide.id,
+                                savedAtMillis = 1L,
+                            ),
+                        ),
+                )
+            val viewModel =
+                createViewModel(
+                    itemRepository = FakeItemRepository(guide = guide),
+                    favoriteRepository = favoriteRepository,
+                )
+
+            viewModel.loadGuide(guide.id)
+            advanceUntilIdle()
+            viewModel.toggleFavorite()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value as ItemGuideDetailUiState.Success
+            assertFalse(state.isFavorite)
+            assertEquals("즐겨찾기에서 제외되었습니다", state.favoriteMessage)
+        }
+
+    @Test
+    fun `새 가이드를 로드하면 이전 로드 결과는 반영하지 않는다`() =
+        runTest {
+            val oldGuide = sampleGuide("유리병")
+            val newGuide = sampleGuide("종이팩")
+            val oldResult = CompletableDeferred<DisposalItemGuide?>()
+            val viewModel =
+                createViewModel(
+                    itemRepository =
+                        FakeItemRepository { guideId ->
+                            when (guideId) {
+                                oldGuide.id -> oldResult.await()
+                                newGuide.id -> newGuide
+                                else -> null
+                            }
+                        },
+                    favoriteRepository = FakeFavoriteRepository(),
+                )
+
+            viewModel.loadGuide(oldGuide.id)
+            viewModel.loadGuide(newGuide.id)
+            advanceUntilIdle()
+
+            var state = viewModel.uiState.value as ItemGuideDetailUiState.Success
+            assertEquals(newGuide, state.guide)
+
+            oldResult.complete(oldGuide)
+            advanceUntilIdle()
+
+            state = viewModel.uiState.value as ItemGuideDetailUiState.Success
+            assertEquals(newGuide, state.guide)
+        }
+
+    private fun createViewModel(
+        itemRepository: FakeItemRepository,
+        favoriteRepository: FakeFavoriteRepository,
+    ): ItemGuideDetailViewModel =
+        ItemGuideDetailViewModel(
+            getDisposalItemGuideUseCase = GetDisposalItemGuideUseCase(itemRepository),
+            observeFavoriteUseCase = ObserveFavoriteUseCase(favoriteRepository),
+            toggleFavoriteUseCase = ToggleFavoriteUseCase(favoriteRepository),
+        )
+
+    private fun sampleGuide(name: String): DisposalItemGuide =
+        DisposalItemGuide(
+            id = name,
+            name = name,
+            category = DisposalCategory.GLASS,
+            subCategory = null,
+            instructions = listOf(DisposalInstruction(method = "재활용폐기물")),
+            steps = emptyList(),
+            cautions = emptyList(),
+            tip = null,
+            isRecyclable = true,
+            relatedSpotTypes = emptyList(),
+        )
+
+    private class FakeItemRepository(
+        private val onGetItemGuide: suspend (String) -> DisposalItemGuide?,
+    ) : DisposalItemGuideRepository {
+        constructor(guide: DisposalItemGuide?) : this({ guideId -> guide?.takeIf { it.id == guideId } })
+
+        override suspend fun searchItemGuides(query: String): List<DisposalItemGuide> = emptyList()
+
+        override suspend fun getItemGuide(guideId: String): DisposalItemGuide? = onGetItemGuide(guideId)
+
+        override suspend fun getCategoryGuides(category: DisposalCategory): List<DisposalItemGuide> = emptyList()
+
+        override fun getCategories(): List<DisposalCategory> = emptyList()
+    }
+
+    private class FakeFavoriteRepository(
+        initialFavorites: List<Favorite> = emptyList(),
+    ) : FavoriteRepository {
+        private val favorites = MutableStateFlow(initialFavorites)
+
+        override fun observeFavorites(): Flow<List<Favorite>> = favorites
+
+        override fun observeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Flow<Boolean> =
+            favorites.map { items ->
+                items.any { it.type == type && it.targetId == targetId }
+            }
+
+        override suspend fun isFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Boolean =
+            favorites.value.any { it.type == type && it.targetId == targetId }
+
+        override suspend fun toggleFavorite(favorite: Favorite): Boolean {
+            return if (isFavorite(favorite.type, favorite.targetId)) {
+                removeFavorite(favorite.type, favorite.targetId)
+                false
+            } else {
+                addFavorite(favorite)
+                true
+            }
+        }
+
+        override suspend fun addFavorite(favorite: Favorite) {
+            favorites.value =
+                favorites.value
+                    .filterNot { it.type == favorite.type && it.targetId == favorite.targetId } + favorite
+        }
+
+        override suspend fun removeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ) {
+            favorites.value =
+                favorites.value.filterNot { it.type == type && it.targetId == targetId }
+        }
+    }
+}

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModelTest.kt
@@ -1,5 +1,9 @@
 package com.team.yeogibeoryeo.presentation.search
 
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
 import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
 import com.team.yeogibeoryeo.domain.item.model.DisposalInstruction
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
@@ -10,6 +14,9 @@ import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -178,7 +185,7 @@ class ItemSearchViewModelTest {
             advanceUntilIdle()
 
             assertNull(viewModel.uiState.value.errorMessageResId)
-            assertEquals("종이", viewModel.uiState.value.selectedGuide?.name)
+            assertEquals("종이", viewModel.uiState.value.pendingGuideToOpen?.name)
         }
 
     @Test
@@ -197,7 +204,7 @@ class ItemSearchViewModelTest {
             assertEquals(listOf(DisposalCategory.VINYL), repository.requestedCategories)
             assertEquals(
                 RepresentativeGuideCategory.VINYL.representativeGuideName,
-                viewModel.uiState.value.selectedGuide?.name,
+                viewModel.uiState.value.pendingGuideToOpen?.name,
             )
             assertEquals("", viewModel.uiState.value.query)
             assertEquals(emptyList<DisposalItemGuide>(), viewModel.uiState.value.guides)
@@ -216,19 +223,7 @@ class ItemSearchViewModelTest {
             viewModel.openCategoryGuide(RepresentativeGuideCategory.VINYL)
             advanceUntilIdle()
 
-            assertEquals(expected, viewModel.uiState.value.selectedGuide)
-        }
-
-    @Test
-    fun `선택한 가이드를 초기화하면 검색 화면 상태로 돌아간다`() =
-        runTest {
-            val guide = sampleGuide("유리병")
-            val viewModel = createViewModel(FakeRepository())
-
-            viewModel.selectGuide(guide)
-            viewModel.clearSelectedGuide()
-
-            assertNull(viewModel.uiState.value.selectedGuide)
+            assertEquals(expected, viewModel.uiState.value.pendingGuideToOpen)
         }
 
     @Test
@@ -263,10 +258,34 @@ class ItemSearchViewModelTest {
             assertFalse(viewModel.uiState.value.isLoading)
         }
 
-    private fun createViewModel(repository: FakeRepository) =
+    @Test
+    fun `즐겨찾기한 검색 결과 id를 상태에 반영한다`() =
+        runTest {
+            val favoriteRepository =
+                FakeFavoriteRepository(
+                    initialFavorites =
+                        listOf(
+                            Favorite(
+                                type = FavoriteTargetType.ITEM_GUIDE,
+                                targetId = "유리병",
+                                savedAtMillis = 1L,
+                            ),
+                        ),
+                )
+            val viewModel = createViewModel(FakeRepository(), favoriteRepository)
+            advanceUntilIdle()
+
+            assertEquals(setOf("유리병"), viewModel.uiState.value.favoriteGuideIds)
+        }
+
+    private fun createViewModel(
+        repository: FakeRepository,
+        favoriteRepository: FakeFavoriteRepository = FakeFavoriteRepository(),
+    ) =
         ItemSearchViewModel(
             SearchDisposalItemGuidesUseCase(repository),
             GetDisposalCategoryGuidesUseCase(repository),
+            ObserveFavoritesUseCase(favoriteRepository),
         )
 
     private fun sampleGuide(name: String): DisposalItemGuide =
@@ -305,5 +324,51 @@ class ItemSearchViewModelTest {
         override suspend fun getItemGuide(guideId: String): DisposalItemGuide? = null
 
         override fun getCategories(): List<DisposalCategory> = emptyList()
+    }
+
+    private class FakeFavoriteRepository(
+        initialFavorites: List<Favorite> = emptyList(),
+    ) : FavoriteRepository {
+        private val favorites = MutableStateFlow(initialFavorites)
+
+        override fun observeFavorites(): Flow<List<Favorite>> = favorites
+
+        override fun observeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Flow<Boolean> =
+            favorites.map { items ->
+                items.any { it.type == type && it.targetId == targetId }
+            }
+
+        override suspend fun isFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Boolean =
+            favorites.value.any { it.type == type && it.targetId == targetId }
+
+        override suspend fun toggleFavorite(favorite: Favorite): Boolean {
+            return if (isFavorite(favorite.type, favorite.targetId)) {
+                removeFavorite(favorite.type, favorite.targetId)
+                false
+            } else {
+                addFavorite(favorite)
+                true
+            }
+        }
+
+        override suspend fun addFavorite(favorite: Favorite) {
+            favorites.value =
+                favorites.value
+                    .filterNot { it.type == favorite.type && it.targetId == favorite.targetId } + favorite
+        }
+
+        override suspend fun removeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ) {
+            favorites.value =
+                favorites.value.filterNot { it.type == type && it.targetId == targetId }
+        }
     }
 }


### PR DESCRIPTION
## 작업 내용

- 공통 즐겨찾기 도메인 모델과 타입 기반 저장 구조를 추가했습니다.
- Room 기반 즐겨찾기 로컬 저장소, DAO, Repository, UseCase를 추가했습니다.
- 품목 가이드 상세 화면에서 즐겨찾기 등록/해제와 현재 상태 표시를 연결했습니다.
- 검색 결과 카드에도 즐겨찾기 상태를 표시하도록 연결했습니다.
- Favorites 화면에서 저장된 품목 가이드 즐겨찾기 목록을 표시하고, 항목 클릭 시 상세 화면으로 이동하도록 연결했습니다.
- 즐겨찾기 추가/해제 피드백을 위한 `FavoriteSnackbar`를 추가했습니다.

## 즐겨찾기 구조 설명

이번 PR의 즐겨찾기 구조는 특정 화면에만 붙는 임시 상태가 아니라, 이후 `품목 가이드`, `수거 장소`, `지역별 가이드`가 같은 방식으로 확장할 수 있는 공통 저장 구조를 기준으로 만들었습니다.

핵심은 즐겨찾기 DB에 화면 표시 데이터를 그대로 복사해 저장하지 않고, 다음 세 가지 메타데이터만 저장하는 것입니다.

```text
type + targetId + savedAtMillis
```

- `type`: 어떤 기능의 즐겨찾기인지 구분합니다.
- `targetId`: 해당 기능 안에서 원본 데이터를 다시 찾기 위한 id입니다.
- `savedAtMillis`: 즐겨찾기에 추가한 시각입니다. 최근 추가한 항목을 위에 보여주는 정렬 기준으로 사용합니다.

### 전체 흐름

```mermaid
flowchart TD
    DetailScreen["각 기능 상세 화면<br/>ItemGuideDetailScreen 등"] --> DetailViewModel["상세 ViewModel"]
    DetailViewModel --> ObserveFavorite["ObserveFavoriteUseCase<br/>현재 대상이 즐겨찾기인지 관찰"]
    DetailViewModel --> ToggleFavorite["ToggleFavoriteUseCase<br/>즐겨찾기 추가/해제"]

    ObserveFavorite --> FavoriteRepository["FavoriteRepository"]
    ToggleFavorite --> FavoriteRepository
    FavoriteRepository --> FavoriteDao["FavoriteDao"]
    FavoriteDao --> FavoriteTable["favorites table<br/>type + targetId + savedAtMillis"]

    FavoriteScreen["FavoritesScreen"] --> FavoritesViewModel["FavoritesViewModel"]
    FavoritesViewModel --> ObserveFavorites["ObserveFavoritesUseCase<br/>타입별 즐겨찾기 목록 관찰"]
    ObserveFavorites --> FavoriteRepository
    FavoritesViewModel --> OriginalSource["원본 데이터 재조회<br/>GetDisposalItemGuideUseCase 등"]
    OriginalSource --> FavoriteUiModel["FavoriteItemUiModel"]
    FavoriteUiModel --> FavoriteCard["FavoriteCard"]
```

### 추가된 파일과 역할

#### domain/favorite

- `Favorite.kt`
  - 즐겨찾기 한 건을 나타내는 도메인 모델입니다.
  - `type`, `targetId`, `savedAtMillis`만 가지고, 원본 상세 데이터는 들고 있지 않습니다.

- `FavoriteTargetType.kt`
  - 즐겨찾기 대상 종류를 구분합니다.
  - 현재 값은 `ITEM_GUIDE`, `COLLECTION_SPOT`, `REGIONAL_GUIDE`입니다.
  - 같은 id 문자열이 서로 다른 기능에 존재할 수 있으므로 `targetId`만 저장하지 않고 `type`을 함께 저장합니다.

- `FavoriteRepository.kt`
  - presentation/domain이 data 구현체를 직접 알지 않도록 하는 repository 계약입니다.
  - 즐겨찾기 목록 관찰, 단일 대상 상태 관찰, 토글, 추가, 삭제 역할을 정의합니다.

- `ObserveFavoritesUseCase.kt`
  - Favorites 화면처럼 특정 타입의 즐겨찾기 목록을 계속 관찰해야 할 때 사용합니다.
  - 예: `ObserveFavoritesUseCase(FavoriteTargetType.ITEM_GUIDE)`

- `ObserveFavoriteUseCase.kt`
  - 상세 화면처럼 현재 보고 있는 대상 하나가 즐겨찾기인지 관찰할 때 사용합니다.
  - 예: `ObserveFavoriteUseCase(ITEM_GUIDE, guideId)`

- `ToggleFavoriteUseCase.kt`
  - 즐겨찾기 버튼을 눌렀을 때 추가/해제를 처리합니다.
  - 토글 후 최종 즐겨찾기 상태를 반환해 snackbar 문구가 실제 상태와 어긋나지 않도록 했습니다.

#### data/favorite

- `FavoriteEntity.kt`
  - Room table `favorites`에 저장되는 모델입니다.
  - primary key는 `type + targetId` 조합입니다.
  - 같은 `targetId`라도 `type`이 다르면 서로 다른 즐겨찾기로 저장됩니다.

- `FavoriteDao.kt`
  - Room DAO입니다.
  - `observeFavorites`, `observeFavorite`, `isFavorite`, `upsertFavorite`, `deleteFavorite`, `toggleFavorite`를 제공합니다.
  - `toggleFavorite`는 `@Transaction`으로 묶어 빠르게 연속 탭해도 추가/삭제 판단이 꼬이지 않도록 했습니다.
  - 목록은 `savedAtMillis DESC`로 조회해 최근 추가한 즐겨찾기가 위에 오도록 했습니다.

- `FavoriteDatabase.kt`
  - 즐겨찾기 전용 Room database입니다.

- `FavoriteMapper.kt`
  - data entity와 domain model 사이 변환을 담당합니다.

- `FavoriteRepositoryImpl.kt`
  - domain의 `FavoriteRepository` 계약을 Room 기반으로 구현합니다.

- `FavoriteDataModule.kt`
  - Hilt로 `FavoriteDatabase`, `FavoriteDao`, `FavoriteRepository`를 주입할 수 있게 연결합니다.

#### presentation/search

- `ItemGuideDetailViewModel.kt`
  - 품목 상세 화면에서 현재 품목이 즐겨찾기인지 관찰합니다.
  - 즐겨찾기 버튼 클릭 시 `ToggleFavoriteUseCase`를 호출하고, 최종 상태에 맞춰 snackbar 메시지를 만듭니다.

- `ItemGuideDetailRoute.kt`
  - 상세 화면의 상태와 snackbar 표시를 연결합니다.

- `ItemGuideDetailScreen.kt`
  - 상세 화면 상단에 즐겨찾기 버튼을 표시합니다.

- `ItemSearchViewModel.kt`
  - `ITEM_GUIDE` 즐겨찾기 목록을 관찰해 검색 결과 카드에 표시할 `favoriteGuideIds`를 만듭니다.

- `ItemSearchUiState.kt`
  - 검색 결과에서 즐겨찾기 표시를 위해 `favoriteGuideIds`를 포함합니다.

- `ItemSearchScreen.kt`, `DisposalItemCard.kt`
  - 검색 결과 카드 우측 상단에 즐겨찾기 상태를 표시합니다.

#### presentation/favorites

- `FavoritesRoute.kt`
  - Favorites 탭 진입 route입니다.

- `FavoritesViewModel.kt`
  - 저장된 `ITEM_GUIDE` 즐겨찾기 목록을 관찰합니다.
  - DB에 저장된 `targetId`로 원본 품목 가이드를 다시 조회하고, 화면에 필요한 `FavoriteItemUiModel`로 변환합니다.

- `FavoritesUiState.kt`
  - Favorites 화면 상태입니다.

- `FavoriteItemUiModel.kt`
  - Favorites 화면 카드에 필요한 표시 모델입니다.
  - domain의 `Favorite`을 그대로 UI에 노출하지 않고, 화면에 필요한 값만 담습니다.

- `FavoritesScreen.kt`
  - 즐겨찾기 목록 또는 빈 상태를 보여줍니다.

- `FavoriteCard.kt`
  - 즐겨찾기 항목 카드입니다.
  - 검색 결과 카드와 유사한 형태로 보여주어 화면 간 일관성을 맞췄습니다.

- `EmptyFavoritesCard.kt`
  - 즐겨찾기가 없을 때 표시하는 빈 상태 카드입니다.

- `FavoriteSnackbar.kt`
  - 즐겨찾기 추가/해제 피드백을 보여주는 snackbar입니다.
  - 현재는 즐겨찾기 기능에서만 사용하므로 `favorites` 영역에 두었습니다.

### 왜 이렇게 설계했는지

- 원본 데이터를 DB에 복사하지 않기 위해서입니다.
  - 즐겨찾기 DB에 이름, 설명, 카테고리, 상세 내용을 모두 저장하면 원본 데이터가 바뀌었을 때 Favorites 화면과 원본 화면의 정보가 달라질 수 있습니다.
  - 그래서 DB에는 `type + targetId`만 저장하고, Favorites 화면에서 원본 데이터를 다시 조회합니다.

- 여러 기능의 즐겨찾기를 같은 구조로 확장하기 위해서입니다.
  - 품목 가이드, 수거 장소, 지역별 가이드는 원본 데이터 구조가 서로 다릅니다.
  - 하지만 즐겨찾기 여부를 판단하는 방식은 “어떤 타입의 어떤 id인가”로 공통화할 수 있습니다.

- 정렬 기준을 공통으로 두기 위해서입니다.
  - `savedAtMillis`를 저장하면 나중에 여러 타입의 즐겨찾기를 한 화면에 섞어 보여주더라도 최근 추가 순으로 정렬할 수 있습니다.

### `type`과 `targetId` 예시

```text
ITEM_GUIDE / 플라스틱 용기
COLLECTION_SPOT / spot-123
REGIONAL_GUIDE / 서울특별시-영등포구
```

예를 들어 다음 두 즐겨찾기는 `targetId`가 같더라도 서로 다른 데이터로 저장됩니다.

```text
ITEM_GUIDE / 유리병
COLLECTION_SPOT / 유리병
```

그래서 즐겨찾기 여부 확인, 토글, 삭제는 모두 `type + targetId` 조합을 기준으로 처리합니다.

### 이번 PR에서 실제 연결한 범위

이번 PR에서는 `ITEM_GUIDE`만 실제 UI에 연결했습니다.

- 품목 상세 상태 확인: `ItemGuideDetailViewModel.kt`
- 품목 상세 UI 토글: `ItemGuideDetailScreen.kt`, `ItemGuideDetailRoute.kt`
- 검색 결과 카드 상태 표시: `ItemSearchViewModel.kt`, `ItemSearchScreen.kt`, `DisposalItemCard.kt`
- 즐겨찾기 목록 표시: `FavoritesViewModel.kt`, `FavoritesScreen.kt`, `FavoriteCard.kt`

### 다른 기능에 확장할 때 보면 되는 기준

수거 장소나 지역별 가이드에 즐겨찾기를 붙일 때도 기본 흐름은 같습니다.

1. 상세 화면에서 현재 대상의 id를 정합니다.
2. 대상 타입을 정합니다.
   - 수거 장소: `FavoriteTargetType.COLLECTION_SPOT`
   - 지역별 가이드: `FavoriteTargetType.REGIONAL_GUIDE`
3. 상세 ViewModel에서 `ObserveFavoriteUseCase(type, targetId)`로 상태를 관찰합니다.
4. 즐겨찾기 버튼 클릭 시 `ToggleFavoriteUseCase(Favorite(type, targetId, savedAtMillis))`를 호출합니다.
5. Favorites 화면에 해당 타입을 보여줄 때는 `ObserveFavoritesUseCase(type)`로 목록을 받습니다.
6. 각 `targetId`로 원본 데이터를 다시 조회한 뒤 UI 모델로 변환합니다.

### 주의할 점

- 즐겨찾기 DB에는 원본 표시 문구나 상세 내용을 저장하지 않습니다.
- 원본 데이터가 바뀌면 Favorites 화면은 최신 원본 데이터를 다시 조회해 보여주는 방향입니다.
- 나중에 API 기반 데이터에서 원본이 삭제되거나 id가 바뀌는 경우, stale favorite row를 어떻게 처리할지는 팀 정책으로 정해야 합니다.
- 현재 품목 가이드는 로컬 JSON 기반이고 데이터 변경 가능성이 낮아 stale favorite 문제가 당장 크게 드러날 가능성은 낮습니다.
- 다만 수거 장소/지역별 가이드처럼 API 기반 데이터가 연결되면 원본 데이터 삭제, id 변경, 응답 구조 변경 가능성이 있으므로 삭제된 대상 처리 정책을 팀에서 함께 논의하면 좋겠습니다.

## 설계 방향

- 즐겨찾기는 이후 품목 가이드, 수거 장소, 지역별 가이드로 확장될 수 있도록 `type + targetId` 기준으로 저장합니다.
- 즐겨찾기 DB에는 원본 상세 데이터를 복제하지 않고, 원본 가이드는 `targetId`로 다시 조회해 표시합니다.
- `savedAtMillis`는 최근 추가한 즐겨찾기 순서로 목록을 정렬하기 위한 공통 메타데이터입니다.
- 현재 PR에서는 `ITEM_GUIDE`만 실제 UI에 연결하고, 다른 대상 타입은 후속 확장을 고려해 구조만 준비했습니다.

## 후속 작업 / 논의 필요

### 검색 상세 진입/복귀 흐름

이번 PR 검토 중 검색 결과에서 상세 화면으로 이동했다가 돌아오는 흐름에서 스크롤 위치가 초기화될 수 있음을 확인했습니다.

이 문제는 즐겨찾기 기능 자체에서 생긴 문제라기보다, #52 Navigation 구조 적용 이후 품목 상세 화면이 검색 화면 내부 상태가 아니라 별도 route로 분리되면서 드러난 검색 화면 복귀 UX 문제로 보입니다.

- quick category 상세 이동을 `uiState`가 아닌 일회성 navigation event로 분리
- `SharedFlow` 기반 검색 화면 navigation event 적용
- 검색 결과에서 상세 화면으로 이동한 뒤 뒤로 돌아왔을 때 스크롤 위치 유지

해당 내용은 이번 PR 범위와 분리해 #77에서 처리합니다.

### 즐겨찾기 아이콘

이번 PR에서는 현재 앱의 bottom navigation과 기존 즐겨찾기 표현에 맞춰 하트 아이콘을 사용했습니다.

다만 즐겨찾기 액션은 하트보다 별 아이콘을 개인적으로 더 선호하는 편이라 아이콘 변경에 대해 의견을 물어보고 싶습니다.

### Snackbar 사용 여부 & 디자인 & 공통화

이번 PR에서는 UX 측면에서 필요할 것 같아 디자인을 고려하지 않고 일단은 즐겨찾기 추가/해제 피드백 용도로 `FavoriteSnackbar`를 추가했습니다. 현재는 즐겨찾기 기능에서만 사용하므로 `favorites` 영역에 두었지만, 이후 품목 가이드, 수거 장소, 지역별 가이드 등 여러 화면에서 같은 snackbar 패턴이 반복되면 공통 snackbar 컴포넌트로 분리할지 팀에서 논의하면 좋겠습니다.

## 화면 캡처

<table>
  <tr>
    <td align="center"><b>즐겨찾기 빈 화면</b></td>
    <td align="center"><b>상세 화면 즐겨찾기 전</b></td>
  </tr>
  <tr>
    <td>
      <img width="250" alt="즐겨찾기 빈 화면" src="https://github.com/user-attachments/assets/64a4beaa-8d58-4a09-ac8f-a757b6c35c06" />
    </td>
    <td>
      <img width="250" alt="상세 화면 즐겨찾기 전" src="https://github.com/user-attachments/assets/59141d24-6995-4d2a-9310-c1094010228c" />
    </td>
  </tr>

  <tr>
    <td align="center"><b>즐겨찾기 추가 Snackbar</b></td>
    <td align="center"><b>상세 화면 즐겨찾기 추가 상태</b></td>
  </tr>
  <tr>
    <td>
      <img width="250" alt="즐겨찾기 추가 Snackbar" src="https://github.com/user-attachments/assets/43a63dfc-5981-4c2c-91b2-229dc5caa214" />
    </td>
    <td>
      <img width="250" alt="상세 화면 즐겨찾기 추가 상태" src="https://github.com/user-attachments/assets/0ceb4057-3c31-4b7c-b668-21a14054077a" />
    </td>
  </tr>

  <tr>
    <td align="center"><b>즐겨찾기 해제 Snackbar</b></td>
    <td align="center"><b>즐겨찾기 반영된 검색 결과</b></td>
  </tr>
  <tr>
    <td>
      <img width="250" alt="즐겨찾기 해제 Snackbar" src="https://github.com/user-attachments/assets/8e84f320-7a59-43c9-9346-91b594e87f72" />
    </td>
    <td>
      <img width="250" alt="즐겨찾기 반영된 검색 결과" src="https://github.com/user-attachments/assets/b97608f7-9c78-4172-a9f0-6a07a60cf360" />
    </td>
  </tr>
  <tr>
    <td align="center"><b>즐겨찾기 목록</b></td>
    <td></td>
  </tr>
  <tr>
    <td>
      <img width="250" alt="즐겨찾기 목록" src="https://github.com/user-attachments/assets/d0581023-1c42-4167-ae47-dd3b955de166" />
    </td>
    <td></td>
  </tr>
</table>

## 테스트

- [x] `./gradlew.bat :data:compileDebugAndroidTestKotlin :domain:test :data:testDebugUnitTest :presentation:testDebugUnitTest :presentation:compileDebugKotlin :app:compileDebugKotlin`
- [x] `./gradlew.bat :data:connectedDebugAndroidTest`

Related #75
