### PR TITLE
feat(map): 지도 BottomSheet 및 오버레이 UX 개선

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -78,6 +78,7 @@ private fun CollectionSpotMapContent(
         uiState.searchMode == MapSearchMode.CURRENT_LOCATION
     val shouldShowBottomSheet = uiState.shouldShowBottomSheet && !isCurrentLocationSearching
     var mapUiMode by remember { mutableStateOf(MapUiMode.Browsing) }
+    var sheetRevealRequest by remember { mutableStateOf(0) }
     val selectedSpot = uiState.selectedSpot
     val sheetLevel = when {
         !shouldShowBottomSheet || mapUiMode == MapUiMode.Browsing -> MapSheetLevel.Hidden
@@ -125,6 +126,7 @@ private fun CollectionSpotMapContent(
             selectedSpot = uiState.selectedSpot,
             onSpotClick = { spot ->
                 mapUiMode = MapUiMode.SpotDetail
+                sheetRevealRequest += 1
                 onSpotClick(spot)
             },
             onMapClick = {
@@ -165,6 +167,7 @@ private fun CollectionSpotMapContent(
         if (shouldShowBottomSheet) {
             ThreeStepMapBottomSheet(
                 sheetLevel = sheetLevel,
+                revealKey = "$mapUiMode-${selectedSpot?.id}-$sheetRevealRequest",
                 modifier = Modifier.align(Alignment.BottomCenter),
             ) {
                 when {
@@ -189,6 +192,7 @@ private fun CollectionSpotMapContent(
                             onTypeClick = onTypeClick,
                             onSpotClick = { spot ->
                                 mapUiMode = MapUiMode.SpotDetail
+                                sheetRevealRequest += 1
                                 onSpotClick(spot)
                             },
                         )
@@ -202,6 +206,7 @@ private fun CollectionSpotMapContent(
 @Composable
 private fun ThreeStepMapBottomSheet(
     sheetLevel: MapSheetLevel,
+    revealKey: Any?,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
@@ -232,7 +237,7 @@ private fun ThreeStepMapBottomSheet(
             Animatable(targetOffset)
         }
 
-        LaunchedEffect(targetOffset) {
+        LaunchedEffect(targetOffset, revealKey) {
             sheetOffset.animateTo(targetOffset)
         }
 
@@ -307,7 +312,7 @@ private enum class MapSheetLevel {
 private val MapSheetTopMargin = 72.dp
 private val MapStatusBottomSheetPeekHeight = 132.dp
 private val MapResultBottomSheetPeekHeight = 144.dp
-private val MapSpotDetailBottomSheetPeekHeight = 292.dp
+private val MapSpotDetailBottomSheetPeekHeight = 220.dp
 
 @Preview(showBackground = true)
 @Composable

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -1,31 +1,43 @@
 package com.team.yeogibeoryeo.presentation.map
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.presentation.map.components.CollectionSpotNaverMap
-import com.team.yeogibeoryeo.presentation.map.components.CurrentLocationButton
-import com.team.yeogibeoryeo.presentation.map.components.EmptySpotResult
-import com.team.yeogibeoryeo.presentation.map.components.MapSearchBar
-import com.team.yeogibeoryeo.presentation.map.components.SpotBottomList
-import com.team.yeogibeoryeo.presentation.map.components.SpotFilterChipRow
+import com.team.yeogibeoryeo.presentation.map.components.CurrentLocationSearchLoadingOverlay
+import com.team.yeogibeoryeo.presentation.map.components.MapOverlayControls
+import com.team.yeogibeoryeo.presentation.map.components.SpotBottomSheetContent
+import com.team.yeogibeoryeo.presentation.map.components.SpotDetailBottomSheetContent
 import com.team.yeogibeoryeo.presentation.map.location.rememberCurrentLocationSearchRequester
+import kotlin.math.roundToInt
+import kotlinx.coroutines.launch
 
 @Composable
 fun CollectionSpotMapScreen(
@@ -62,80 +74,240 @@ private fun CollectionSpotMapContent(
     onSpotClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
+    val isCurrentLocationSearching = uiState.isLoading &&
+        uiState.searchMode == MapSearchMode.CURRENT_LOCATION
+    val shouldShowBottomSheet = uiState.shouldShowBottomSheet && !isCurrentLocationSearching
+    var mapUiMode by remember { mutableStateOf(MapUiMode.Browsing) }
+    val selectedSpot = uiState.selectedSpot
+    val sheetLevel = when {
+        !shouldShowBottomSheet || mapUiMode == MapUiMode.Browsing -> MapSheetLevel.Hidden
+        mapUiMode == MapUiMode.SpotDetail && selectedSpot != null -> MapSheetLevel.Medium
+        else -> MapSheetLevel.Peek
+    }
+
+    LaunchedEffect(
+        uiState.hasSearched,
+        uiState.isLoading,
+        uiState.searchMode,
+        uiState.errorMessage,
+        uiState.locationNoticeMessage,
+    ) {
+        when {
+            isCurrentLocationSearching -> {
+                mapUiMode = MapUiMode.Browsing
+            }
+
+            uiState.isLoading || uiState.errorMessage != null || uiState.locationNoticeMessage != null -> {
+                mapUiMode = MapUiMode.ResultList
+            }
+
+            uiState.hasSearched && mapUiMode == MapUiMode.Browsing -> {
+                mapUiMode = MapUiMode.ResultList
+            }
+        }
+    }
+
+    LaunchedEffect(selectedSpot?.id, uiState.spots) {
+        if (selectedSpot == null && mapUiMode == MapUiMode.SpotDetail) {
+            mapUiMode = if (uiState.hasSearched) {
+                MapUiMode.ResultList
+            } else {
+                MapUiMode.Browsing
+            }
+        }
+    }
+
+    BoxWithConstraints(
         modifier = modifier.fillMaxSize(),
     ) {
-        MapSearchBar(
-            keyword = uiState.searchKeyword,
-            onKeywordChanged = onKeywordChanged,
-            onSearchClick = onSearchClick,
-        )
-
-        SpotFilterChipRow(
-            selectedTypes = uiState.selectedTypes,
-            onTypeClick = onTypeClick,
-        )
-
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-        ) {
-            CurrentLocationButton(
-                onClick = onCurrentLocationClick,
-            )
-        }
-
         CollectionSpotNaverMap(
             spots = uiState.spots,
             selectedSpot = uiState.selectedSpot,
-            onSpotClick = onSpotClick,
+            onSpotClick = { spot ->
+                mapUiMode = MapUiMode.SpotDetail
+                onSpotClick(spot)
+            },
+            onMapClick = {
+                mapUiMode = if (mapUiMode == MapUiMode.Browsing) {
+                    MapUiMode.ResultList.takeIf { shouldShowBottomSheet } ?: MapUiMode.Browsing
+                } else {
+                    MapUiMode.Browsing
+                }
+            },
             modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
+                .fillMaxSize(),
         )
 
-        when {
-            uiState.isLoading -> {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(0.45f),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    CircularProgressIndicator()
+        if (mapUiMode != MapUiMode.SpotDetail) {
+            MapOverlayControls(
+                keyword = uiState.searchKeyword,
+                selectedTypes = uiState.selectedTypes,
+                onKeywordChanged = onKeywordChanged,
+                onSearchClick = {
+                    mapUiMode = MapUiMode.ResultList
+                    onSearchClick()
+                },
+                onTypeClick = { type ->
+                    mapUiMode = MapUiMode.ResultList
+                    onTypeClick(type)
+                },
+                onCurrentLocationClick = {
+                    mapUiMode = MapUiMode.ResultList
+                    onCurrentLocationClick()
+                },
+            )
+        }
+
+        if (isCurrentLocationSearching) {
+            CurrentLocationSearchLoadingOverlay()
+        }
+
+        if (shouldShowBottomSheet) {
+            ThreeStepMapBottomSheet(
+                sheetLevel = sheetLevel,
+                modifier = Modifier.align(Alignment.BottomCenter),
+            ) {
+                when {
+                    mapUiMode == MapUiMode.SpotDetail && selectedSpot != null -> {
+                        SpotDetailBottomSheetContent(
+                            spot = selectedSpot,
+                            onCloseClick = {
+                                mapUiMode = MapUiMode.ResultList
+                            },
+                        )
+                    }
+
+                    mapUiMode == MapUiMode.ResultList -> {
+                        SpotBottomSheetContent(
+                            spots = uiState.spots,
+                            selectedSpot = selectedSpot,
+                            isLoading = uiState.isLoading,
+                            hasSearched = uiState.hasSearched,
+                            selectedTypes = uiState.selectedTypes,
+                            locationNoticeMessage = uiState.locationNoticeMessage,
+                            errorMessage = uiState.errorMessage,
+                            onTypeClick = onTypeClick,
+                            onSpotClick = { spot ->
+                                mapUiMode = MapUiMode.SpotDetail
+                                onSpotClick(spot)
+                            },
+                        )
+                    }
                 }
-            }
-
-            uiState.locationNoticeMessage != null -> {
-                EmptySpotResult(
-                    title = "현재 위치 검색 안내",
-                    description = uiState.locationNoticeMessage,
-                )
-            }
-
-            uiState.errorMessage != null -> {
-                EmptySpotResult(
-                    title = "수거 장소를 불러오지 못했습니다.",
-                    description = uiState.errorMessage,
-                )
-            }
-
-            uiState.hasSearched && uiState.spots.isEmpty() -> {
-                EmptySpotResult()
-            }
-
-            uiState.spots.isNotEmpty() -> {
-                SpotBottomList(
-                    spots = uiState.spots,
-                    selectedSpot = uiState.selectedSpot,
-                    onSpotClick = onSpotClick,
-                    modifier = Modifier.weight(0.45f),
-                )
             }
         }
     }
 }
+
+@Composable
+private fun ThreeStepMapBottomSheet(
+    sheetLevel: MapSheetLevel,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        val density = LocalDensity.current
+        val coroutineScope = rememberCoroutineScope()
+        val sheetHeight = maxHeight - MapSheetTopMargin
+        val sheetHeightPx = with(density) {
+            sheetHeight.toPx().coerceAtLeast(1f)
+        }
+        val hiddenOffset = with(density) {
+            (sheetHeight - Dp.Hairline).toPx().coerceIn(0f, sheetHeightPx)
+        }
+        val peekOffset = with(density) {
+            (sheetHeight - MapResultBottomSheetPeekHeight).toPx().coerceIn(0f, hiddenOffset)
+        }
+        val mediumOffset = with(density) {
+            (sheetHeight - MapSpotDetailBottomSheetPeekHeight).toPx().coerceIn(0f, hiddenOffset)
+        }
+        val expandedOffset = 0f
+        val targetOffset = when (sheetLevel) {
+            MapSheetLevel.Hidden -> hiddenOffset
+            MapSheetLevel.Peek -> peekOffset
+            MapSheetLevel.Medium -> mediumOffset
+            MapSheetLevel.Expanded -> expandedOffset
+        }
+        val sheetOffset = remember(sheetHeightPx) {
+            Animatable(targetOffset)
+        }
+
+        LaunchedEffect(targetOffset) {
+            sheetOffset.animateTo(targetOffset)
+        }
+
+        Surface(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .height(sheetHeight)
+                .offset {
+                    IntOffset(x = 0, y = sheetOffset.value.roundToInt())
+                }
+                .pointerInput(sheetHeightPx, hiddenOffset, peekOffset, mediumOffset) {
+                    detectVerticalDragGestures(
+                        onVerticalDrag = { change, dragAmount ->
+                            change.consume()
+                            coroutineScope.launch {
+                                sheetOffset.snapTo(
+                                    (sheetOffset.value + dragAmount).coerceIn(
+                                        expandedOffset,
+                                        hiddenOffset,
+                                    ),
+                                )
+                            }
+                        },
+                        onDragEnd = {
+                            val nearestOffset = listOf(
+                                hiddenOffset,
+                                peekOffset,
+                                mediumOffset,
+                                expandedOffset,
+                            ).minBy { offset ->
+                                kotlin.math.abs(offset - sheetOffset.value)
+                            }
+
+                            coroutineScope.launch {
+                                sheetOffset.animateTo(nearestOffset)
+                            }
+                        },
+                    )
+                },
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surface,
+            shadowElevation = 4.dp,
+        ) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                content()
+            }
+        }
+    }
+}
+
+private val CollectionSpotMapUiState.shouldShowBottomSheet: Boolean
+    get() = isLoading ||
+        locationNoticeMessage != null ||
+        errorMessage != null ||
+        hasSearched ||
+        spots.isNotEmpty()
+
+private enum class MapUiMode {
+    Browsing,
+    ResultList,
+    SpotDetail,
+}
+
+private enum class MapSheetLevel {
+    Hidden,
+    Peek,
+    Medium,
+    Expanded,
+}
+
+private val MapSheetTopMargin = 72.dp
+private val MapStatusBottomSheetPeekHeight = 132.dp
+private val MapResultBottomSheetPeekHeight = 144.dp
+private val MapSpotDetailBottomSheetPeekHeight = 292.dp
 
 @Preview(showBackground = true)
 @Composable

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -78,13 +78,9 @@ private fun CollectionSpotMapContent(
         uiState.searchMode == MapSearchMode.CURRENT_LOCATION
     val shouldShowBottomSheet = uiState.shouldShowBottomSheet && !isCurrentLocationSearching
     var mapUiMode by remember { mutableStateOf(MapUiMode.Browsing) }
+    var sheetLevel by remember { mutableStateOf(MapSheetLevel.Hidden) }
     var sheetRevealRequest by remember { mutableStateOf(0) }
     val selectedSpot = uiState.selectedSpot
-    val sheetLevel = when {
-        !shouldShowBottomSheet || mapUiMode == MapUiMode.Browsing -> MapSheetLevel.Hidden
-        mapUiMode == MapUiMode.SpotDetail && selectedSpot != null -> MapSheetLevel.Medium
-        else -> MapSheetLevel.Peek
-    }
 
     LaunchedEffect(
         uiState.hasSearched,
@@ -96,14 +92,17 @@ private fun CollectionSpotMapContent(
         when {
             isCurrentLocationSearching -> {
                 mapUiMode = MapUiMode.Browsing
+                sheetLevel = MapSheetLevel.Hidden
             }
 
             uiState.isLoading || uiState.errorMessage != null || uiState.locationNoticeMessage != null -> {
                 mapUiMode = MapUiMode.ResultList
+                sheetLevel = MapSheetLevel.Peek
             }
 
             uiState.hasSearched && mapUiMode == MapUiMode.Browsing -> {
                 mapUiMode = MapUiMode.ResultList
+                sheetLevel = MapSheetLevel.Peek
             }
         }
     }
@@ -111,8 +110,10 @@ private fun CollectionSpotMapContent(
     LaunchedEffect(selectedSpot?.id, uiState.spots) {
         if (selectedSpot == null && mapUiMode == MapUiMode.SpotDetail) {
             mapUiMode = if (uiState.hasSearched) {
+                sheetLevel = MapSheetLevel.Peek
                 MapUiMode.ResultList
             } else {
+                sheetLevel = MapSheetLevel.Hidden
                 MapUiMode.Browsing
             }
         }
@@ -126,14 +127,17 @@ private fun CollectionSpotMapContent(
             selectedSpot = uiState.selectedSpot,
             onSpotClick = { spot ->
                 mapUiMode = MapUiMode.SpotDetail
+                sheetLevel = MapSheetLevel.Medium
                 sheetRevealRequest += 1
                 onSpotClick(spot)
             },
             onMapClick = {
-                mapUiMode = if (mapUiMode == MapUiMode.Browsing) {
-                    MapUiMode.ResultList.takeIf { shouldShowBottomSheet } ?: MapUiMode.Browsing
+                if (mapUiMode == MapUiMode.Browsing) {
+                    mapUiMode = MapUiMode.ResultList.takeIf { shouldShowBottomSheet } ?: MapUiMode.Browsing
+                    sheetLevel = MapSheetLevel.Peek.takeIf { shouldShowBottomSheet } ?: MapSheetLevel.Hidden
                 } else {
-                    MapUiMode.Browsing
+                    mapUiMode = MapUiMode.Browsing
+                    sheetLevel = MapSheetLevel.Hidden
                 }
             },
             modifier = Modifier
@@ -147,14 +151,17 @@ private fun CollectionSpotMapContent(
                 onKeywordChanged = onKeywordChanged,
                 onSearchClick = {
                     mapUiMode = MapUiMode.ResultList
+                    sheetLevel = MapSheetLevel.Peek
                     onSearchClick()
                 },
                 onTypeClick = { type ->
                     mapUiMode = MapUiMode.ResultList
+                    sheetLevel = MapSheetLevel.Peek
                     onTypeClick(type)
                 },
                 onCurrentLocationClick = {
                     mapUiMode = MapUiMode.ResultList
+                    sheetLevel = MapSheetLevel.Peek
                     onCurrentLocationClick()
                 },
             )
@@ -168,6 +175,9 @@ private fun CollectionSpotMapContent(
             ThreeStepMapBottomSheet(
                 sheetLevel = sheetLevel,
                 revealKey = "$mapUiMode-${selectedSpot?.id}-$sheetRevealRequest",
+                onSheetLevelChanged = { level ->
+                    sheetLevel = level
+                },
                 modifier = Modifier.align(Alignment.BottomCenter),
             ) {
                 when {
@@ -176,6 +186,7 @@ private fun CollectionSpotMapContent(
                             spot = selectedSpot,
                             onCloseClick = {
                                 mapUiMode = MapUiMode.ResultList
+                                sheetLevel = MapSheetLevel.Peek
                             },
                         )
                     }
@@ -192,6 +203,7 @@ private fun CollectionSpotMapContent(
                             onTypeClick = onTypeClick,
                             onSpotClick = { spot ->
                                 mapUiMode = MapUiMode.SpotDetail
+                                sheetLevel = MapSheetLevel.Medium
                                 sheetRevealRequest += 1
                                 onSpotClick(spot)
                             },
@@ -207,6 +219,7 @@ private fun CollectionSpotMapContent(
 private fun ThreeStepMapBottomSheet(
     sheetLevel: MapSheetLevel,
     revealKey: Any?,
+    onSheetLevelChanged: (MapSheetLevel) -> Unit,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
@@ -227,12 +240,15 @@ private fun ThreeStepMapBottomSheet(
             (sheetHeight - MapSpotDetailBottomSheetPeekHeight).toPx().coerceIn(0f, hiddenOffset)
         }
         val expandedOffset = 0f
-        val targetOffset = when (sheetLevel) {
-            MapSheetLevel.Hidden -> hiddenOffset
-            MapSheetLevel.Peek -> peekOffset
-            MapSheetLevel.Medium -> mediumOffset
-            MapSheetLevel.Expanded -> expandedOffset
-        }
+        fun offsetFor(level: MapSheetLevel): Float =
+            when (level) {
+                MapSheetLevel.Hidden -> hiddenOffset
+                MapSheetLevel.Peek -> peekOffset
+                MapSheetLevel.Medium -> mediumOffset
+                MapSheetLevel.Expanded -> expandedOffset
+            }
+
+        val targetOffset = offsetFor(sheetLevel)
         val sheetOffset = remember(sheetHeightPx) {
             Animatable(targetOffset)
         }
@@ -263,17 +279,13 @@ private fun ThreeStepMapBottomSheet(
                             }
                         },
                         onDragEnd = {
-                            val nearestOffset = listOf(
-                                hiddenOffset,
-                                peekOffset,
-                                mediumOffset,
-                                expandedOffset,
-                            ).minBy { offset ->
-                                kotlin.math.abs(offset - sheetOffset.value)
+                            val nearestLevel = MapSheetLevel.entries.minBy { level ->
+                                kotlin.math.abs(offsetFor(level) - sheetOffset.value)
                             }
 
+                            onSheetLevelChanged(nearestLevel)
                             coroutineScope.launch {
-                                sheetOffset.animateTo(nearestOffset)
+                                sheetOffset.animateTo(offsetFor(nearestLevel))
                             }
                         },
                     )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CollectionSpotNaverMap.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CollectionSpotNaverMap.kt
@@ -3,7 +3,7 @@ package com.team.yeogibeoryeo.presentation.map.components
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.MaterialTheme
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
 import com.naver.maps.map.CameraUpdate
@@ -20,8 +20,11 @@ fun CollectionSpotNaverMap(
     spots: List<CollectionSpot>,
     selectedSpot: CollectionSpot?,
     onSpotClick: (CollectionSpot) -> Unit,
+    onMapClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val defaultMarkerColor = MaterialTheme.colorScheme.primary
+    val selectedMarkerColor = MaterialTheme.colorScheme.tertiary
     val markerSpots = spots.filter { spot ->
         spot.coordinate != null
     }
@@ -69,6 +72,9 @@ fun CollectionSpotNaverMap(
     NaverMap(
         modifier = modifier,
         cameraPositionState = cameraPositionState,
+        onMapClick = { _, _ ->
+            onMapClick()
+        },
     ) {
         markerSpots.forEach { spot ->
             val coordinate = spot.coordinate ?: return@forEach
@@ -83,9 +89,9 @@ fun CollectionSpotNaverMap(
                 ),
                 captionText = spot.name,
                 iconTintColor = if (isSelected) {
-                    SELECTED_MARKER_COLOR
+                    selectedMarkerColor
                 } else {
-                    DEFAULT_MARKER_COLOR
+                    defaultMarkerColor
                 },
                 zIndex = if (isSelected) {
                     SELECTED_MARKER_Z_INDEX
@@ -105,9 +111,6 @@ private val DEFAULT_LOCATION = LatLng(
     37.5666102,
     126.9783881,
 )
-
-private val DEFAULT_MARKER_COLOR = Color(0xFF00C853)
-private val SELECTED_MARKER_COLOR = Color(0xFFFF7043)
 
 private const val DEFAULT_ZOOM = 12.0
 private const val SEARCH_RESULT_ZOOM = 15.0

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CurrentLocationSearchLoadingOverlay.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CurrentLocationSearchLoadingOverlay.kt
@@ -1,0 +1,67 @@
+package com.team.yeogibeoryeo.presentation.map.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CurrentLocationSearchLoadingOverlay(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.18f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Surface(
+            shape = MaterialTheme.shapes.large,
+            color = MaterialTheme.colorScheme.surface,
+            tonalElevation = 4.dp,
+            shadowElevation = 4.dp,
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 28.dp, vertical = 24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(14.dp),
+            ) {
+                Text(
+                    text = "검색중",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                CircularProgressIndicator(
+                    modifier = Modifier.size(48.dp),
+                    color = MaterialTheme.colorScheme.primary,
+                    strokeWidth = 4.dp,
+                )
+                Text(
+                    text = "현재 위치 주변을 찾고 있어요",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CurrentLocationSearchLoadingOverlayPreview() {
+    MaterialTheme {
+        CurrentLocationSearchLoadingOverlay()
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapOverlayControls.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapOverlayControls.kt
@@ -1,0 +1,160 @@
+package com.team.yeogibeoryeo.presentation.map.components
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.presentation.map.mapper.toDisplayName
+
+@Composable
+fun MapOverlayControls(
+    keyword: String,
+    selectedTypes: Set<CollectionSpotType>,
+    onKeywordChanged: (String) -> Unit,
+    onSearchClick: () -> Unit,
+    onTypeClick: (CollectionSpotType) -> Unit,
+    onCurrentLocationClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .padding(top = 2.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        MapOverlaySearchArea(
+            keyword = keyword,
+            onKeywordChanged = onKeywordChanged,
+            onSearchClick = onSearchClick,
+        )
+
+        MapOverlayQuickControlArea(
+            selectedTypes = selectedTypes,
+            onTypeClick = onTypeClick,
+            onCurrentLocationClick = onCurrentLocationClick,
+        )
+    }
+}
+
+@Composable
+private fun MapOverlaySearchArea(
+    keyword: String,
+    onKeywordChanged: (String) -> Unit,
+    onSearchClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surface,
+        tonalElevation = 3.dp,
+        shadowElevation = 2.dp,
+    ) {
+        MapSearchBar(
+            keyword = keyword,
+            onKeywordChanged = onKeywordChanged,
+            onSearchClick = onSearchClick,
+        )
+    }
+}
+
+@Composable
+private fun MapOverlayQuickControlArea(
+    selectedTypes: Set<CollectionSpotType>,
+    onTypeClick: (CollectionSpotType) -> Unit,
+    onCurrentLocationClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(min = 48.dp)
+            .padding(horizontal = 16.dp),
+        contentAlignment = Alignment.CenterEnd,
+    ) {
+        if (selectedTypes.isNotEmpty()) {
+            Row(
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(end = CurrentLocationButtonReservedWidth),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                selectedTypes.forEach { type ->
+                    FilterChip(
+                        selected = true,
+                        onClick = {
+                            onTypeClick(type)
+                        },
+                        label = {
+                            Text(text = type.toDisplayName())
+                        },
+                    )
+                }
+            }
+        }
+
+        CurrentLocationButton(
+            onClick = onCurrentLocationClick,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MapOverlayControlsPreview() {
+    MaterialTheme {
+        Surface {
+            MapOverlayControls(
+                keyword = "",
+                selectedTypes = emptySet(),
+                onKeywordChanged = {},
+                onSearchClick = {},
+                onTypeClick = {},
+                onCurrentLocationClick = {},
+            )
+        }
+    }
+}
+
+private val CurrentLocationButtonReservedWidth = 176.dp
+
+@Preview(showBackground = true)
+@Composable
+private fun MapOverlayControlsSelectedPreview() {
+    MaterialTheme {
+        Surface {
+            MapOverlayControls(
+                keyword = "문래동",
+                selectedTypes = setOf(
+                    CollectionSpotType.BATTERY_BIN,
+                    CollectionSpotType.SMALL_E_WASTE_BIN,
+                ),
+                onKeywordChanged = {},
+                onSearchClick = {},
+                onTypeClick = {},
+                onCurrentLocationClick = {},
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
@@ -30,7 +30,7 @@ fun MapSearchBar(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(horizontal = 14.dp, vertical = 8.dp),
     ) {
         OutlinedTextField(
             value = keyword,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
@@ -15,11 +15,15 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun MapSearchBar(
     keyword: String,
@@ -27,6 +31,15 @@ fun MapSearchBar(
     onSearchClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    fun submitSearch() {
+        focusManager.clearFocus()
+        keyboardController?.hide()
+        onSearchClick()
+    }
+
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -44,7 +57,7 @@ fun MapSearchBar(
             singleLine = true,
             trailingIcon = {
                 IconButton(
-                    onClick = onSearchClick,
+                    onClick = ::submitSearch,
                 ) {
                     Icon(
                         imageVector = Icons.Default.Search,
@@ -57,7 +70,7 @@ fun MapSearchBar(
             ),
             keyboardActions = KeyboardActions(
                 onSearch = {
-                    onSearchClick()
+                    submitSearch()
                 },
             ),
         )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomCard.kt
@@ -26,7 +26,7 @@ import com.team.yeogibeoryeo.presentation.map.mapper.toDisplayName
 fun SpotBottomCard(
     spot: CollectionSpot,
     isSelected: Boolean,
-    onClick: (CollectionSpot) -> Unit,
+    onClick: ((CollectionSpot) -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
     val containerColor = if (isSelected) {
@@ -44,13 +44,18 @@ fun SpotBottomCard(
     } else {
         MaterialTheme.colorScheme.onSurfaceVariant
     }
+    val cardModifier = modifier.fillMaxWidth().let { baseModifier ->
+        if (onClick == null) {
+            baseModifier
+        } else {
+            baseModifier.clickable {
+                onClick(spot)
+            }
+        }
+    }
 
     Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable {
-                onClick(spot)
-            },
+        modifier = cardModifier,
         colors = CardDefaults.cardColors(
             containerColor = containerColor,
             contentColor = contentColor,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomCard.kt
@@ -1,5 +1,6 @@
 package com.team.yeogibeoryeo.presentation.map.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -28,6 +29,22 @@ fun SpotBottomCard(
     onClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val containerColor = if (isSelected) {
+        MaterialTheme.colorScheme.tertiaryContainer
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+    val contentColor = if (isSelected) {
+        MaterialTheme.colorScheme.onTertiaryContainer
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+    val supportingContentColor = if (isSelected) {
+        MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.78f)
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
     Card(
         modifier = modifier
             .fillMaxWidth()
@@ -35,15 +52,17 @@ fun SpotBottomCard(
                 onClick(spot)
             },
         colors = CardDefaults.cardColors(
-            containerColor = if (isSelected) {
-                MaterialTheme.colorScheme.primaryContainer
-            } else {
-                MaterialTheme.colorScheme.surface
-            },
+            containerColor = containerColor,
+            contentColor = contentColor,
         ),
         elevation = CardDefaults.cardElevation(
-            defaultElevation = if (isSelected) 6.dp else 2.dp,
+            defaultElevation = if (isSelected) 8.dp else 2.dp,
         ),
+        border = if (isSelected) {
+            BorderStroke(1.dp, MaterialTheme.colorScheme.tertiary)
+        } else {
+            null
+        },
     ) {
         Column(
             modifier = Modifier
@@ -55,7 +74,7 @@ fun SpotBottomCard(
                     text = spot.type.toDisplayName(),
                     style = MaterialTheme.typography.labelMedium,
                     color = if (isSelected) {
-                        MaterialTheme.colorScheme.onPrimaryContainer
+                        MaterialTheme.colorScheme.tertiary
                     } else {
                         MaterialTheme.colorScheme.primary
                     },
@@ -67,7 +86,7 @@ fun SpotBottomCard(
                     Text(
                         text = "${distanceMeter}m",
                         style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        color = supportingContentColor,
                     )
                 }
             }
@@ -83,7 +102,7 @@ fun SpotBottomCard(
                 text = spot.address,
                 modifier = Modifier.padding(top = 4.dp),
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = supportingContentColor,
             )
 
             spot.detailLocation?.let { detailLocation ->
@@ -91,7 +110,7 @@ fun SpotBottomCard(
                     text = detailLocation,
                     modifier = Modifier.padding(top = 2.dp),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = supportingContentColor,
                 )
             }
         }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomList.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomList.kt
@@ -22,11 +22,21 @@ fun SpotBottomList(
     selectedSpot: CollectionSpot?,
     onSpotClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(
+        start = 16.dp,
+        top = 12.dp,
+        end = 16.dp,
+        bottom = 96.dp,
+    ),
 ) {
     val listState = rememberLazyListState()
 
     LaunchedEffect(selectedSpot?.id, spots) {
         val selectedIndex = spots.indexOfFirst { spot ->
+            spot == selectedSpot
+        }.takeIf { index ->
+            index >= 0
+        } ?: spots.indexOfFirst { spot ->
             spot.id == selectedSpot?.id
         }
 
@@ -38,16 +48,16 @@ fun SpotBottomList(
     LazyColumn(
         state = listState,
         modifier = modifier,
-        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+        contentPadding = contentPadding,
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         itemsIndexed(
             items = spots,
-            key = { _, spot -> spot.id },
+            key = { index, spot -> "${spot.id}_$index" },
         ) { _, spot ->
             SpotBottomCard(
                 spot = spot,
-                isSelected = spot.id == selectedSpot?.id,
+                isSelected = spot == selectedSpot,
                 onClick = {
                     onSpotClick(spot)
                 },

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
@@ -140,7 +140,7 @@ fun SpotDetailBottomSheetContent(
         SpotBottomCard(
             spot = spot,
             isSelected = true,
-            onClick = {},
+            onClick = null,
             modifier = Modifier.fillMaxWidth(),
         )
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
@@ -135,8 +134,8 @@ fun SpotDetailBottomSheetContent(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .navigationBarsPadding()
-            .padding(horizontal = 20.dp, vertical = 16.dp),
+            .padding(horizontal = 20.dp)
+            .padding(top = 16.dp, bottom = 8.dp),
     ) {
         SpotBottomCard(
             spot = spot,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
@@ -1,0 +1,281 @@
+package com.team.yeogibeoryeo.presentation.map.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+
+@Composable
+fun SpotBottomSheetContent(
+    spots: List<CollectionSpot>,
+    selectedSpot: CollectionSpot?,
+    isLoading: Boolean,
+    hasSearched: Boolean,
+    selectedTypes: Set<CollectionSpotType>,
+    locationNoticeMessage: String?,
+    errorMessage: String?,
+    onTypeClick: (CollectionSpotType) -> Unit,
+    onSpotClick: (CollectionSpot) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        SpotBottomSheetHeader(
+            resultCount = spots.size,
+            hasSearched = hasSearched,
+        )
+
+        if (hasSearched && !isLoading) {
+            SpotFilterChipRow(
+                selectedTypes = selectedTypes,
+                onTypeClick = onTypeClick,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+
+        when {
+            isLoading -> {
+                SpotBottomSheetLoading()
+            }
+
+            locationNoticeMessage != null -> {
+                EmptySpotResult(
+                    title = "현재 위치 검색 안내",
+                    description = locationNoticeMessage,
+                )
+            }
+
+            errorMessage != null -> {
+                EmptySpotResult(
+                    title = "수거 장소를 불러오지 못했습니다.",
+                    description = errorMessage,
+                )
+            }
+
+            hasSearched && spots.isEmpty() -> {
+                EmptySpotResult()
+            }
+
+            spots.isNotEmpty() -> {
+                SpotBottomList(
+                    spots = spots,
+                    selectedSpot = selectedSpot,
+                    onSpotClick = onSpotClick,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = SpotBottomSheetListMaxHeight),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun SpotBottomSheetHeader(
+    resultCount: Int,
+    hasSearched: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = if (hasSearched) {
+                "검색 결과 ${resultCount}개"
+            } else {
+                "수거 장소 검색"
+            },
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 14.dp),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+
+        HorizontalDivider(
+            color = MaterialTheme.colorScheme.outlineVariant,
+        )
+    }
+}
+
+@Composable
+private fun SpotBottomSheetLoading(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(min = 180.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+fun SpotDetailBottomSheetContent(
+    spot: CollectionSpot,
+    onCloseClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .padding(horizontal = 20.dp, vertical = 16.dp),
+    ) {
+        SpotBottomCard(
+            spot = spot,
+            isSelected = true,
+            onClick = {},
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Text(
+            text = "목록으로",
+            modifier = Modifier
+                .align(Alignment.End)
+                .clickable(onClick = onCloseClick)
+                .padding(top = 12.dp, bottom = 8.dp),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SpotBottomSheetContentPreview() {
+    MaterialTheme {
+        Surface {
+            SpotBottomSheetContent(
+                spots = sampleSpotBottomSheetSpots(),
+                selectedSpot = sampleSpotBottomSheetSpots()[1],
+                isLoading = false,
+                hasSearched = true,
+                selectedTypes = setOf(CollectionSpotType.BATTERY_BIN),
+                locationNoticeMessage = null,
+                errorMessage = null,
+                onTypeClick = {},
+                onSpotClick = {},
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SpotBottomSheetContentLoadingPreview() {
+    MaterialTheme {
+        Surface {
+            SpotBottomSheetContent(
+                spots = emptyList(),
+                selectedSpot = null,
+                isLoading = true,
+                hasSearched = true,
+                selectedTypes = emptySet(),
+                locationNoticeMessage = null,
+                errorMessage = null,
+                onTypeClick = {},
+                onSpotClick = {},
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SpotBottomSheetContentEmptyPreview() {
+    MaterialTheme {
+        Surface {
+            SpotBottomSheetContent(
+                spots = emptyList(),
+                selectedSpot = null,
+                isLoading = false,
+                hasSearched = true,
+                selectedTypes = emptySet(),
+                locationNoticeMessage = null,
+                errorMessage = null,
+                onTypeClick = {},
+                onSpotClick = {},
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SpotDetailBottomSheetContentPreview() {
+    MaterialTheme {
+        Surface {
+            SpotDetailBottomSheetContent(
+                spot = sampleSpotBottomSheetSpots()[0],
+                onCloseClick = {},
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SpotBottomSheetHeaderPreview() {
+    MaterialTheme {
+        Surface {
+            SpotBottomSheetHeader(
+                resultCount = 3,
+                hasSearched = true,
+            )
+        }
+    }
+}
+
+private fun sampleSpotBottomSheetSpots(): List<CollectionSpot> {
+    return listOf(
+        CollectionSpot(
+            id = "1",
+            name = "폐건전지 수거함",
+            type = CollectionSpotType.BATTERY_BIN,
+            address = "서울특별시 영등포구 문래동",
+            detailLocation = "주민센터 앞",
+            coordinate = null,
+            distanceMeter = 120,
+            isBookmarked = false,
+        ),
+        CollectionSpot(
+            id = "2",
+            name = "중소형 폐가전 수거함",
+            type = CollectionSpotType.SMALL_E_WASTE_BIN,
+            address = "서울특별시 구로구 구로동",
+            detailLocation = "아파트 관리사무소 옆",
+            coordinate = null,
+            distanceMeter = 350,
+            isBookmarked = false,
+        ),
+        CollectionSpot(
+            id = "3",
+            name = "재활용센터",
+            type = CollectionSpotType.RECYCLING_CENTER,
+            address = "서울특별시 성동구 용답동",
+            detailLocation = null,
+            coordinate = null,
+            distanceMeter = null,
+            isBookmarked = false,
+        ),
+    )
+}
+
+private val SpotBottomSheetListMaxHeight = 560.dp


### PR DESCRIPTION
## 작업 내용

Closes #73

지도 화면의 탐색 UX를 개선했습니다.

기존에는 검색바, 필터칩, 현재 위치 버튼이 지도 영역과 분리되어 있어 지도 표시 영역이 좁고, 하단 장소 리스트도 지도와 함께 보기 불편했습니다.

이번 작업에서는 지도 위 오버레이 컨트롤과 커스텀 3단계 BottomSheet 구조를 적용해 지도 기반 탐색 흐름을 정리했습니다.

## 주요 변경 사항

- 검색바를 지도 상단 오버레이 구조로 변경
- 선택된 필터칩을 지도 위 오버레이로 표시
- 현재 위치 버튼을 지도 위 고정 컨트롤로 정리
- 장소 목록을 커스텀 3단계 BottomSheet로 전환
  - 낮은 상태: 검색 결과 요약
  - 중간 상태: 선택된 장소 상세 카드
  - 확장 상태: 장소 리스트 탐색
- 마커 클릭 시 선택된 장소 상세 카드 표시
- 카드 클릭 시 기존처럼 지도 카메라 이동 및 선택 상태 유지
- 지도 클릭 시 검색바 / BottomSheet 노출 흐름 정리
- 검색 실행 시 키보드가 내려가도록 포커스 처리
- 현재 위치 검색 중 지도 위 로딩 오버레이 추가
- 선택된 카드와 마커 색상을 MaterialTheme 기반 스타일로 정리
- BottomSheet / 오버레이 관련 컴포넌트 분리

## 스크린샷

### 현재 위치 검색 흐름

| 현재 위치 검색 중 | 현재 위치 검색 결과 |
| --- | --- |
| <img width="260" alt="현재 위치 검색 중" src="https://github.com/user-attachments/assets/ab3b9177-19ba-4d7b-a6b7-3d8383def440" /> | <img width="260" alt="현재 위치 검색 결과" src="https://github.com/user-attachments/assets/3395ec0d-709d-4ded-b534-12f2fbf87b8c" /> |

### 필터 및 장소 선택

| 필터 선택 | 장소 선택 상세 |
| --- | --- |
| <img width="260" alt="필터 선택 화면" src="https://github.com/user-attachments/assets/d480a40a-1ddc-4a60-8200-ba8395cec2ec" /> | <img width="260" alt="장소 선택 상세 화면" src="https://github.com/user-attachments/assets/48d08612-6f43-465e-a755-5d3c1acfbce6" /> |

### 키워드 검색 흐름

| 검색 결과 | 필터 선택 | 장소 선택 상세 |
| --- | --- | --- |
| <img width="260" alt="용답동 검색 결과" src="https://github.com/user-attachments/assets/dd6fb1a3-1f0b-43c4-9c83-c34bf5ed3842" /> | <img width="260" alt="용답동 필터 선택" src="https://github.com/user-attachments/assets/d6128177-818f-44ab-943c-a1614293328d" /> | <img width="260" alt="용답동 장소 선택 상세" src="https://github.com/user-attachments/assets/c8f3ab1b-a0f4-4adc-a480-85abe9b019f0" /> |

## 확인한 동작

- [x] 검색 결과가 있을 때 BottomSheet가 표시됨
- [x] BottomSheet가 낮은 상태 / 중간 상태 / 확장 상태로 동작함
- [x] BottomSheet 확장 상태에서 장소 리스트 스크롤이 동작함
- [x] 마커 클릭 시 선택된 장소 상세 카드가 표시됨
- [x] 상세 BottomSheet를 내린 뒤 다른 마커를 누르면 다시 상세 카드가 표시됨
- [x] 카드 클릭 시 해당 장소로 지도 카메라가 이동함
- [x] 선택된 카드와 마커가 강조됨
- [x] 필터칩 선택 시 지도 마커와 BottomSheet 리스트가 함께 갱신됨
- [x] 현재 위치 버튼이 필터칩 선택 여부와 무관하게 고정 위치를 유지함
- [x] 현재 위치 검색 중 지도 위 로딩 오버레이가 표시됨
- [x] 검색바 입력 후 돋보기 버튼 또는 키보드 검색 액션 실행 시 키보드가 내려감
- [x] Bottom Navigation과 BottomSheet가 시각적으로 충돌하지 않음

## 테스트

- [x] `./gradlew :presentation:compileDebugKotlin`
- [x] `./gradlew :presentation:testDebugUnitTest`
- [x] `./gradlew :app:installDebug`

## 후속 작업

현재 위치 표시 / 위치 추적 / Map 재진입 시 현재 위치 또는 마지막 지도 위치 유지 정책은 별도 후속 이슈에서 진행합니다.

- Follow-up: #79