### PR TITLE
feat: Map 진입 시 현재 위치 기반 검색 자동 실행

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -51,6 +51,10 @@ fun CollectionSpotMapScreen(
         onDenied = viewModel::onLocationPermissionDenied,
     )
 
+    LaunchedEffect(Unit) {
+        viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+    }
+
     CollectionSpotMapContent(
         uiState = uiState,
         onKeywordChanged = viewModel::onSearchKeywordChanged,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -38,11 +38,44 @@ class CollectionSpotMapViewModel @Inject constructor(
     private var hasRequestedInitialCurrentLocationSearch = false
 
     fun onSearchKeywordChanged(keyword: String) {
+        val shouldCancelCurrentLocationSearch =
+            uiState.value.isLoading &&
+                uiState.value.searchMode == MapSearchMode.CURRENT_LOCATION
+
+        if (shouldCancelCurrentLocationSearch) {
+            spotSearchJob?.cancel()
+        }
+
         _uiState.update {
             it.copy(
                 searchKeyword = keyword,
+                spots = if (shouldCancelCurrentLocationSearch) {
+                    emptyList()
+                } else {
+                    it.spots
+                },
+                selectedSpot = if (shouldCancelCurrentLocationSearch) {
+                    null
+                } else {
+                    it.selectedSpot
+                },
+                isLoading = if (shouldCancelCurrentLocationSearch) {
+                    false
+                } else {
+                    it.isLoading
+                },
+                hasSearched = if (shouldCancelCurrentLocationSearch) {
+                    false
+                } else {
+                    it.hasSearched
+                },
                 errorMessage = null,
                 locationNoticeMessage = null,
+                searchMode = if (shouldCancelCurrentLocationSearch) {
+                    MapSearchMode.KEYWORD
+                } else {
+                    it.searchMode
+                },
             )
         }
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -10,6 +10,7 @@ import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByKeywordU
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByLocationUseCase
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationProvider
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationResult
+import com.team.yeogibeoryeo.presentation.map.location.LocationPermissionChecker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
@@ -26,6 +27,7 @@ class CollectionSpotMapViewModel @Inject constructor(
     private val searchCollectionSpotsByLocationUseCase: SearchCollectionSpotsByLocationUseCase,
     private val filterCollectionSpotsUseCase: FilterCollectionSpotsUseCase,
     private val currentLocationProvider: CurrentLocationProvider,
+    private val locationPermissionChecker: LocationPermissionChecker,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CollectionSpotMapUiState())
@@ -33,6 +35,7 @@ class CollectionSpotMapViewModel @Inject constructor(
 
     private var originalSpots: List<CollectionSpot> = emptyList()
     private var spotSearchJob: Job? = null
+    private var hasRequestedInitialCurrentLocationSearch = false
 
     fun onSearchKeywordChanged(keyword: String) {
         _uiState.update {
@@ -188,6 +191,22 @@ class CollectionSpotMapViewModel @Inject constructor(
                 searchMode = MapSearchMode.KEYWORD,
             )
         }
+    }
+
+    fun searchByCurrentLocationOnMapEntryIfPermitted() {
+        val currentState = uiState.value
+        if (
+            hasRequestedInitialCurrentLocationSearch ||
+            currentState.hasSearched ||
+            currentState.isLoading ||
+            currentState.searchKeyword.isNotBlank() ||
+            !locationPermissionChecker.hasFineLocationPermission()
+        ) {
+            return
+        }
+
+        hasRequestedInitialCurrentLocationSearch = true
+        searchByCurrentLocation()
     }
 
     fun onCurrentLocationNotFound() {

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -247,6 +247,59 @@ class CollectionSpotMapViewModelTest {
         }
 
     @Test
+    fun `지도 진입 시 이미 검색 결과가 있으면 자동 현재 위치 검색을 실행하지 않는다`() =
+        runTest {
+            val keywordSpot = sampleSpot("keyword", CollectionSpotType.OTHER)
+            val repository = FakeCollectionSpotRepository(
+                keywordSpots = listOf(keywordSpot),
+                locationSpots = listOf(sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+                hasFineLocationPermission = true,
+            )
+
+            viewModel.onSearchKeywordChanged("문래동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+
+            assertEquals(0, repository.locationSearchCallCount)
+            assertEquals(listOf(keywordSpot), viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
+        }
+
+    @Test
+    fun `지도 진입 시 다른 검색이 로딩 중이면 자동 현재 위치 검색을 실행하지 않는다`() =
+        runTest {
+            val locationResult = CompletableDeferred<CurrentLocationResult>()
+            val locationSpot = sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)
+            val repository = FakeCollectionSpotRepository(locationSpots = listOf(locationSpot))
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationProvider = FakeCurrentLocationProvider {
+                    locationResult.await()
+                },
+                hasFineLocationPermission = true,
+            )
+
+            viewModel.searchByCurrentLocation()
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+            locationResult.complete(
+                CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(1, repository.locationSearchCallCount)
+            assertEquals(listOf(locationSpot), viewModel.uiState.value.spots)
+        }
+
+    @Test
     fun `지도 진입 시 사용자가 검색어를 입력한 상태면 자동 현재 위치 검색을 실행하지 않는다`() =
         runTest {
             val repository = FakeCollectionSpotRepository()
@@ -264,6 +317,37 @@ class CollectionSpotMapViewModelTest {
             assertEquals(0, repository.locationSearchCallCount)
             assertFalse(viewModel.uiState.value.hasSearched)
             assertEquals("문래동", viewModel.uiState.value.searchKeyword)
+        }
+
+    @Test
+    fun `지도 진입 자동 현재 위치 검색 중 검색어를 입력하면 현재 위치 결과를 반영하지 않는다`() =
+        runTest {
+            val locationResult = CompletableDeferred<CurrentLocationResult>()
+            val locationSpot = sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)
+            val repository = FakeCollectionSpotRepository(locationSpots = listOf(locationSpot))
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationProvider = FakeCurrentLocationProvider {
+                    locationResult.await()
+                },
+                hasFineLocationPermission = true,
+            )
+
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+            viewModel.onSearchKeywordChanged("문래동")
+            locationResult.complete(
+                CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(0, repository.locationSearchCallCount)
+            assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertFalse(viewModel.uiState.value.hasSearched)
+            assertEquals("문래동", viewModel.uiState.value.searchKeyword)
+            assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
         }
 
     private fun createViewModel(

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -9,6 +9,7 @@ import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByKeywordU
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByLocationUseCase
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationProvider
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationResult
+import com.team.yeogibeoryeo.presentation.map.location.LocationPermissionChecker
 import com.team.yeogibeoryeo.presentation.search.MainDispatcherRule
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -185,25 +186,109 @@ class CollectionSpotMapViewModelTest {
             assertNull(viewModel.uiState.value.locationNoticeMessage)
         }
 
+    @Test
+    fun `지도 진입 시 위치 권한이 있으면 현재 위치 검색을 자동 실행한다`() =
+        runTest {
+            val currentCoordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881)
+            val expectedSpots = listOf(sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE))
+            val repository = FakeCollectionSpotRepository(locationSpots = expectedSpots)
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(currentCoordinate),
+                hasFineLocationPermission = true,
+            )
+
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+
+            assertEquals(1, repository.locationSearchCallCount)
+            assertEquals(currentCoordinate, repository.lastLocationCoordinate)
+            assertEquals(expectedSpots, viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.CURRENT_LOCATION, viewModel.uiState.value.searchMode)
+        }
+
+    @Test
+    fun `지도 진입 시 위치 권한이 없으면 자동 현재 위치 검색을 실행하지 않는다`() =
+        runTest {
+            val repository = FakeCollectionSpotRepository()
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+                hasFineLocationPermission = false,
+            )
+
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+
+            assertEquals(0, repository.locationSearchCallCount)
+            assertFalse(viewModel.uiState.value.hasSearched)
+            assertNull(viewModel.uiState.value.locationNoticeMessage)
+            assertNull(viewModel.uiState.value.errorMessage)
+        }
+
+    @Test
+    fun `지도 진입 자동 현재 위치 검색은 여러 번 호출되어도 한 번만 실행된다`() =
+        runTest {
+            val repository = FakeCollectionSpotRepository(
+                locationSpots = listOf(sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+                hasFineLocationPermission = true,
+            )
+
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+
+            assertEquals(1, repository.locationSearchCallCount)
+        }
+
+    @Test
+    fun `지도 진입 시 사용자가 검색어를 입력한 상태면 자동 현재 위치 검색을 실행하지 않는다`() =
+        runTest {
+            val repository = FakeCollectionSpotRepository()
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+                hasFineLocationPermission = true,
+            )
+
+            viewModel.onSearchKeywordChanged("문래동")
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+
+            assertEquals(0, repository.locationSearchCallCount)
+            assertFalse(viewModel.uiState.value.hasSearched)
+            assertEquals("문래동", viewModel.uiState.value.searchKeyword)
+        }
+
     private fun createViewModel(
         repository: FakeCollectionSpotRepository,
         currentLocationResult: CurrentLocationResult,
+        hasFineLocationPermission: Boolean = true,
     ): CollectionSpotMapViewModel {
         return createViewModel(
             repository = repository,
             currentLocationProvider = FakeCurrentLocationProvider(currentLocationResult),
+            hasFineLocationPermission = hasFineLocationPermission,
         )
     }
 
     private fun createViewModel(
         repository: FakeCollectionSpotRepository,
         currentLocationProvider: CurrentLocationProvider,
+        hasFineLocationPermission: Boolean = true,
     ): CollectionSpotMapViewModel {
         return CollectionSpotMapViewModel(
             searchCollectionSpotsByKeywordUseCase = SearchCollectionSpotsByKeywordUseCase(repository),
             searchCollectionSpotsByLocationUseCase = SearchCollectionSpotsByLocationUseCase(repository),
             filterCollectionSpotsUseCase = FilterCollectionSpotsUseCase(),
             currentLocationProvider = currentLocationProvider,
+            locationPermissionChecker = FakeLocationPermissionChecker(hasFineLocationPermission),
         )
     }
 
@@ -228,6 +313,12 @@ class CollectionSpotMapViewModelTest {
         constructor(result: CurrentLocationResult) : this({ result })
 
         override suspend fun getCurrentLocation(): CurrentLocationResult = resultProvider()
+    }
+
+    private class FakeLocationPermissionChecker(
+        private val hasFineLocationPermission: Boolean,
+    ) : LocationPermissionChecker {
+        override fun hasFineLocationPermission(): Boolean = hasFineLocationPermission
     }
 
     private class FakeCollectionSpotRepository(


### PR DESCRIPTION
## 작업 내용

- Map 화면 진입 시 위치 권한이 이미 허용되어 있으면 현재 위치 기반 수거 장소 검색을 자동 실행하도록 추가
- 권한이 없는 경우 Map 진입 시 권한 요청 팝업을 띄우지 않도록 유지
- 자동 현재 위치 검색이 같은 화면 생명주기에서 중복 실행되지 않도록 처리
- 이미 검색했거나 로딩 중이거나 검색어가 입력된 상태에서는 자동 검색이 기존 상태를 덮어쓰지 않도록 처리
- 기존 현재 위치 버튼 기반 수동 검색 흐름 유지
- 자동 검색 관련 ViewModel 단위 테스트 추가

## 검증

- [x] 위치 권한 허용 상태에서 앱 재실행 후 Map 진입 시 자동 검색 확인
- [x] 위치 권한 없음 상태에서 Map 진입 시 권한 팝업이 자동으로 뜨지 않음 확인
- [x] 위치 권한 없음 상태에서 현재 위치 버튼 클릭 시 권한 요청 확인
- [x] 기존 키워드 검색, 필터링, 마커 선택, BottomSheet 동작 회귀 없음 확인
- [x] `./gradlew.bat :presentation:testDebugUnitTest --tests com.team.yeogibeoryeo.presentation.map.CollectionSpotMapViewModelTest`
- [x] `./gradlew.bat :presentation:testDebugUnitTest`

## 제외한 작업

- 현재 위치 좌표/검색 결과 캐시
- Naver Map 사용자 현재 위치 overlay
- locationSource / locationTrackingMode 적용
- 현재 지도에서 검색 UX

Refs #79

