### PR TITLE
feat: 지도 내 위치 표시 및 위치 추적 UX 개선

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -1,13 +1,7 @@
 package com.team.yeogibeoryeo.presentation.map
 
-import androidx.compose.animation.core.Animatable
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -16,28 +10,29 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.naver.maps.map.compose.LocationTrackingMode
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.presentation.map.components.CollectionSpotNaverMap
 import com.team.yeogibeoryeo.presentation.map.components.CurrentLocationSearchLoadingOverlay
 import com.team.yeogibeoryeo.presentation.map.components.MapOverlayControls
+import com.team.yeogibeoryeo.presentation.map.components.MapResultBottomSheetPeekHeight
+import com.team.yeogibeoryeo.presentation.map.components.MapSheetLevel
+import com.team.yeogibeoryeo.presentation.map.components.MapSpotDetailBottomSheetPeekHeight
+import com.team.yeogibeoryeo.presentation.map.components.MyLocationButton
 import com.team.yeogibeoryeo.presentation.map.components.SpotBottomSheetContent
 import com.team.yeogibeoryeo.presentation.map.components.SpotDetailBottomSheetContent
+import com.team.yeogibeoryeo.presentation.map.components.ThreeStepMapBottomSheet
+import com.team.yeogibeoryeo.presentation.map.location.rememberFineLocationPermissionGranted
 import com.team.yeogibeoryeo.presentation.map.location.rememberCurrentLocationSearchRequester
-import kotlin.math.roundToInt
-import kotlinx.coroutines.launch
 
 @Composable
 fun CollectionSpotMapScreen(
@@ -45,9 +40,35 @@ fun CollectionSpotMapScreen(
     viewModel: CollectionSpotMapViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val hasFineLocationPermission = rememberFineLocationPermissionGranted()
+    var hasGrantedLocationPermissionInSession by rememberSaveable {
+        mutableStateOf(false)
+    }
+    val isLocationPermissionGranted =
+        hasFineLocationPermission || hasGrantedLocationPermissionInSession
+    var locationTrackingMode by remember {
+        mutableStateOf(LocationTrackingMode.None)
+    }
+
+    LaunchedEffect(hasFineLocationPermission) {
+        if (!hasFineLocationPermission) {
+            hasGrantedLocationPermissionInSession = false
+        }
+    }
 
     val requestCurrentLocationSearch = rememberCurrentLocationSearchRequester(
-        onGranted = viewModel::searchByCurrentLocation,
+        onGranted = {
+            hasGrantedLocationPermissionInSession = true
+            locationTrackingMode = LocationTrackingMode.NoFollow
+            viewModel.searchByCurrentLocation()
+        },
+        onDenied = viewModel::onLocationPermissionDenied,
+    )
+    val requestMyLocationTracking = rememberCurrentLocationSearchRequester(
+        onGranted = {
+            hasGrantedLocationPermissionInSession = true
+            locationTrackingMode = LocationTrackingMode.Follow
+        },
         onDenied = viewModel::onLocationPermissionDenied,
     )
 
@@ -57,10 +78,18 @@ fun CollectionSpotMapScreen(
 
     CollectionSpotMapContent(
         uiState = uiState,
+        isLocationPermissionGranted = isLocationPermissionGranted,
+        locationTrackingMode = locationTrackingMode,
+        onLocationTrackingModeChange = { mode ->
+            locationTrackingMode = mode
+        },
         onKeywordChanged = viewModel::onSearchKeywordChanged,
         onSearchClick = viewModel::searchByKeyword,
         onCurrentLocationClick = {
             requestCurrentLocationSearch()
+        },
+        onMyLocationPermissionRequest = {
+            requestMyLocationTracking()
         },
         onTypeClick = viewModel::onSpotTypeClick,
         onSpotClick = viewModel::onSpotClick,
@@ -71,9 +100,13 @@ fun CollectionSpotMapScreen(
 @Composable
 private fun CollectionSpotMapContent(
     uiState: CollectionSpotMapUiState,
+    isLocationPermissionGranted: Boolean,
+    locationTrackingMode: LocationTrackingMode,
+    onLocationTrackingModeChange: (LocationTrackingMode) -> Unit,
     onKeywordChanged: (String) -> Unit,
     onSearchClick: () -> Unit,
     onCurrentLocationClick: () -> Unit,
+    onMyLocationPermissionRequest: () -> Unit,
     onTypeClick: (CollectionSpotType) -> Unit,
     onSpotClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
@@ -85,6 +118,17 @@ private fun CollectionSpotMapContent(
     var sheetLevel by remember { mutableStateOf(MapSheetLevel.Hidden) }
     var sheetRevealRequest by remember { mutableStateOf(0) }
     val selectedSpot = uiState.selectedSpot
+    val mapLocationTrackingMode = when {
+        !isLocationPermissionGranted -> LocationTrackingMode.None
+        locationTrackingMode == LocationTrackingMode.None -> LocationTrackingMode.NoFollow
+        else -> locationTrackingMode
+    }
+
+    LaunchedEffect(isLocationPermissionGranted) {
+        if (!isLocationPermissionGranted) {
+            onLocationTrackingModeChange(LocationTrackingMode.None)
+        }
+    }
 
     LaunchedEffect(
         uiState.hasSearched,
@@ -129,13 +173,17 @@ private fun CollectionSpotMapContent(
         CollectionSpotNaverMap(
             spots = uiState.spots,
             selectedSpot = uiState.selectedSpot,
+            isLocationPermissionGranted = isLocationPermissionGranted,
+            locationTrackingMode = mapLocationTrackingMode,
             onSpotClick = { spot ->
+                onLocationTrackingModeChange(LocationTrackingMode.NoFollow)
                 mapUiMode = MapUiMode.SpotDetail
                 sheetLevel = MapSheetLevel.Medium
                 sheetRevealRequest += 1
                 onSpotClick(spot)
             },
             onMapClick = {
+                onLocationTrackingModeChange(LocationTrackingMode.NoFollow)
                 if (mapUiMode == MapUiMode.Browsing) {
                     mapUiMode = MapUiMode.ResultList.takeIf { shouldShowBottomSheet } ?: MapUiMode.Browsing
                     sheetLevel = MapSheetLevel.Peek.takeIf { shouldShowBottomSheet } ?: MapSheetLevel.Hidden
@@ -154,6 +202,7 @@ private fun CollectionSpotMapContent(
                 selectedTypes = uiState.selectedTypes,
                 onKeywordChanged = onKeywordChanged,
                 onSearchClick = {
+                    onLocationTrackingModeChange(LocationTrackingMode.NoFollow)
                     mapUiMode = MapUiMode.ResultList
                     sheetLevel = MapSheetLevel.Peek
                     onSearchClick()
@@ -164,10 +213,33 @@ private fun CollectionSpotMapContent(
                     onTypeClick(type)
                 },
                 onCurrentLocationClick = {
+                    onLocationTrackingModeChange(LocationTrackingMode.NoFollow)
                     mapUiMode = MapUiMode.ResultList
                     sheetLevel = MapSheetLevel.Peek
                     onCurrentLocationClick()
                 },
+            )
+        }
+
+        if (mapUiMode != MapUiMode.SpotDetail) {
+            MyLocationButton(
+                isTracking = mapLocationTrackingMode == LocationTrackingMode.Follow,
+                onClick = {
+                    if (isLocationPermissionGranted) {
+                        onLocationTrackingModeChange(LocationTrackingMode.Follow)
+                    } else {
+                        onMyLocationPermissionRequest()
+                    }
+                },
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(
+                        end = MyLocationButtonHorizontalPadding,
+                        bottom = myLocationButtonBottomPadding(
+                            sheetLevel = sheetLevel,
+                            shouldShowBottomSheet = shouldShowBottomSheet,
+                        ),
+                    ),
             )
         }
 
@@ -206,6 +278,7 @@ private fun CollectionSpotMapContent(
                             errorMessage = uiState.errorMessage,
                             onTypeClick = onTypeClick,
                             onSpotClick = { spot ->
+                                onLocationTrackingModeChange(LocationTrackingMode.NoFollow)
                                 mapUiMode = MapUiMode.SpotDetail
                                 sheetLevel = MapSheetLevel.Medium
                                 sheetRevealRequest += 1
@@ -214,92 +287,6 @@ private fun CollectionSpotMapContent(
                         )
                     }
                 }
-            }
-        }
-    }
-}
-
-@Composable
-private fun ThreeStepMapBottomSheet(
-    sheetLevel: MapSheetLevel,
-    revealKey: Any?,
-    onSheetLevelChanged: (MapSheetLevel) -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
-) {
-    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
-        val density = LocalDensity.current
-        val coroutineScope = rememberCoroutineScope()
-        val sheetHeight = maxHeight - MapSheetTopMargin
-        val sheetHeightPx = with(density) {
-            sheetHeight.toPx().coerceAtLeast(1f)
-        }
-        val hiddenOffset = with(density) {
-            (sheetHeight - Dp.Hairline).toPx().coerceIn(0f, sheetHeightPx)
-        }
-        val peekOffset = with(density) {
-            (sheetHeight - MapResultBottomSheetPeekHeight).toPx().coerceIn(0f, hiddenOffset)
-        }
-        val mediumOffset = with(density) {
-            (sheetHeight - MapSpotDetailBottomSheetPeekHeight).toPx().coerceIn(0f, hiddenOffset)
-        }
-        val expandedOffset = 0f
-        fun offsetFor(level: MapSheetLevel): Float =
-            when (level) {
-                MapSheetLevel.Hidden -> hiddenOffset
-                MapSheetLevel.Peek -> peekOffset
-                MapSheetLevel.Medium -> mediumOffset
-                MapSheetLevel.Expanded -> expandedOffset
-            }
-
-        val targetOffset = offsetFor(sheetLevel)
-        val sheetOffset = remember(sheetHeightPx) {
-            Animatable(targetOffset)
-        }
-
-        LaunchedEffect(targetOffset, revealKey) {
-            sheetOffset.animateTo(targetOffset)
-        }
-
-        Surface(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth()
-                .height(sheetHeight)
-                .offset {
-                    IntOffset(x = 0, y = sheetOffset.value.roundToInt())
-                }
-                .pointerInput(sheetHeightPx, hiddenOffset, peekOffset, mediumOffset) {
-                    detectVerticalDragGestures(
-                        onVerticalDrag = { change, dragAmount ->
-                            change.consume()
-                            coroutineScope.launch {
-                                sheetOffset.snapTo(
-                                    (sheetOffset.value + dragAmount).coerceIn(
-                                        expandedOffset,
-                                        hiddenOffset,
-                                    ),
-                                )
-                            }
-                        },
-                        onDragEnd = {
-                            val nearestLevel = MapSheetLevel.entries.minBy { level ->
-                                kotlin.math.abs(offsetFor(level) - sheetOffset.value)
-                            }
-
-                            onSheetLevelChanged(nearestLevel)
-                            coroutineScope.launch {
-                                sheetOffset.animateTo(offsetFor(nearestLevel))
-                            }
-                        },
-                    )
-                },
-            shape = MaterialTheme.shapes.extraLarge,
-            color = MaterialTheme.colorScheme.surface,
-            shadowElevation = 4.dp,
-        ) {
-            Box(modifier = Modifier.fillMaxSize()) {
-                content()
             }
         }
     }
@@ -318,17 +305,19 @@ private enum class MapUiMode {
     SpotDetail,
 }
 
-private enum class MapSheetLevel {
-    Hidden,
-    Peek,
-    Medium,
-    Expanded,
+private fun myLocationButtonBottomPadding(
+    sheetLevel: MapSheetLevel,
+    shouldShowBottomSheet: Boolean,
+) = if (!shouldShowBottomSheet) {
+    MyLocationButtonBottomPadding
+} else {
+    when (sheetLevel) {
+        MapSheetLevel.Hidden -> MyLocationButtonBottomPadding
+        MapSheetLevel.Peek -> MapResultBottomSheetPeekHeight + MyLocationButtonBottomPadding
+        MapSheetLevel.Medium -> MapSpotDetailBottomSheetPeekHeight + MyLocationButtonBottomPadding
+        MapSheetLevel.Expanded -> MyLocationButtonBottomPadding
+    }
 }
-
-private val MapSheetTopMargin = 72.dp
-private val MapStatusBottomSheetPeekHeight = 132.dp
-private val MapResultBottomSheetPeekHeight = 144.dp
-private val MapSpotDetailBottomSheetPeekHeight = 220.dp
 
 @Preview(showBackground = true)
 @Composable
@@ -340,12 +329,19 @@ private fun CollectionSpotMapContentPreview() {
                     searchKeyword = "문래동",
                     hasSearched = true,
                 ),
+                isLocationPermissionGranted = true,
+                locationTrackingMode = LocationTrackingMode.NoFollow,
+                onLocationTrackingModeChange = {},
                 onKeywordChanged = {},
                 onSearchClick = {},
                 onCurrentLocationClick = {},
+                onMyLocationPermissionRequest = {},
                 onTypeClick = {},
                 onSpotClick = {},
             )
         }
     }
 }
+
+private val MyLocationButtonHorizontalPadding = 16.dp
+private val MyLocationButtonBottomPadding = 16.dp

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CollectionSpotNaverMap.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CollectionSpotNaverMap.kt
@@ -8,17 +8,22 @@ import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
 import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.LocationTrackingMode
+import com.naver.maps.map.compose.MapProperties
 import com.naver.maps.map.compose.Marker
 import com.naver.maps.map.compose.MarkerState
 import com.naver.maps.map.compose.NaverMap
 import com.naver.maps.map.compose.rememberCameraPositionState
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.presentation.map.location.rememberMapLocationSource
 
 @OptIn(ExperimentalNaverMapApi::class)
 @Composable
 fun CollectionSpotNaverMap(
     spots: List<CollectionSpot>,
     selectedSpot: CollectionSpot?,
+    isLocationPermissionGranted: Boolean,
+    locationTrackingMode: LocationTrackingMode,
     onSpotClick: (CollectionSpot) -> Unit,
     onMapClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -28,6 +33,14 @@ fun CollectionSpotNaverMap(
     val markerSpots = spots.filter { spot ->
         spot.coordinate != null
     }
+    val locationSource = rememberMapLocationSource()
+    val mapProperties = MapProperties(
+        locationTrackingMode = if (isLocationPermissionGranted) {
+            locationTrackingMode
+        } else {
+            LocationTrackingMode.None
+        },
+    )
 
     val cameraPositionState = rememberCameraPositionState {
         position = CameraPosition(
@@ -72,6 +85,10 @@ fun CollectionSpotNaverMap(
     NaverMap(
         modifier = modifier,
         cameraPositionState = cameraPositionState,
+        properties = mapProperties,
+        locationSource = locationSource.takeIf {
+            isLocationPermissionGranted
+        },
         onMapClick = { _, _ ->
             onMapClick()
         },

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapOverlayControls.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapOverlayControls.kt
@@ -116,6 +116,7 @@ private fun MapOverlayQuickControlArea(
 
         CurrentLocationButton(
             onClick = onCurrentLocationClick,
+            modifier = Modifier.align(Alignment.CenterEnd),
         )
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MyLocationButton.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MyLocationButton.kt
@@ -3,41 +3,47 @@ package com.team.yeogibeoryeo.presentation.map.components
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MyLocation
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun CurrentLocationButton(
+fun MyLocationButton(
+    isTracking: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    FilledTonalButton(
+    SmallFloatingActionButton(
         onClick = onClick,
         modifier = modifier,
+        containerColor = if (isTracking) {
+            MaterialTheme.colorScheme.primaryContainer
+        } else {
+            MaterialTheme.colorScheme.surface
+        },
+        contentColor = if (isTracking) {
+            MaterialTheme.colorScheme.onPrimaryContainer
+        } else {
+            MaterialTheme.colorScheme.primary
+        },
     ) {
         Icon(
             imageVector = Icons.Default.MyLocation,
-            contentDescription = null,
-        )
-
-        Text(
-            text = "내 주변 검색",
-            modifier = Modifier.padding(start = 6.dp),
+            contentDescription = "내 위치로 이동",
         )
     }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun CurrentLocationButtonPreview() {
+private fun MyLocationButtonPreview() {
     MaterialTheme {
-        CurrentLocationButton(
+        MyLocationButton(
+            isTracking = false,
             onClick = {},
             modifier = Modifier.padding(16.dp),
         )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/ThreeStepMapBottomSheet.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/ThreeStepMapBottomSheet.kt
@@ -1,0 +1,122 @@
+package com.team.yeogibeoryeo.presentation.map.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+import kotlinx.coroutines.launch
+
+@Composable
+fun ThreeStepMapBottomSheet(
+    sheetLevel: MapSheetLevel,
+    revealKey: Any?,
+    onSheetLevelChanged: (MapSheetLevel) -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        val density = LocalDensity.current
+        val coroutineScope = rememberCoroutineScope()
+        val sheetHeight = maxHeight - MapSheetTopMargin
+        val sheetHeightPx = with(density) {
+            sheetHeight.toPx().coerceAtLeast(1f)
+        }
+        val hiddenOffset = with(density) {
+            (sheetHeight - Dp.Hairline).toPx().coerceIn(0f, sheetHeightPx)
+        }
+        val peekOffset = with(density) {
+            (sheetHeight - MapResultBottomSheetPeekHeight).toPx().coerceIn(0f, hiddenOffset)
+        }
+        val mediumOffset = with(density) {
+            (sheetHeight - MapSpotDetailBottomSheetPeekHeight).toPx().coerceIn(0f, hiddenOffset)
+        }
+        val expandedOffset = 0f
+        fun offsetFor(level: MapSheetLevel): Float =
+            when (level) {
+                MapSheetLevel.Hidden -> hiddenOffset
+                MapSheetLevel.Peek -> peekOffset
+                MapSheetLevel.Medium -> mediumOffset
+                MapSheetLevel.Expanded -> expandedOffset
+            }
+
+        val targetOffset = offsetFor(sheetLevel)
+        val sheetOffset = remember(sheetHeightPx) {
+            Animatable(targetOffset)
+        }
+
+        LaunchedEffect(targetOffset, revealKey) {
+            sheetOffset.animateTo(targetOffset)
+        }
+
+        Surface(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .height(sheetHeight)
+                .offset {
+                    IntOffset(x = 0, y = sheetOffset.value.roundToInt())
+                }
+                .pointerInput(sheetHeightPx, hiddenOffset, peekOffset, mediumOffset) {
+                    detectVerticalDragGestures(
+                        onVerticalDrag = { change, dragAmount ->
+                            change.consume()
+                            coroutineScope.launch {
+                                sheetOffset.snapTo(
+                                    (sheetOffset.value + dragAmount).coerceIn(
+                                        expandedOffset,
+                                        hiddenOffset,
+                                    ),
+                                )
+                            }
+                        },
+                        onDragEnd = {
+                            val nearestLevel = MapSheetLevel.entries.minBy { level ->
+                                kotlin.math.abs(offsetFor(level) - sheetOffset.value)
+                            }
+
+                            onSheetLevelChanged(nearestLevel)
+                            coroutineScope.launch {
+                                sheetOffset.animateTo(offsetFor(nearestLevel))
+                            }
+                        },
+                    )
+                },
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surface,
+            shadowElevation = 4.dp,
+        ) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                content()
+            }
+        }
+    }
+}
+
+enum class MapSheetLevel {
+    Hidden,
+    Peek,
+    Medium,
+    Expanded,
+}
+
+private val MapSheetTopMargin = 72.dp
+val MapResultBottomSheetPeekHeight = 144.dp
+val MapSpotDetailBottomSheetPeekHeight = 220.dp

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/LocationPermissionRequester.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/LocationPermissionRequester.kt
@@ -6,11 +6,17 @@ import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 
 @Composable
 fun rememberCurrentLocationSearchRequester(
@@ -40,6 +46,30 @@ fun rememberCurrentLocationSearchRequester(
             }
         }
     }
+}
+
+@Composable
+fun rememberFineLocationPermissionGranted(): Boolean {
+    val context = LocalContext.current
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    var isGranted by remember {
+        mutableStateOf(context.hasFineLocationPermission())
+    }
+
+    DisposableEffect(context, lifecycle) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                isGranted = context.hasFineLocationPermission()
+            }
+        }
+
+        lifecycle.addObserver(observer)
+        onDispose {
+            lifecycle.removeObserver(observer)
+        }
+    }
+
+    return isGranted
 }
 
 private fun Context.hasFineLocationPermission(): Boolean {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/MapLocationSource.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/MapLocationSource.kt
@@ -34,6 +34,8 @@ private class PlayServicesMapLocationSource(
 
     @SuppressLint("MissingPermission")
     override fun activate(listener: LocationSource.OnLocationChangedListener) {
+        deactivate()
+
         if (!context.hasFineLocationPermission()) return
 
         val request = LocationRequest.Builder(
@@ -49,12 +51,16 @@ private class PlayServicesMapLocationSource(
             }
         }
 
-        locationCallback = callback
-        fusedLocationProviderClient.requestLocationUpdates(
-            request,
-            callback,
-            Looper.getMainLooper(),
-        )
+        try {
+            fusedLocationProviderClient.requestLocationUpdates(
+                request,
+                callback,
+                Looper.getMainLooper(),
+            )
+            locationCallback = callback
+        } catch (exception: SecurityException) {
+            locationCallback = null
+        }
     }
 
     override fun deactivate() {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/MapLocationSource.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/MapLocationSource.kt
@@ -1,0 +1,74 @@
+package com.team.yeogibeoryeo.presentation.map.location
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Looper
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import com.naver.maps.map.LocationSource
+
+@Composable
+fun rememberMapLocationSource(): LocationSource {
+    val context = LocalContext.current.applicationContext
+
+    return remember(context) {
+        PlayServicesMapLocationSource(context)
+    }
+}
+
+private class PlayServicesMapLocationSource(
+    private val context: Context,
+) : LocationSource {
+    private val fusedLocationProviderClient =
+        LocationServices.getFusedLocationProviderClient(context)
+    private var locationCallback: LocationCallback? = null
+
+    @SuppressLint("MissingPermission")
+    override fun activate(listener: LocationSource.OnLocationChangedListener) {
+        if (!context.hasFineLocationPermission()) return
+
+        val request = LocationRequest.Builder(
+            Priority.PRIORITY_HIGH_ACCURACY,
+            LOCATION_UPDATE_INTERVAL_MILLIS,
+        ).setMinUpdateIntervalMillis(
+            LOCATION_MIN_UPDATE_INTERVAL_MILLIS,
+        ).build()
+
+        val callback = object : LocationCallback() {
+            override fun onLocationResult(result: LocationResult) {
+                result.lastLocation?.let(listener::onLocationChanged)
+            }
+        }
+
+        locationCallback = callback
+        fusedLocationProviderClient.requestLocationUpdates(
+            request,
+            callback,
+            Looper.getMainLooper(),
+        )
+    }
+
+    override fun deactivate() {
+        locationCallback?.let(fusedLocationProviderClient::removeLocationUpdates)
+        locationCallback = null
+    }
+}
+
+private fun Context.hasFineLocationPermission(): Boolean {
+    return ContextCompat.checkSelfPermission(
+        this,
+        Manifest.permission.ACCESS_FINE_LOCATION,
+    ) == PackageManager.PERMISSION_GRANTED
+}
+
+private const val LOCATION_UPDATE_INTERVAL_MILLIS = 3_000L
+private const val LOCATION_MIN_UPDATE_INTERVAL_MILLIS = 1_000L


### PR DESCRIPTION
## 작업 내용

| 구분 | 내용 |
|---|---|
| 현재 위치 overlay | 지도 위에 사용자 현재 위치가 표시되도록 `locationSource` 연결 |
| 위치 추적 | 내 위치 FAB 클릭 시 `locationTrackingMode`를 `Follow`로 전환 |
| 기본 위치 모드 | Map 진입 시 자동 카메라 추적은 하지 않고 `NoFollow` 기반으로 overlay만 표시 |
| 버튼 역할 분리 | 기존 `현재 위치` 버튼을 `내 주변 검색`으로 변경 |
| 내 위치 이동 | 지도 우하단, BottomSheet 위에 내 위치 FAB 추가 |
| 권한 처리 | 권한이 없으면 overlay/tracking 비활성화, 버튼 클릭 시 기존 권한 요청 흐름 사용 |
| 안정성 | Naver SDK 기본 `FusedLocationSource` 호환 이슈를 피하기 위해 custom `MapLocationSource` 구현 |
| 구조 정리 | `ThreeStepMapBottomSheet`를 별도 컴포넌트로 분리해 Screen 책임 완화 |

## 구현 상세

| 항목 | 설명 |
|---|---|
| `MapLocationSource` | Play Services `FusedLocationProviderClient.requestLocationUpdates()` 기반 custom `LocationSource` |
| `CollectionSpotNaverMap` | 권한 허용 상태에서만 `locationSource`와 `locationTrackingMode` 적용 |
| `MyLocationButton` | 내 위치 이동/추적 전용 FAB |
| `CurrentLocationButton` | 현재 위치 기반 수거 장소 검색 전용 `내 주변 검색` 버튼 |
| `MapOverlayControls` | 상단 overlay에는 검색/필터/내 주변 검색만 유지 |
| `CollectionSpotMapScreen` | 위치 권한 상태와 tracking mode를 Screen-local state로 관리 |

## 검증

| 항목 | 결과 |
|---|---|
| 위치 권한 허용 상태에서 현재 위치 overlay 표시 | 확인 완료 |
| 내 위치 FAB 클릭 시 현재 위치로 카메라 이동 | 확인 완료 |
| 내 위치 FAB가 BottomSheet 위 우하단에 표시 | 확인 완료 |
| `내 주변 검색` 클릭 시 현재 위치 기반 수거 장소 검색 | 확인 완료 |
| 앱 재실행 후 권한 허용 상태에서 #79 자동 검색 흐름 유지 | 확인 완료 |
| 기존 키워드 검색/필터/마커 선택/BottomSheet 동작 | 회귀 없음 확인 |
| Map 진입 시 크래시 | custom `MapLocationSource` 적용 후 해결 확인 |

## 테스트

| 명령어 | 결과 |
|---|---|
| `./gradlew.bat :presentation:compileDebugKotlin` | 성공 |
| `./gradlew.bat :presentation:testDebugUnitTest` | 성공 |
| `./gradlew.bat :app:installDebug` | 성공 |

## 스크린샷

| 내 위치 FAB | 내 위치 이동 |
|---|---|
| <img width="240" alt="내 위치 FAB" src="https://github.com/user-attachments/assets/c0817c27-54e3-4545-8189-90c7a9452a9b" /> | <img width="240" alt="내 위치 이동" src="https://github.com/user-attachments/assets/45f1c481-a7ea-4b92-aad8-58cd0d49ea98" /> |

| 내 주변 검색 | 앱 재실행 후 자동 검색 |
|---|---|
| <img width="240" alt="내 주변 검색" src="https://github.com/user-attachments/assets/8534258b-41d5-4aee-9027-d515f8fa5ba0" /> | <img width="240" alt="앱 재실행 후 자동 검색" src="https://github.com/user-attachments/assets/257e1e5d-3f3b-4295-bc21-1f389ff1ba23" /> |

## 제외한 작업

| 항목 | 비고 |
|---|---|
| 현재 지도에서 검색 | 후속 이슈로 분리 |
| 현재 지도 중심 좌표 기반 검색 | 후속 이슈로 분리 |
| 최근 현재 위치 검색 결과 캐시 | 후속 이슈로 분리 |
| 마지막 카메라 위치 저장 | 후속 검토 |
| `/getSpot` domain/data 수정 | 이번 PR에서 제외 |
| CurrentLocationProvider 구조 변경 | 이번 PR에서 제외 |

Refs #81