### PR TITLE
fix: 검색 상세 이동 및 탭 선택 상태 개선

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
@@ -22,4 +22,11 @@ data class ItemSearchRoute(
 @Serializable
 data class ItemGuideDetailRoute(
     val guideId: String,
+    val source: ItemGuideDetailSource = ItemGuideDetailSource.SEARCH,
 )
+
+@Serializable
+enum class ItemGuideDetailSource {
+    SEARCH,
+    FAVORITES,
+}

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -9,7 +9,8 @@ import androidx.compose.material.icons.outlined.Today
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.navigation.NavDestination
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -18,7 +19,6 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.team.yeogibeoryeo.common.navigation.AppBottomNavigationBar
 import com.team.yeogibeoryeo.common.navigation.BottomNavigationItem
-import com.team.yeogibeoryeo.common.navigation.hasRouteName
 import com.team.yeogibeoryeo.common.navigation.navigateBottomTab
 import com.team.yeogibeoryeo.presentation.favorites.FavoritesRoute as FavoritesScreenRoute
 import com.team.yeogibeoryeo.presentation.map.CollectionSpotMapScreen
@@ -31,8 +31,8 @@ fun YeogiBeoryeoNavHost(
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
 ) {
-    val currentDestination =
-        navController.currentBackStackEntryAsState().value?.destination
+    val currentBackStackEntry = navController.currentBackStackEntryAsState().value
+    val currentDestination = currentBackStackEntry?.destination
 
     Scaffold(
         modifier = modifier,
@@ -43,25 +43,25 @@ fun YeogiBeoryeoNavHost(
                         BottomNavigationItem(
                             label = "Search",
                             icon = Icons.Outlined.Recycling,
-                            selected = currentDestination.isItemSearchSelected(),
+                            selected = currentBackStackEntry.isItemSearchSelected(),
                             onClick = { navController.navigateBottomTab(ItemSearchRoute()) },
                         ),
                         BottomNavigationItem(
                             label = "Map",
                             icon = Icons.Outlined.LocationOn,
-                            selected = currentDestination.hasRouteName<MapRoute>(),
+                            selected = currentDestination?.hasRoute<MapRoute>() == true,
                             onClick = { navController.navigateBottomTab(MapRoute) },
                         ),
                         BottomNavigationItem(
                             label = "Guide",
                             icon = Icons.Outlined.Today,
-                            selected = currentDestination.hasRouteName<RegionalGuideRoute>(),
+                            selected = currentDestination?.hasRoute<RegionalGuideRoute>() == true,
                             onClick = { navController.navigateBottomTab(RegionalGuideRoute()) },
                         ),
                         BottomNavigationItem(
                             label = "Favorites",
                             icon = Icons.Outlined.FavoriteBorder,
-                            selected = currentDestination.hasRouteName<FavoritesRoute>(),
+                            selected = currentBackStackEntry.isFavoritesSelected(),
                             onClick = { navController.navigateBottomTab(FavoritesRoute) },
                         ),
                     ),
@@ -88,7 +88,12 @@ fun YeogiBeoryeoNavHost(
             composable<FavoritesRoute> {
                 FavoritesScreenRoute(
                     onItemGuideClick = { guideId ->
-                        navController.navigate(ItemGuideDetailRoute(guideId = guideId))
+                        navController.navigate(
+                            ItemGuideDetailRoute(
+                                guideId = guideId,
+                                source = ItemGuideDetailSource.FAVORITES,
+                            ),
+                        )
                     },
                 )
             }
@@ -98,7 +103,12 @@ fun YeogiBeoryeoNavHost(
                 ItemSearchScreenRoute(
                     initialQuery = route.initialQuery,
                     onGuideSelected = { guide ->
-                        navController.navigate(ItemGuideDetailRoute(guideId = guide.id))
+                        navController.navigate(
+                            ItemGuideDetailRoute(
+                                guideId = guide.id,
+                                source = ItemGuideDetailSource.SEARCH,
+                            ),
+                        )
                     },
                 )
             }
@@ -114,6 +124,15 @@ fun YeogiBeoryeoNavHost(
     }
 }
 
-private fun NavDestination?.isItemSearchSelected(): Boolean =
-    hasRouteName<ItemSearchRoute>() ||
-        hasRouteName<ItemGuideDetailRoute>()
+private fun NavBackStackEntry?.isItemSearchSelected(): Boolean =
+    this?.destination?.hasRoute<ItemSearchRoute>() == true ||
+        isItemGuideDetailSource(ItemGuideDetailSource.SEARCH)
+
+private fun NavBackStackEntry?.isFavoritesSelected(): Boolean =
+    this?.destination?.hasRoute<FavoritesRoute>() == true ||
+        isItemGuideDetailSource(ItemGuideDetailSource.FAVORITES)
+
+private fun NavBackStackEntry?.isItemGuideDetailSource(source: ItemGuideDetailSource): Boolean =
+    this != null &&
+        destination.hasRoute<ItemGuideDetailRoute>() &&
+        toRoute<ItemGuideDetailRoute>().source == source

--- a/common/src/main/java/com/team/yeogibeoryeo/common/navigation/NavControllerExtensions.kt
+++ b/common/src/main/java/com/team/yeogibeoryeo/common/navigation/NavControllerExtensions.kt
@@ -1,11 +1,7 @@
 package com.team.yeogibeoryeo.common.navigation
 
-import androidx.navigation.NavDestination
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
-
-inline fun <reified T : Any> NavDestination?.hasRouteName(): Boolean =
-    this?.route?.substringBefore("?") == requireNotNull(T::class.qualifiedName)
 
 inline fun <reified T : Any> NavHostController.navigateBottomTab(route: T) {
     navigate(route) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchEvent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchEvent.kt
@@ -1,0 +1,9 @@
+package com.team.yeogibeoryeo.presentation.search
+
+import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
+
+sealed interface ItemSearchEvent {
+    data class NavigateToGuide(
+        val guide: DisposalItemGuide,
+    ) : ItemSearchEvent
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -32,7 +32,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -59,15 +62,20 @@ fun ItemSearchRoute(
     viewModel: ItemSearchViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val pendingGuideToOpen = uiState.pendingGuideToOpen
     val currentOnGuideSelected by rememberUpdatedState(onGuideSelected)
 
     val searchResultListState = rememberLazyListState()
     val categoryListState = rememberLazyListState()
+    var handledSearchResultVersion by rememberSaveable { mutableIntStateOf(0) }
 
-    LaunchedEffect(uiState.guides) {
-        if (uiState.hasSearched && uiState.guides.isNotEmpty()) {
+    LaunchedEffect(uiState.searchResultVersion) {
+        if (
+            uiState.searchResultVersion != handledSearchResultVersion &&
+            uiState.hasSearched &&
+            uiState.guides.isNotEmpty()
+        ) {
             searchResultListState.scrollToItem(0)
+            handledSearchResultVersion = uiState.searchResultVersion
         }
     }
 
@@ -77,10 +85,11 @@ fun ItemSearchRoute(
         }
     }
 
-    LaunchedEffect(pendingGuideToOpen?.id) {
-        if (pendingGuideToOpen != null) {
-            currentOnGuideSelected(pendingGuideToOpen)
-            viewModel.clearPendingGuideToOpen()
+    LaunchedEffect(viewModel.events) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is ItemSearchEvent.NavigateToGuide -> currentOnGuideSelected(event.guide)
+            }
         }
     }
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchUiState.kt
@@ -7,7 +7,7 @@ data class ItemSearchUiState(
     val query: String = "",
     val guides: List<DisposalItemGuide> = emptyList(),
     val favoriteGuideIds: Set<String> = emptySet(),
-    val pendingGuideToOpen: DisposalItemGuide? = null,
+    val searchResultVersion: Int = 0,
     val isLoading: Boolean = false,
     val hasSearched: Boolean = false,
     @param:StringRes val errorMessageResId: Int? = null,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModel.kt
@@ -13,8 +13,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -29,6 +32,8 @@ constructor(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(ItemSearchUiState())
     val uiState: StateFlow<ItemSearchUiState> = _uiState.asStateFlow()
+    private val _events = MutableSharedFlow<ItemSearchEvent>()
+    val events: SharedFlow<ItemSearchEvent> = _events.asSharedFlow()
     private var searchJob: Job? = null
 
     init {
@@ -53,16 +58,11 @@ constructor(
             it.copy(
                 query = query,
                 guides = emptyList(),
-                pendingGuideToOpen = null,
                 isLoading = false,
                 hasSearched = false,
                 errorMessageResId = null,
             )
         }
-    }
-
-    fun clearPendingGuideToOpen() {
-        _uiState.update { it.copy(pendingGuideToOpen = null) }
     }
 
     fun clearSearch() {
@@ -89,7 +89,6 @@ constructor(
             _uiState.update {
                 it.copy(
                     guides = emptyList(),
-                    pendingGuideToOpen = null,
                     hasSearched = false,
                     errorMessageResId = null,
                 )
@@ -103,7 +102,6 @@ constructor(
                 _uiState.update {
                     it.copy(
                         isLoading = true,
-                        pendingGuideToOpen = null,
                         hasSearched = true,
                         errorMessageResId = null,
                     )
@@ -114,6 +112,7 @@ constructor(
                         _uiState.update {
                             it.copy(
                                 guides = guides,
+                                searchResultVersion = it.searchResultVersion + 1,
                                 isLoading = false,
                             )
                         }
@@ -122,7 +121,6 @@ constructor(
                         _uiState.update {
                             it.copy(
                                 guides = emptyList(),
-                                pendingGuideToOpen = null,
                                 isLoading = false,
                                 errorMessageResId = R.string.search_load_failed_message,
                             )
@@ -138,7 +136,6 @@ constructor(
                 _uiState.update {
                     it.copy(
                         isLoading = true,
-                        pendingGuideToOpen = null,
                         errorMessageResId = null,
                     )
                 }
@@ -149,11 +146,9 @@ constructor(
                             guides.firstOrNull { it.name == category.representativeGuideName }
                                 ?: guides.firstOrNull()
 
-                        _uiState.update {
-                            it.copy(
-                                isLoading = false,
-                                pendingGuideToOpen = representativeGuide,
-                            )
+                        _uiState.update { it.copy(isLoading = false) }
+                        if (representativeGuide != null) {
+                            _events.emit(ItemSearchEvent.NavigateToGuide(representativeGuide))
                         }
                     }
                     .onFailure {

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModelTest.kt
@@ -13,9 +13,12 @@ import com.team.yeogibeoryeo.domain.item.usecase.SearchDisposalItemGuidesUseCase
 import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -59,6 +62,20 @@ class ItemSearchViewModelTest {
             assertEquals(expected, viewModel.uiState.value.guides)
             assertFalse(viewModel.uiState.value.isLoading)
             assertNull(viewModel.uiState.value.errorMessageResId)
+        }
+
+    @Test
+    fun `검색 성공 시 검색 결과 버전을 증가시킨다`() =
+        runTest {
+            val repository = FakeRepository(onSearch = { listOf(sampleGuide(it)) })
+            val viewModel = createViewModel(repository)
+
+            viewModel.search("유리")
+            val firstVersion = viewModel.uiState.value.searchResultVersion
+            viewModel.search("비닐")
+
+            assertEquals(1, firstVersion)
+            assertEquals(2, viewModel.uiState.value.searchResultVersion)
         }
 
     @Test
@@ -179,17 +196,21 @@ class ItemSearchViewModelTest {
                     },
                 )
             val viewModel = createViewModel(repository)
+            val event = async(start = CoroutineStart.UNDISPATCHED) { viewModel.events.first() }
 
             viewModel.openCategoryGuide(RepresentativeGuideCategory.VINYL)
             viewModel.openCategoryGuide(RepresentativeGuideCategory.PAPER)
             advanceUntilIdle()
 
             assertNull(viewModel.uiState.value.errorMessageResId)
-            assertEquals("종이", viewModel.uiState.value.pendingGuideToOpen?.name)
+            assertEquals(
+                "종이",
+                (event.await() as ItemSearchEvent.NavigateToGuide).guide.name,
+            )
         }
 
     @Test
-    fun `카테고리 선택 시 대표 가이드를 상세 상태로 저장한다`() =
+    fun `카테고리 선택 시 대표 가이드 이동 이벤트를 발행한다`() =
         runTest {
             val expected = listOf(
                 sampleGuide("비닐봉투"),
@@ -197,6 +218,7 @@ class ItemSearchViewModelTest {
             )
             val repository = FakeRepository(onCategory = { expected })
             val viewModel = createViewModel(repository)
+            val event = async(start = CoroutineStart.UNDISPATCHED) { viewModel.events.first() }
 
             viewModel.openCategoryGuide(RepresentativeGuideCategory.VINYL)
             advanceUntilIdle()
@@ -204,7 +226,7 @@ class ItemSearchViewModelTest {
             assertEquals(listOf(DisposalCategory.VINYL), repository.requestedCategories)
             assertEquals(
                 RepresentativeGuideCategory.VINYL.representativeGuideName,
-                viewModel.uiState.value.pendingGuideToOpen?.name,
+                (event.await() as ItemSearchEvent.NavigateToGuide).guide.name,
             )
             assertEquals("", viewModel.uiState.value.query)
             assertEquals(emptyList<DisposalItemGuide>(), viewModel.uiState.value.guides)
@@ -213,17 +235,18 @@ class ItemSearchViewModelTest {
         }
 
     @Test
-    fun `카테고리 대표 가이드가 없으면 첫 가이드를 상세 상태로 저장한다`() =
+    fun `카테고리 대표 가이드가 없으면 첫 가이드 이동 이벤트를 발행한다`() =
         runTest {
             val expected = sampleGuide("첫 번째 가이드")
             val repository =
                 FakeRepository(onCategory = { listOf(expected, sampleGuide("두 번째 가이드")) })
             val viewModel = createViewModel(repository)
+            val event = async(start = CoroutineStart.UNDISPATCHED) { viewModel.events.first() }
 
             viewModel.openCategoryGuide(RepresentativeGuideCategory.VINYL)
             advanceUntilIdle()
 
-            assertEquals(expected, viewModel.uiState.value.pendingGuideToOpen)
+            assertEquals(expected, (event.await() as ItemSearchEvent.NavigateToGuide).guide)
         }
 
     @Test


### PR DESCRIPTION
## 작업 내용

- quick category 상세 이동을 `uiState`가 아닌 `SharedFlow` 기반 일회성 navigation event로 분리했습니다.
- 검색 결과에서 상세 화면으로 이동했다가 뒤로 돌아왔을 때 기존 스크롤 위치가 유지되도록 수정했습니다.
- 새 검색 결과가 도착한 경우에만 검색 결과 리스트가 맨 위로 이동하도록 처리했습니다.
- `ItemGuideDetailRoute`에 상세 진입 출처를 추가해 Search / Favorites 진입 경로를 구분했습니다.
- Search에서 품목 상세로 진입하면 Search 탭 선택 상태가 유지되도록 수정했습니다.
- Favorites에서 품목 상세로 진입하면 Favorites 탭 선택 상태가 유지되도록 수정했습니다.
- 상세 route의 진입 출처를 판별하는 과정에서 기존 문자열 route 비교 방식의 한계를 확인해, bottom navigation 선택 판별을 공식 `hasRoute<T>()` 기준으로 정리했습니다.

## 변경 이유

#75, #78 PR 검토 중 품목 상세 화면 진입/복귀 흐름에서 navigation UX 개선 지점을 확인했습니다.

기존에는 quick category 상세 이동이 화면 상태와 일회성 navigation event의 책임이 섞인 형태로 처리될 수 있었고, 검색 결과에서 상세 화면으로 이동했다가 돌아왔을 때 검색 결과 스크롤 위치가 초기화될 수 있었습니다.

또한 품목 상세 화면이 Search와 Favorites 양쪽에서 열릴 수 있는데, 상세 route 자체에는 진입 출처가 없어 bottom navigation 선택 상태를 안정적으로 유지하기 어려웠습니다.

그래서 `ItemGuideDetailRoute`에 상세 진입 출처를 추가했는데, 이 과정에서 기존 `NavControllerExtensions`의 route 판별 helper가 `destination.route` 문자열을 직접 비교하고 있다는 점도 함께 확인했습니다. 이 방식은 Compose Navigation의 type-safe route 흐름과 맞지 않고, route argument가 있는 destination을 다룰 때 판별 기준이 불명확해질 수 있어 공식 `hasRoute<T>()` 기준으로 정리했습니다.

이번 변경에서는 검색 화면의 일회성 navigation event를 분리하고, 상세 route에 진입 출처를 포함해 Search / Favorites 각각의 bottom navigation 선택 상태가 유지되도록 정리했습니다.

## 주요 변경 사항

- `ItemSearchEvent` 추가
  - 검색 화면의 일회성 navigation event를 표현합니다.
- `ItemSearchViewModel` 수정
  - quick category 상세 조회 성공 시 `NavigateToGuide` event를 emit합니다.
- `ItemSearchScreen` 수정
  - event를 collect해 상세 화면으로 이동합니다.
  - `searchResultVersion` 기준으로 새 검색 결과가 도착했을 때만 리스트를 상단으로 이동합니다.
- `ItemSearchUiState` 수정
  - `pendingGuideToOpen` 대신 검색 결과 버전 값을 관리합니다.
- `ItemGuideDetailRoute` 수정
  - `guideId`와 함께 `ItemGuideDetailSource`를 route argument로 보존합니다.
- `YeogiBeoryeoNavHost` 수정
  - 상세 route의 source에 따라 bottom navigation selected 상태를 계산합니다.
  - 공식 `hasRoute<T>()` 기반으로 route를 판별합니다.
- `NavControllerExtensions` 정리
  - 문자열 기반 route name helper를 제거하고 bottom tab 이동 helper만 유지합니다.

## 검증 내용

- [x] Search에서 품목 상세 진입 시 Search 탭 선택 상태 유지 확인
- [x] Favorites에서 품목 상세 진입 시 Favorites 탭 선택 상태 유지 확인
- [x] 검색 결과 상세 진입 후 뒤로가기 시 기존 스크롤 위치 유지 확인
- [x] 새 검색 결과 도착 시 리스트 상단 이동 확인
- [x] 문자열 route 비교 제거 후 공식 `hasRoute<T>()` 기준 동작 확인
- [x] 앱에서 최종 동작 확인

## 테스트

- [x] `./gradlew.bat :app:compileDebugKotlin :presentation:testDebugUnitTest`

## 후속 작업

- 이번 PR은 품목 상세 진입/복귀 navigation UX 정리에 집중했습니다.
- Search / Favorites 외 다른 상세 화면 진입 정책이 추가되면 route source 기준을 함께 확장할 수 있습니다.

## 관련 이슈

Related #77
