### PR TITLE
setting: Android CI 빌드 속도 최적화

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -58,6 +60,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' || (github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/main') }}
 
       - name: Create local.properties for CI
         run: |
@@ -68,5 +72,95 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      - name: Run unit tests and build debug APK
-        run: ./gradlew :common:testDebugUnitTest :data:testDebugUnitTest :presentation:testDebugUnitTest :domain:test :app:assembleDebug --no-daemon --stacktrace
+      - name: Determine Gradle tasks
+        id: gradle-tasks
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+            HEAD_SHA="${{ github.sha }}"
+          fi
+
+          if [[ "$BASE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+            CHANGED_FILES="$(git ls-tree -r --name-only "$HEAD_SHA")"
+          else
+            CHANGED_FILES="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          full_test=false
+          common_changed=false
+          domain_changed=false
+          data_changed=false
+          presentation_changed=false
+
+          while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+
+            case "$file" in
+              .github/workflows/*|gradle/*|*gradle.kts|settings.gradle.kts|gradle.properties|gradle/libs.versions.toml)
+                full_test=true
+                ;;
+              common/*)
+                common_changed=true
+                ;;
+              domain/*)
+                domain_changed=true
+                ;;
+              data/*)
+                data_changed=true
+                ;;
+              presentation/*)
+                presentation_changed=true
+                ;;
+            esac
+          done <<< "$CHANGED_FILES"
+
+          tasks=(":app:assembleDebug")
+
+          if [[ "$full_test" == "true" ]]; then
+            tasks=(
+              ":common:testDebugUnitTest"
+              ":data:testDebugUnitTest"
+              ":presentation:testDebugUnitTest"
+              ":domain:test"
+              ":app:assembleDebug"
+            )
+          else
+            if [[ "$common_changed" == "true" ]]; then
+              tasks+=(":common:testDebugUnitTest" ":presentation:testDebugUnitTest")
+            fi
+
+            if [[ "$domain_changed" == "true" ]]; then
+              tasks+=(":domain:test" ":data:testDebugUnitTest" ":presentation:testDebugUnitTest")
+            fi
+
+            if [[ "$data_changed" == "true" ]]; then
+              tasks+=(":data:testDebugUnitTest")
+            fi
+
+            if [[ "$presentation_changed" == "true" ]]; then
+              tasks+=(":presentation:testDebugUnitTest")
+            fi
+          fi
+
+          unique_tasks=()
+          for task in "${tasks[@]}"; do
+            if [[ ! " ${unique_tasks[*]} " =~ " ${task} " ]]; then
+              unique_tasks+=("$task")
+            fi
+          done
+
+          selected_tasks="${unique_tasks[*]}"
+          echo "tasks=$selected_tasks" >> "$GITHUB_OUTPUT"
+          echo "Selected Gradle tasks: $selected_tasks"
+
+      - name: Run selected unit tests and build debug APK
+        run: ./gradlew ${{ steps.gradle-tasks.outputs.tasks }} --no-daemon --stacktrace


### PR DESCRIPTION
## 작업 내용

- `develop`, `main` push에서만 Gradle cache를 저장하도록 `setup-gradle`의 `cache-read-only` 정책을 명시했습니다.
- PR과 그 외 브랜치에서는 Gradle cache를 읽기 전용으로 사용하도록 유지했습니다.
- 변경 파일을 기준으로 필요한 unit test task만 선택하는 `Determine Gradle tasks` 단계를 추가했습니다.
- 모든 CI 실행에서 앱 조립 검증을 위해 `:app:assembleDebug`는 항상 실행하도록 유지했습니다.
- 빌드 설정 또는 workflow가 변경된 경우에는 전체 unit test task를 실행하도록 처리했습니다.
- 변경 파일 비교를 안정적으로 하기 위해 `actions/checkout`에 `fetch-depth: 0`을 설정했습니다.

## AS-IS / TO-BE

| 구분 | AS-IS | TO-BE |
|---|---|---|
| Gradle cache 저장 | `setup-gradle`의 기본 cache 정책에 맡겨져 있었습니다. 이 프로젝트의 GitHub 기본 브랜치는 `main`인데, 실제 개발 흐름은 `develop`에 PR을 올리고 `develop` push CI를 자주 실행하는 구조입니다. 그런데 기본 정책상 `main`이 아닌 `develop` push에서도 cache 저장이 제한될 수 있고, 실제 로그에서도 `develop` push가 `Cache is read-only`로 동작해 다음 CI run이 새 cache를 재사용하기 어려웠습니다. | PR은 cache read-only로 유지하고, 안정 브랜치인 `develop` / `main` push에서만 cache write가 가능하도록 명시했습니다. |
| PR unit test 실행 | 변경한 모듈과 관계없이 항상 전체 unit test를 실행했습니다. | 변경 파일을 확인해 필요한 모듈의 unit test만 선택 실행합니다. |
| 앱 조립 검증 | 전체 unit test와 함께 `:app:assembleDebug`를 실행했습니다. | unit test 범위는 줄이되, `:app:assembleDebug`는 항상 실행해 앱 조립 안전망은 유지합니다. |
| 빌드 설정 변경 대응 | 일반 코드 변경과 동일하게 고정 task를 실행했습니다. | workflow, Gradle 설정, version catalog 등 빌드 설정이 바뀌면 전체 unit test를 실행합니다. |
| 변경 파일 비교 | 기존 CI는 고정 Gradle task를 실행했기 때문에 변경 파일 목록을 계산할 필요가 거의 없었고, checkout 기본 설정을 그대로 사용했습니다. | 이번 CI는 변경 파일을 보고 실행할 test task를 고르므로 `git diff BASE_SHA HEAD_SHA`가 필요합니다. base commit이 runner에 없으면 비교가 실패할 수 있습니다. `actions/checkout`에서 `fetch-depth: 0`은 checkout 깊이를 제한하지 않고 전체 history를 가져오겠다는 의미이므로, PR base/head 비교에 필요한 commit을 안정적으로 참조할 수 있게 했습니다. |

간단히 말하면, 기존에는 모든 PR이 같은 무게의 CI를 실행했다면, 변경 후에는 앱 조립은 항상 확인하면서도 변경 범위에 맞는 unit test만 실행하도록 조정했습니다.

## 변경 이유

현재 Android CI는 PR과 `develop` / `main` push에서 동일하게 전체 unit test와 `:app:assembleDebug`를 실행하고 있습니다.

최근 Actions 로그를 확인했을 때 Gradle cache는 복원되고 있었지만, `develop` push에서도 `Cache is read-only`로 동작했습니다. 이 상태에서는 CI가 새로 만든 configuration cache나 task output cache를 다음 run을 위해 저장하지 못하므로, 이후 CI가 같은 작업을 반복할 가능성이 커집니다.

또한 변경 모듈과 무관하게 모든 unit test를 실행하고 있어, Android 멀티 모듈 의존성을 고려한 범위 안에서 필요한 테스트만 선택 실행하도록 정리했습니다.

## selective CI 기준

| 변경 범위 | 실행 unit test |
|---|---|
| `domain/**` | `:domain:test`, `:data:testDebugUnitTest`, `:presentation:testDebugUnitTest` |
| `data/**` | `:data:testDebugUnitTest` |
| `presentation/**` | `:presentation:testDebugUnitTest` |
| `common/**` | `:common:testDebugUnitTest`, `:presentation:testDebugUnitTest` |
| `app/**` | unit test 추가 없이 `:app:assembleDebug`로 앱 조립 확인 |
| 빌드 설정 / workflow | 전체 unit test 실행 |

모든 경우에 `:app:assembleDebug`는 항상 실행합니다.

## 검증 내용

- [x] 기존 전체 CI task 조합이 로컬에서 통과하는지 확인
- [x] workflow 변경 시 전체 unit test task가 선택되도록 조건 구성
- [x] PR에서는 Gradle cache read-only가 유지되도록 조건 구성
- [x] `develop`, `main` push에서는 Gradle cache write가 가능하도록 조건 구성
- [x] GitHub Actions PR run에서 선택 task와 빌드 성공 확인
- [x] `develop` merge 후 cache 저장/재사용 로그 확인

## 테스트

- [x] `./gradlew.bat :common:testDebugUnitTest :data:testDebugUnitTest :presentation:testDebugUnitTest :domain:test :app:assembleDebug --no-daemon --stacktrace`

## 제외한 작업

- `--no-daemon` 제거 여부 결정: 로컬 비교에서는 daemon 사용이 더 빨랐지만, GitHub Actions는 매번 새 runner에서 실행되므로 같은 효과가 난다고 단정하기 어렵습니다. 이번 PR에서는 변경 범위를 cache 정책과 selective task 실행으로 제한하고, `--no-daemon` 제거는 별도 PR에서 전후 CI 시간을 비교한 뒤 판단합니다.
- CI job 병렬 분리: 이번 PR에서는 cache 정책과 selective task 실행을 먼저 적용하고, merge 이후 실제 CI 시간을 확인한 뒤 별도 판단
- Android instrumented test 자동 실행 추가: 테스트 범위 확대에 가까우므로, Room / Navigation 등 필요한 변경 범위를 정한 뒤 별도 이슈에서 논의



## 관련 이슈

Related #88




