### PR TITLE
feat: 지도 현재 위치 검색 결과 캐시 UX 개선

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ lifecycleRuntimeKtx = "2.6.1"
 lifecycleViewModelKtx = "2.6.1"
 activityCompose = "1.8.0"
 navigationCompose = "2.9.6"
+datastore = "1.2.1"
 
 # Compose
 composeBom = "2026.02.01"
@@ -70,6 +71,9 @@ androidx-compose-material-icons-extended = { group = "androidx.compose.material"
 
 # Navigation
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+
+# DataStore
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
 # Coroutines
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.google.ksp)
     alias(libs.plugins.hilt.android)
 }
@@ -48,6 +49,8 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.datastore.preferences)
+    implementation(libs.kotlinx.serialization.json)
 
     // Location
     implementation(libs.google.android.gms.play.services.location)

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -8,6 +8,8 @@ import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByKeywordUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByLocationUseCase
+import com.team.yeogibeoryeo.presentation.map.cache.RecentCurrentLocationSpotCache
+import com.team.yeogibeoryeo.presentation.map.cache.RecentCurrentLocationSpotCacheEntry
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationProvider
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationResult
 import com.team.yeogibeoryeo.presentation.map.location.LocationPermissionChecker
@@ -28,6 +30,7 @@ class CollectionSpotMapViewModel @Inject constructor(
     private val filterCollectionSpotsUseCase: FilterCollectionSpotsUseCase,
     private val currentLocationProvider: CurrentLocationProvider,
     private val locationPermissionChecker: LocationPermissionChecker,
+    private val recentCurrentLocationSpotCache: RecentCurrentLocationSpotCache,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CollectionSpotMapUiState())
@@ -35,9 +38,12 @@ class CollectionSpotMapViewModel @Inject constructor(
 
     private var originalSpots: List<CollectionSpot> = emptyList()
     private var spotSearchJob: Job? = null
+    private var currentLocationRefreshJob: Job? = null
     private var hasRequestedInitialCurrentLocationSearch = false
 
     fun onSearchKeywordChanged(keyword: String) {
+        currentLocationRefreshJob?.cancel()
+
         val shouldCancelCurrentLocationSearch =
             uiState.value.isLoading &&
                 uiState.value.searchMode == MapSearchMode.CURRENT_LOCATION
@@ -82,6 +88,7 @@ class CollectionSpotMapViewModel @Inject constructor(
 
     fun searchByKeyword() {
         val keyword = uiState.value.searchKeyword.trim()
+        currentLocationRefreshJob?.cancel()
 
         if (keyword.isBlank()) {
             spotSearchJob?.cancel()
@@ -132,52 +139,44 @@ class CollectionSpotMapViewModel @Inject constructor(
     }
 
     fun searchByCurrentLocation() {
+        currentLocationRefreshJob?.cancel()
         spotSearchJob?.cancel()
         spotSearchJob = viewModelScope.launch {
-            _uiState.update {
-                it.copy(
-                    isLoading = true,
-                    hasSearched = true,
-                    errorMessage = null,
-                    locationNoticeMessage = null,
-                    selectedSpot = null,
-                    searchMode = MapSearchMode.CURRENT_LOCATION,
-                )
-            }
-
-            when (val result = currentLocationProvider.getCurrentLocation()) {
-                is CurrentLocationResult.Found -> {
-                    searchByLocation(result.coordinate)
-                }
-
-                CurrentLocationResult.NotFound -> {
-                    onCurrentLocationNotFound()
-                }
-
-                CurrentLocationResult.PermissionDenied -> {
-                    onLocationPermissionDenied()
-                }
-            }
+            searchByCurrentLocationInternal(
+                showLoading = true,
+                preservePreviousResultOnFailure = false,
+            )
         }
     }
 
     private suspend fun searchByLocation(
         coordinate: Coordinate,
+        preservePreviousResultOnFailure: Boolean,
     ) {
-        runCatching {
-            searchCollectionSpotsByLocationUseCase(
+        try {
+            val spots = searchCollectionSpotsByLocationUseCase(
                 coordinate = coordinate,
                 radiusMeter = DEFAULT_RADIUS_METER,
                 types = emptySet(),
             )
-        }.onSuccess { spots ->
+
+            if (!canApplyCurrentLocationResult()) return
+
             updateSpotResult(spots)
-        }.onFailure { throwable ->
+            recentCurrentLocationSpotCache.saveRecentCurrentLocationSpots(
+                RecentCurrentLocationSpotCacheEntry(
+                    spots = spots,
+                    savedAtMillis = System.currentTimeMillis(),
+                ),
+            )
+        } catch (throwable: Throwable) {
             if (throwable is CancellationException) throw throwable
 
-            updateSpotFailure(
-                message = throwable.message ?: "현재 위치 주변 수거 장소를 불러오지 못했습니다.",
-            )
+            if (!preservePreviousResultOnFailure) {
+                updateSpotFailure(
+                    message = throwable.message ?: "현재 위치 주변 수거 장소를 불러오지 못했습니다.",
+                )
+            }
         }
     }
 
@@ -239,7 +238,24 @@ class CollectionSpotMapViewModel @Inject constructor(
         }
 
         hasRequestedInitialCurrentLocationSearch = true
-        searchByCurrentLocation()
+        spotSearchJob?.cancel()
+        spotSearchJob = viewModelScope.launch {
+            val cachedEntry = recentCurrentLocationSpotCache.getRecentCurrentLocationSpots()
+            val hasFreshCache = cachedEntry?.isFresh(System.currentTimeMillis()) == true
+
+            if (hasFreshCache && canStartInitialCurrentLocationSearch()) {
+                showCachedCurrentLocationSpots(cachedEntry.spots)
+                refreshCurrentLocationSilently()
+                return@launch
+            }
+
+            if (canStartInitialCurrentLocationSearch()) {
+                searchByCurrentLocationInternal(
+                    showLoading = true,
+                    preservePreviousResultOnFailure = false,
+                )
+            }
+        }
     }
 
     fun onCurrentLocationNotFound() {
@@ -297,6 +313,91 @@ class CollectionSpotMapViewModel @Inject constructor(
                 locationNoticeMessage = null,
             )
         }
+    }
+
+    private suspend fun searchByCurrentLocationInternal(
+        showLoading: Boolean,
+        preservePreviousResultOnFailure: Boolean,
+    ) {
+        if (showLoading) {
+            _uiState.update {
+                it.copy(
+                    isLoading = true,
+                    hasSearched = true,
+                    errorMessage = null,
+                    locationNoticeMessage = null,
+                    selectedSpot = null,
+                    searchMode = MapSearchMode.CURRENT_LOCATION,
+                )
+            }
+        }
+
+        when (val result = currentLocationProvider.getCurrentLocation()) {
+            is CurrentLocationResult.Found -> {
+                searchByLocation(
+                    coordinate = result.coordinate,
+                    preservePreviousResultOnFailure = preservePreviousResultOnFailure,
+                )
+            }
+
+            CurrentLocationResult.NotFound -> {
+                if (!preservePreviousResultOnFailure) {
+                    onCurrentLocationNotFound()
+                }
+            }
+
+            CurrentLocationResult.PermissionDenied -> {
+                if (!preservePreviousResultOnFailure) {
+                    onLocationPermissionDenied()
+                }
+            }
+        }
+    }
+
+    private fun showCachedCurrentLocationSpots(spots: List<CollectionSpot>) {
+        originalSpots = spots
+
+        val filteredSpots = filterCollectionSpotsUseCase(
+            spots = originalSpots,
+            selectedTypes = uiState.value.selectedTypes,
+        )
+
+        _uiState.update {
+            it.copy(
+                spots = filteredSpots,
+                selectedSpot = null,
+                isLoading = false,
+                hasSearched = true,
+                errorMessage = null,
+                locationNoticeMessage = null,
+                searchMode = MapSearchMode.CURRENT_LOCATION,
+            )
+        }
+    }
+
+    private fun refreshCurrentLocationSilently() {
+        currentLocationRefreshJob?.cancel()
+        currentLocationRefreshJob = viewModelScope.launch {
+            searchByCurrentLocationInternal(
+                showLoading = false,
+                preservePreviousResultOnFailure = true,
+            )
+        }
+    }
+
+    private fun canStartInitialCurrentLocationSearch(): Boolean {
+        val currentState = uiState.value
+
+        return currentState.searchKeyword.isBlank() &&
+            (!currentState.hasSearched || currentState.searchMode == MapSearchMode.CURRENT_LOCATION) &&
+            locationPermissionChecker.hasFineLocationPermission()
+    }
+
+    private fun canApplyCurrentLocationResult(): Boolean {
+        val currentState = uiState.value
+
+        return currentState.searchKeyword.isBlank() &&
+            currentState.searchMode == MapSearchMode.CURRENT_LOCATION
     }
 
     private companion object {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/cache/DataStoreRecentCurrentLocationSpotCache.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/cache/DataStoreRecentCurrentLocationSpotCache.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
@@ -29,6 +30,8 @@ class DataStoreRecentCurrentLocationSpotCache @Inject constructor(
         } catch (exception: IllegalArgumentException) {
             clearRecentCurrentLocationSpots()
             null
+        } catch (exception: CancellationException) {
+            throw exception
         } catch (exception: Exception) {
             null
         }
@@ -43,6 +46,8 @@ class DataStoreRecentCurrentLocationSpotCache @Inject constructor(
             dataStore.edit { preferences ->
                 preferences[RECENT_CURRENT_LOCATION_SPOTS_KEY] = cacheJson
             }
+        } catch (exception: CancellationException) {
+            throw exception
         } catch (exception: Exception) {
             // Cache writes must not fail the current location search success flow.
         }
@@ -53,6 +58,8 @@ class DataStoreRecentCurrentLocationSpotCache @Inject constructor(
             dataStore.edit { preferences ->
                 preferences.remove(RECENT_CURRENT_LOCATION_SPOTS_KEY)
             }
+        } catch (exception: CancellationException) {
+            throw exception
         } catch (exception: Exception) {
             // Cache invalidation failure can be ignored safely.
         }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/cache/DataStoreRecentCurrentLocationSpotCache.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/cache/DataStoreRecentCurrentLocationSpotCache.kt
@@ -1,0 +1,65 @@
+package com.team.yeogibeoryeo.presentation.map.cache
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import javax.inject.Inject
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class DataStoreRecentCurrentLocationSpotCache @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) : RecentCurrentLocationSpotCache {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    override suspend fun getRecentCurrentLocationSpots(): RecentCurrentLocationSpotCacheEntry? {
+        return try {
+            val cacheJson = dataStore.data.first()[RECENT_CURRENT_LOCATION_SPOTS_KEY] ?: return null
+
+            json.decodeFromString<RecentCurrentLocationSpotCacheDto>(cacheJson).toDomain()
+        } catch (exception: SerializationException) {
+            clearRecentCurrentLocationSpots()
+            null
+        } catch (exception: IllegalArgumentException) {
+            clearRecentCurrentLocationSpots()
+            null
+        } catch (exception: Exception) {
+            null
+        }
+    }
+
+    override suspend fun saveRecentCurrentLocationSpots(
+        entry: RecentCurrentLocationSpotCacheEntry,
+    ) {
+        try {
+            val cacheJson = json.encodeToString(entry.toDto())
+
+            dataStore.edit { preferences ->
+                preferences[RECENT_CURRENT_LOCATION_SPOTS_KEY] = cacheJson
+            }
+        } catch (exception: Exception) {
+            // Cache writes must not fail the current location search success flow.
+        }
+    }
+
+    override suspend fun clearRecentCurrentLocationSpots() {
+        try {
+            dataStore.edit { preferences ->
+                preferences.remove(RECENT_CURRENT_LOCATION_SPOTS_KEY)
+            }
+        } catch (exception: Exception) {
+            // Cache invalidation failure can be ignored safely.
+        }
+    }
+
+    private companion object {
+        val RECENT_CURRENT_LOCATION_SPOTS_KEY =
+            stringPreferencesKey("recent_current_location_spots")
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/cache/RecentCurrentLocationSpotCache.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/cache/RecentCurrentLocationSpotCache.kt
@@ -1,0 +1,27 @@
+package com.team.yeogibeoryeo.presentation.map.cache
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+
+interface RecentCurrentLocationSpotCache {
+    suspend fun getRecentCurrentLocationSpots(): RecentCurrentLocationSpotCacheEntry?
+
+    suspend fun saveRecentCurrentLocationSpots(entry: RecentCurrentLocationSpotCacheEntry)
+
+    suspend fun clearRecentCurrentLocationSpots()
+}
+
+data class RecentCurrentLocationSpotCacheEntry(
+    val spots: List<CollectionSpot>,
+    val savedAtMillis: Long,
+) {
+    fun isFresh(
+        nowMillis: Long,
+        ttlMillis: Long = RECENT_CURRENT_LOCATION_SPOT_CACHE_TTL_MILLIS,
+    ): Boolean {
+        val elapsedMillis = nowMillis - savedAtMillis
+
+        return elapsedMillis in 0 until ttlMillis
+    }
+}
+
+const val RECENT_CURRENT_LOCATION_SPOT_CACHE_TTL_MILLIS = 10 * 60 * 1_000L

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/cache/RecentCurrentLocationSpotCacheDto.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/cache/RecentCurrentLocationSpotCacheDto.kt
@@ -1,0 +1,27 @@
+package com.team.yeogibeoryeo.presentation.map.cache
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class RecentCurrentLocationSpotCacheDto(
+    val spots: List<CollectionSpotCacheDto>,
+    val savedAtMillis: Long,
+)
+
+@Serializable
+internal data class CollectionSpotCacheDto(
+    val id: String,
+    val name: String,
+    val type: String,
+    val address: String,
+    val detailLocation: String?,
+    val coordinate: CoordinateCacheDto?,
+    val distanceMeter: Int?,
+    val isBookmarked: Boolean,
+)
+
+@Serializable
+internal data class CoordinateCacheDto(
+    val latitude: Double,
+    val longitude: Double,
+)

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/cache/RecentCurrentLocationSpotCacheMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/cache/RecentCurrentLocationSpotCacheMapper.kt
@@ -1,0 +1,59 @@
+package com.team.yeogibeoryeo.presentation.map.cache
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+
+internal fun RecentCurrentLocationSpotCacheEntry.toDto(): RecentCurrentLocationSpotCacheDto {
+    return RecentCurrentLocationSpotCacheDto(
+        spots = spots.map(CollectionSpot::toDto),
+        savedAtMillis = savedAtMillis,
+    )
+}
+
+internal fun RecentCurrentLocationSpotCacheDto.toDomain(): RecentCurrentLocationSpotCacheEntry {
+    return RecentCurrentLocationSpotCacheEntry(
+        spots = spots.map(CollectionSpotCacheDto::toDomain),
+        savedAtMillis = savedAtMillis,
+    )
+}
+
+private fun CollectionSpot.toDto(): CollectionSpotCacheDto {
+    return CollectionSpotCacheDto(
+        id = id,
+        name = name,
+        type = type.name,
+        address = address,
+        detailLocation = detailLocation,
+        coordinate = coordinate?.toDto(),
+        distanceMeter = distanceMeter,
+        isBookmarked = isBookmarked,
+    )
+}
+
+private fun CollectionSpotCacheDto.toDomain(): CollectionSpot {
+    return CollectionSpot(
+        id = id,
+        name = name,
+        type = CollectionSpotType.valueOf(type),
+        address = address,
+        detailLocation = detailLocation,
+        coordinate = coordinate?.toDomain(),
+        distanceMeter = distanceMeter,
+        isBookmarked = isBookmarked,
+    )
+}
+
+private fun Coordinate.toDto(): CoordinateCacheDto {
+    return CoordinateCacheDto(
+        latitude = latitude,
+        longitude = longitude,
+    )
+}
+
+private fun CoordinateCacheDto.toDomain(): Coordinate {
+    return Coordinate(
+        latitude = latitude,
+        longitude = longitude,
+    )
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/di/MapCacheModule.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/di/MapCacheModule.kt
@@ -1,0 +1,43 @@
+package com.team.yeogibeoryeo.presentation.map.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.team.yeogibeoryeo.presentation.map.cache.DataStoreRecentCurrentLocationSpotCache
+import com.team.yeogibeoryeo.presentation.map.cache.RecentCurrentLocationSpotCache
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+private val Context.mapCacheDataStore by preferencesDataStore(
+    name = "map_cache_preferences",
+)
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class MapCacheBindModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindRecentCurrentLocationSpotCache(
+        dataStoreRecentCurrentLocationSpotCache: DataStoreRecentCurrentLocationSpotCache,
+    ): RecentCurrentLocationSpotCache
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object MapCacheProvideModule {
+
+    @Provides
+    @Singleton
+    fun provideMapCacheDataStore(
+        @ApplicationContext context: Context,
+    ): DataStore<Preferences> {
+        return context.mapCacheDataStore
+    }
+}

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -7,6 +7,8 @@ import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByKeywordUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByLocationUseCase
+import com.team.yeogibeoryeo.presentation.map.cache.RecentCurrentLocationSpotCache
+import com.team.yeogibeoryeo.presentation.map.cache.RecentCurrentLocationSpotCacheEntry
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationProvider
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationResult
 import com.team.yeogibeoryeo.presentation.map.location.LocationPermissionChecker
@@ -350,15 +352,254 @@ class CollectionSpotMapViewModelTest {
             assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
         }
 
+    @Test
+    fun `유효한 캐시와 위치 권한이 있으면 지도 진입 시 캐시 결과를 즉시 표시한다`() =
+        runTest {
+            val locationResult = CompletableDeferred<CurrentLocationResult>()
+            val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
+            val cache = FakeRecentCurrentLocationSpotCache(
+                entry = freshCacheEntry(listOf(cachedSpot)),
+            )
+            val repository = FakeCollectionSpotRepository(
+                locationSpots = listOf(sampleSpot("refresh", CollectionSpotType.RECYCLING_CENTER)),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationProvider = FakeCurrentLocationProvider {
+                    locationResult.await()
+                },
+                hasFineLocationPermission = true,
+                recentCurrentLocationSpotCache = cache,
+            )
+
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+
+            assertEquals(listOf(cachedSpot), viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.CURRENT_LOCATION, viewModel.uiState.value.searchMode)
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertEquals(0, repository.locationSearchCallCount)
+        }
+
+    @Test
+    fun `유효한 캐시 표시 후 refresh 성공 시 화면 결과와 캐시를 최신 결과로 교체한다`() =
+        runTest {
+            val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
+            val refreshedSpot = sampleSpot("refresh", CollectionSpotType.RECYCLING_CENTER)
+            val cache = FakeRecentCurrentLocationSpotCache(
+                entry = freshCacheEntry(listOf(cachedSpot)),
+            )
+            val repository = FakeCollectionSpotRepository(locationSpots = listOf(refreshedSpot))
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+                hasFineLocationPermission = true,
+                recentCurrentLocationSpotCache = cache,
+            )
+
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+            advanceUntilIdle()
+
+            assertEquals(listOf(refreshedSpot), viewModel.uiState.value.spots)
+            assertEquals(listOf(refreshedSpot), cache.entry?.spots)
+            assertEquals(1, repository.locationSearchCallCount)
+            assertEquals(1, cache.saveCallCount)
+        }
+
+    @Test
+    fun `유효한 캐시 표시 후 refresh 실패 시 기존 캐시 결과를 유지한다`() =
+        runTest {
+            val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
+            val cache = FakeRecentCurrentLocationSpotCache(
+                entry = freshCacheEntry(listOf(cachedSpot)),
+            )
+            val repository = FakeCollectionSpotRepository()
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+                hasFineLocationPermission = true,
+                recentCurrentLocationSpotCache = cache,
+            )
+
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+            advanceUntilIdle()
+
+            assertEquals(listOf(cachedSpot), viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.CURRENT_LOCATION, viewModel.uiState.value.searchMode)
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertNull(viewModel.uiState.value.locationNoticeMessage)
+            assertNull(viewModel.uiState.value.errorMessage)
+            assertEquals(0, repository.locationSearchCallCount)
+            assertEquals(0, cache.saveCallCount)
+        }
+
+    @Test
+    fun `캐시가 없으면 기존 현재 위치 자동 검색 흐름을 실행한다`() =
+        runTest {
+            val currentCoordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881)
+            val expectedSpot = sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)
+            val cache = FakeRecentCurrentLocationSpotCache()
+            val repository = FakeCollectionSpotRepository(locationSpots = listOf(expectedSpot))
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(currentCoordinate),
+                hasFineLocationPermission = true,
+                recentCurrentLocationSpotCache = cache,
+            )
+
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+            advanceUntilIdle()
+
+            assertEquals(1, cache.getCallCount)
+            assertEquals(1, repository.locationSearchCallCount)
+            assertEquals(currentCoordinate, repository.lastLocationCoordinate)
+            assertEquals(listOf(expectedSpot), viewModel.uiState.value.spots)
+        }
+
+    @Test
+    fun `캐시가 만료되면 기존 현재 위치 자동 검색 흐름을 실행한다`() =
+        runTest {
+            val expiredSpot = sampleSpot("expired", CollectionSpotType.OTHER)
+            val expectedSpot = sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)
+            val cache = FakeRecentCurrentLocationSpotCache(
+                entry = RecentCurrentLocationSpotCacheEntry(
+                    spots = listOf(expiredSpot),
+                    savedAtMillis = 0L,
+                ),
+            )
+            val repository = FakeCollectionSpotRepository(locationSpots = listOf(expectedSpot))
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+                hasFineLocationPermission = true,
+                recentCurrentLocationSpotCache = cache,
+            )
+
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+            advanceUntilIdle()
+
+            assertEquals(1, repository.locationSearchCallCount)
+            assertEquals(listOf(expectedSpot), viewModel.uiState.value.spots)
+        }
+
+    @Test
+    fun `위치 권한이 없으면 캐시가 있어도 자동 표시하지 않는다`() =
+        runTest {
+            val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
+            val cache = FakeRecentCurrentLocationSpotCache(
+                entry = freshCacheEntry(listOf(cachedSpot)),
+            )
+            val repository = FakeCollectionSpotRepository()
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+                hasFineLocationPermission = false,
+                recentCurrentLocationSpotCache = cache,
+            )
+
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+
+            assertEquals(0, cache.getCallCount)
+            assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
+            assertFalse(viewModel.uiState.value.hasSearched)
+            assertEquals(0, repository.locationSearchCallCount)
+        }
+
+    @Test
+    fun `refresh 중 키워드 검색이 시작되면 refresh 결과가 키워드 검색 결과를 덮어쓰지 않는다`() =
+        runTest {
+            val locationResult = CompletableDeferred<CurrentLocationResult>()
+            val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
+            val keywordSpot = sampleSpot("keyword", CollectionSpotType.OTHER)
+            val refreshSpot = sampleSpot("refresh", CollectionSpotType.RECYCLING_CENTER)
+            val cache = FakeRecentCurrentLocationSpotCache(
+                entry = freshCacheEntry(listOf(cachedSpot)),
+            )
+            val repository = FakeCollectionSpotRepository(
+                keywordSpots = listOf(keywordSpot),
+                locationSpots = listOf(refreshSpot),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationProvider = FakeCurrentLocationProvider {
+                    locationResult.await()
+                },
+                hasFineLocationPermission = true,
+                recentCurrentLocationSpotCache = cache,
+            )
+
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+            viewModel.onSearchKeywordChanged("문래동")
+            viewModel.searchByKeyword()
+            locationResult.complete(
+                CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(listOf(keywordSpot), viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
+            assertEquals(0, repository.locationSearchCallCount)
+            assertEquals(0, cache.saveCallCount)
+        }
+
+    @Test
+    fun `현재 위치 버튼 수동 검색 성공 시 캐시를 갱신한다`() =
+        runTest {
+            val expectedSpot = sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)
+            val cache = FakeRecentCurrentLocationSpotCache()
+            val repository = FakeCollectionSpotRepository(locationSpots = listOf(expectedSpot))
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+                recentCurrentLocationSpotCache = cache,
+            )
+
+            viewModel.searchByCurrentLocation()
+
+            assertEquals(1, cache.saveCallCount)
+            assertEquals(listOf(expectedSpot), cache.entry?.spots)
+        }
+
+    @Test
+    fun `키워드 검색 성공 시 캐시를 갱신하지 않는다`() =
+        runTest {
+            val keywordSpot = sampleSpot("keyword", CollectionSpotType.OTHER)
+            val cache = FakeRecentCurrentLocationSpotCache()
+            val repository = FakeCollectionSpotRepository(keywordSpots = listOf(keywordSpot))
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+                recentCurrentLocationSpotCache = cache,
+            )
+
+            viewModel.onSearchKeywordChanged("문래동")
+            viewModel.searchByKeyword()
+
+            assertEquals(listOf(keywordSpot), viewModel.uiState.value.spots)
+            assertEquals(0, cache.saveCallCount)
+            assertNull(cache.entry)
+        }
+
     private fun createViewModel(
         repository: FakeCollectionSpotRepository,
         currentLocationResult: CurrentLocationResult,
         hasFineLocationPermission: Boolean = true,
+        recentCurrentLocationSpotCache: RecentCurrentLocationSpotCache = FakeRecentCurrentLocationSpotCache(),
     ): CollectionSpotMapViewModel {
         return createViewModel(
             repository = repository,
             currentLocationProvider = FakeCurrentLocationProvider(currentLocationResult),
             hasFineLocationPermission = hasFineLocationPermission,
+            recentCurrentLocationSpotCache = recentCurrentLocationSpotCache,
         )
     }
 
@@ -366,6 +607,7 @@ class CollectionSpotMapViewModelTest {
         repository: FakeCollectionSpotRepository,
         currentLocationProvider: CurrentLocationProvider,
         hasFineLocationPermission: Boolean = true,
+        recentCurrentLocationSpotCache: RecentCurrentLocationSpotCache = FakeRecentCurrentLocationSpotCache(),
     ): CollectionSpotMapViewModel {
         return CollectionSpotMapViewModel(
             searchCollectionSpotsByKeywordUseCase = SearchCollectionSpotsByKeywordUseCase(repository),
@@ -373,6 +615,16 @@ class CollectionSpotMapViewModelTest {
             filterCollectionSpotsUseCase = FilterCollectionSpotsUseCase(),
             currentLocationProvider = currentLocationProvider,
             locationPermissionChecker = FakeLocationPermissionChecker(hasFineLocationPermission),
+            recentCurrentLocationSpotCache = recentCurrentLocationSpotCache,
+        )
+    }
+
+    private fun freshCacheEntry(
+        spots: List<CollectionSpot>,
+    ): RecentCurrentLocationSpotCacheEntry {
+        return RecentCurrentLocationSpotCacheEntry(
+            spots = spots,
+            savedAtMillis = System.currentTimeMillis(),
         )
     }
 
@@ -403,6 +655,32 @@ class CollectionSpotMapViewModelTest {
         private val hasFineLocationPermission: Boolean,
     ) : LocationPermissionChecker {
         override fun hasFineLocationPermission(): Boolean = hasFineLocationPermission
+    }
+
+    private class FakeRecentCurrentLocationSpotCache(
+        var entry: RecentCurrentLocationSpotCacheEntry? = null,
+    ) : RecentCurrentLocationSpotCache {
+        var getCallCount = 0
+            private set
+        var saveCallCount = 0
+            private set
+        var clearCallCount = 0
+            private set
+
+        override suspend fun getRecentCurrentLocationSpots(): RecentCurrentLocationSpotCacheEntry? {
+            getCallCount += 1
+            return entry
+        }
+
+        override suspend fun saveRecentCurrentLocationSpots(entry: RecentCurrentLocationSpotCacheEntry) {
+            saveCallCount += 1
+            this.entry = entry
+        }
+
+        override suspend fun clearRecentCurrentLocationSpots() {
+            clearCallCount += 1
+            entry = null
+        }
     }
 
     private class FakeCollectionSpotRepository(


### PR DESCRIPTION
Refs #82

## 작업 내용

| 구분 | 내용 |
|---|---|
| 최근 검색 결과 캐시 | 현재 위치 기반 수거 장소 검색 성공 결과를 DataStore에 저장하도록 추가 |
| TTL 정책 | 최근 캐시가 10분 이내이면 Map 진입 시 즉시 표시 |
| Silent refresh | 캐시 표시 후 최신 현재 위치 검색을 조용히 실행하고, 성공 시 화면 결과와 캐시 갱신 |
| 실패 처리 | refresh 실패 시 기존 캐시 결과를 유지 |
| 충돌 방지 | 키워드 검색 시작 후 refresh 결과가 키워드 검색 결과를 덮어쓰지 않도록 guard 추가 |
| 캐시 범위 | 사용자 현재 위치 좌표는 저장하지 않고, 수거 장소 결과 목록과 저장 시각만 저장 |
| 테스트 | 캐시 표시, 만료, 권한 없음, refresh 성공/실패, 키워드 검색 충돌 방지 테스트 추가 |

## 정책 정리

| 항목 | 정책 |
|---|---|
| 저장 대상 | 최근 현재 위치 기반 검색 성공 결과 목록, 저장 시각 |
| 저장하지 않는 것 | 사용자 현재 위치 기준 좌표 |
| TTL | 10분 |
| 권한 없음 | 캐시가 있어도 자동 표시하지 않음 |
| 캐시 없음/만료 | 기존 #79 자동 현재 위치 검색 흐름 유지 |
| 현재 위치 수동 검색 | 성공 시 캐시 갱신 |
| 키워드 검색 | 캐시 갱신하지 않음 |

## 검증

| 항목 | 결과 |
|---|---|
| `./gradlew.bat :presentation:compileDebugKotlin` | 성공 |
| `./gradlew.bat :presentation:testDebugUnitTest` | 성공 |
| `./gradlew.bat :app:assembleDebug` | 성공 |
| 실제 기기 테스트 | 성공 |

## 수동 검증

| 시나리오 | 결과 |
|---|---|
| 위치 권한 허용 상태에서 Map 최초 진입 시 현재 위치 검색 | 정상 |
| 현재 위치 검색 성공 후 앱 재실행, 10분 이내 Map 재진입 시 캐시 즉시 표시 | 정상 |
| 캐시 표시 후 최신 현재 위치 검색 refresh | 정상 |
| 키워드 검색 결과가 refresh 결과에 덮어쓰이지 않음 | 정상 |
| 현재 위치 버튼 수동 검색 후 캐시 갱신 | 정상 |
| 필터칩, 마커 선택, 카드 선택, BottomSheet 동작 | 정상 |

## 이번 PR에서 제외한 작업

| 항목 | 비고 |
|---|---|
| 사용자 현재 위치 좌표 저장 | 위치 민감도 때문에 제외 |
| NaverMap overlay / locationTrackingMode 수정 | #81 범위 |
| 현재 지도에서 검색 | 후속 후보 |
| `/getSpot` domain/data 로직 수정 | 기존 검색 로직 유지 |
| Room 기반 캐시 | 재사용 범위가 커질 때 검토 |

## 후속 리팩토링 후보

현재 #82에서는 Map 화면 UX 개선 범위를 작게 유지하기 위해 최근 현재 위치 검색 결과 캐시를 `presentation/map/cache` 내부에 구현했습니다.

다만 아래 요구가 생기면 캐시 책임을 domain/data 계층으로 분리하는 것이 좋아 보입니다.

- 홈 화면에서도 최근 주변 수거 장소를 보여줘야 하는 경우
- 즐겨찾기 또는 추천 장소와 최근 주변 수거 장소를 함께 다뤄야 하는 경우
- 캐시 정책이 여러 화면에서 재사용되는 경우
- 저장 정책이 TTL 단순 캐시를 넘어 Room 기반 local data로 확장되는 경우

검토 방향:

| 계층 | 방향 |
|---|---|
| domain | 최근 수거 장소 cache repository/usecase 정의 |
| data | DataStore 또는 Room 기반 cache datasource 구현 |
| presentation | ViewModel이 cache 구현체가 아니라 usecase만 의존하도록 변경 |
| mapper | cache DTO와 domain model mapper를 data 계층으로 이동 |

## 후속 이슈 후보

| 후보 | 이유 |
|---|---|
| Room 기반 최근 주변 수거 장소 저장 구조 고도화 | 홈/즐겨찾기/추천 장소와 연결 가능성이 커서 장기적으로 필요 |
| 캐시 결과임을 표시하는 UI | 사용자가 “방금 전 결과”인지 최신 결과인지 구분할 필요가 생길 수 있음 |
| 현재 지도에서 검색 | 지도 이동 후 현재 화면 기준 검색 UX 확장 |
| visible bounds 기반 검색 | 현재 지도에서 검색 기능 구현 시 함께 검토 |
| 마지막 카메라 위치 저장 정책 | Map 재진입 UX 고도화 |