### PR TITLE
fix: 품목 검색 결과 가나다순 정렬 적용

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/item/repository/DisposalItemGuideRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/item/repository/DisposalItemGuideRepositoryImpl.kt
@@ -42,7 +42,6 @@ constructor(
             .sortedWith(
                 compareBy(
                     { (_, rank) -> rank },
-                    { (item, _) -> item.name.length },
                     { (item, _) -> item.name },
                 ),
             )

--- a/data/src/test/java/com/team/yeogibeoryeo/data/item/repository/DisposalItemGuideRepositoryImplTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/item/repository/DisposalItemGuideRepositoryImplTest.kt
@@ -252,6 +252,34 @@ class DisposalItemGuideRepositoryImplTest {
         }
 
     @Test
+    fun `searchItemGuides는 같은 매칭 등급이면 품목명 가나다순으로 반환한다`() =
+        runBlocking {
+            val repository =
+                DisposalItemGuideRepositoryImpl(
+                    localDataSource =
+                        FakeLocalSource(
+                            wasteDictionaryItems =
+                                listOf(
+                                    sampleDictionaryItem(
+                                        name = "전기히터",
+                                        categoryPaths = listOf(listOf("재활용폐기물", "전기전자제품")),
+                                        dischargeMethods = listOf("전기히터는 폐가전 수거 기준에 따라 배출합니다."),
+                                    ),
+                                    sampleDictionaryItem(
+                                        name = "전기다리미",
+                                        categoryPaths = listOf(listOf("재활용폐기물", "전기전자제품")),
+                                        dischargeMethods = listOf("전기다리미는 폐가전 수거 기준에 따라 배출합니다."),
+                                    ),
+                                ),
+                        ),
+                )
+
+            val results = repository.searchItemGuides("전기")
+
+            assertEquals(listOf("전기다리미", "전기히터"), results.map { it.name })
+        }
+
+    @Test
     fun `searchItemGuides는 유사 품목 정확 일치를 유사 품목 부분 일치보다 우선한다`() =
         runBlocking {
             val repository =


### PR DESCRIPTION
## 작업 내용

- 품목 검색 결과 정렬 기준에서 이름 길이 우선 조건을 제거했습니다.
- 같은 매칭 등급 안에서는 품목명이 가나다순으로 정렬되도록 수정했습니다.
- 이름 정확 일치, 이름 시작 일치, 이름 부분 일치, 유사 품목 매칭 등 기존 검색 매칭 등급 우선순위는 유지했습니다.
- `전기` 검색 시 `전기다리미`가 `전기히터`보다 먼저 표시되는 케이스를 테스트로 보강했습니다.

## 변경 이유

품목 검색 결과가 같은 매칭 등급 안에서도 가나다순으로 표시되지 않는 문제가 있었습니다.

예를 들어 `전기`로 검색했을 때 `전기히터`가 `전기다리미`보다 먼저 표시될 수 있었습니다.

원인을 확인해보니 검색 결과 정렬이 `매칭 등급 -> 이름 길이 -> 이름` 순서로 적용되고 있어, 같은 매칭 등급에서는 품목명 가나다순보다 이름 길이가 먼저 반영되고 있었습니다.

사용자는 검색 결과를 품목명 기준으로 훑어보는 경우가 많으므로, 같은 매칭 등급 안에서는 품목명이 가나다순으로 정렬되도록 정리했습니다.

## 주요 변경 사항

- `DisposalItemGuideRepositoryImpl` 수정
  - 검색 결과 정렬 조건에서 `item.name.length` 기준을 제거했습니다.
  - 기존 매칭 등급 우선순위는 유지하고, 같은 등급 안에서 `item.name` 기준으로 정렬되도록 했습니다.
- `DisposalItemGuideRepositoryImplTest` 보강
  - 같은 매칭 등급의 검색 결과가 품목명 가나다순으로 반환되는지 확인하는 테스트를 추가했습니다.
  - `전기` 검색 결과에서 `전기다리미`, `전기히터` 순서가 유지되는지 확인합니다.

## 검증 내용

- [x] 같은 매칭 등급 안에서 품목명이 가나다순으로 정렬되는지 확인
- [x] `전기` 검색 시 `전기다리미`가 `전기히터`보다 먼저 반환되는지 테스트로 확인
- [x] 기존 검색 매칭 등급 우선순위가 유지되는지 기존 테스트로 확인

## 테스트

- [x] `./gradlew.bat :data:testDebugUnitTest --tests com.team.yeogibeoryeo.data.item.repository.DisposalItemGuideRepositoryImplTest`

## 관련 이슈

Related #90
