### PR TITLE
[Design] 하단 탭 라벨 한국어 과업명 적용

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -38,25 +38,25 @@ fun YeogiBeoryeoNavHost(
                 items =
                     listOf(
                         BottomNavigationItem(
-                            label = "Search",
+                            label = "품목",
                             iconResId = CommonR.drawable.ic_symbol_recycle,
                             selected = currentBackStackEntry.isItemSearchSelected(),
                             onClick = { navController.navigateBottomTab(ItemSearchRoute()) },
                         ),
                         BottomNavigationItem(
-                            label = "Map",
+                            label = "지도",
                             iconResId = AppR.drawable.ic_navigation_map,
                             selected = currentDestination?.hasRoute<MapRoute>() == true,
                             onClick = { navController.navigateBottomTab(MapRoute) },
                         ),
                         BottomNavigationItem(
-                            label = "Guide",
+                            label = "안내",
                             iconResId = AppR.drawable.ic_navigation_guide,
                             selected = currentDestination?.hasRoute<RegionalGuideRoute>() == true,
                             onClick = { navController.navigateBottomTab(RegionalGuideRoute()) },
                         ),
                         BottomNavigationItem(
-                            label = "Favorites",
+                            label = "저장",
                             iconResId = CommonR.drawable.ic_favorite,
                             selected = currentBackStackEntry.isFavoritesSelected(),
                             onClick = { navController.navigateBottomTab(FavoritesRoute) },


### PR DESCRIPTION
## 작업 내용

- 하단 NavigationBar 탭 라벨을 영어에서 한국어 과업명으로 변경했습니다.
  - `Search` → `품목`
  - `Map` → `지도`
  - `Guide` → `안내`
  - `Favorites` → `저장`

## 변경 이유

앱 전반의 화면 문구가 한국어 중심으로 구성되어 있어, 하단 탭 라벨도 동일한 언어 체계로 맞췄습니다.

Android Material 3의 NavigationBar는 compact 화면에서 3~5개의 주요 목적지를 전환하는 컴포넌트입니다. 따라서 제한된 폭 안에서 사용자가 각 탭의 목적을 빠르게 이해할 수 있도록, 짧고 명확한 한국어 라벨을 사용했습니다.

`Guide` 탭은 단순히 “방법”만 제공하는 화면이 아니라 지역별 생활폐기물 안내, 요일, 시간, 장소, 문의 정보까지 포함합니다. 그래서 `방법`, `지역`, `요일` 후보보다 화면 범위를 자연스럽게 담는 `안내`로 정리했습니다.

## 주요 변경 사항

- `YeogiBeoryeoNavHost`의 BottomNavigationItem 라벨 문구를 한국어로 변경했습니다.
- 기존 route, icon, selected 상태, 상세 화면 진입 시 탭 선택 유지 로직은 변경하지 않았습니다.

## 스크린샷

<img width="225" alt="image" src="https://github.com/user-attachments/assets/51d6a614-f7a4-422a-8c35-6be9a31a6a22" />

## 확인 사항

- [x] 하단 탭 라벨이 `품목 / 지도 / 안내 / 저장`으로 표시되도록 변경
- [x] 기존 BottomNavigation 선택 상태 로직 유지
- [x] 품목 상세 화면 진입 시 출처에 따른 탭 선택 유지 로직 변경 없음

## 테스트

- [x] `./gradlew.bat :app:compileDebugKotlin`

## 관련 이슈

Related #96
