### PR TITLE
refactor: 최근 주변 수거 장소 캐시 계층 분리

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation(project(":domain"))
 
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.datastore.preferences)
 
     // Coroutine
     implementation(libs.bundles.coroutines)

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/cache/DataStoreRecentCurrentLocationSpotCacheRepository.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/cache/DataStoreRecentCurrentLocationSpotCacheRepository.kt
@@ -1,9 +1,11 @@
-package com.team.yeogibeoryeo.presentation.map.cache
+package com.team.yeogibeoryeo.data.spot.cache
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.team.yeogibeoryeo.domain.spot.model.RecentCurrentLocationSpotCacheEntry
+import com.team.yeogibeoryeo.domain.spot.repository.RecentCurrentLocationSpotCacheRepository
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
@@ -11,9 +13,9 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
-class DataStoreRecentCurrentLocationSpotCache @Inject constructor(
+class DataStoreRecentCurrentLocationSpotCacheRepository @Inject constructor(
     private val dataStore: DataStore<Preferences>,
-) : RecentCurrentLocationSpotCache {
+) : RecentCurrentLocationSpotCacheRepository {
     private val json = Json {
         ignoreUnknownKeys = true
         encodeDefaults = true

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/cache/RecentCurrentLocationSpotCacheDto.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/cache/RecentCurrentLocationSpotCacheDto.kt
@@ -1,4 +1,4 @@
-package com.team.yeogibeoryeo.presentation.map.cache
+package com.team.yeogibeoryeo.data.spot.cache
 
 import kotlinx.serialization.Serializable
 

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/cache/RecentCurrentLocationSpotCacheMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/cache/RecentCurrentLocationSpotCacheMapper.kt
@@ -1,8 +1,9 @@
-package com.team.yeogibeoryeo.presentation.map.cache
+package com.team.yeogibeoryeo.data.spot.cache
 
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.model.RecentCurrentLocationSpotCacheEntry
 
 internal fun RecentCurrentLocationSpotCacheEntry.toDto(): RecentCurrentLocationSpotCacheDto {
     return RecentCurrentLocationSpotCacheDto(

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/di/SpotCacheDataModule.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/di/SpotCacheDataModule.kt
@@ -1,11 +1,11 @@
-package com.team.yeogibeoryeo.presentation.map.di
+package com.team.yeogibeoryeo.data.spot.di
 
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
-import com.team.yeogibeoryeo.presentation.map.cache.DataStoreRecentCurrentLocationSpotCache
-import com.team.yeogibeoryeo.presentation.map.cache.RecentCurrentLocationSpotCache
+import com.team.yeogibeoryeo.data.spot.cache.DataStoreRecentCurrentLocationSpotCacheRepository
+import com.team.yeogibeoryeo.domain.spot.repository.RecentCurrentLocationSpotCacheRepository
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -20,18 +20,18 @@ private val Context.mapCacheDataStore by preferencesDataStore(
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class MapCacheBindModule {
+abstract class SpotCacheBindModule {
 
     @Binds
     @Singleton
-    abstract fun bindRecentCurrentLocationSpotCache(
-        dataStoreRecentCurrentLocationSpotCache: DataStoreRecentCurrentLocationSpotCache,
-    ): RecentCurrentLocationSpotCache
+    abstract fun bindRecentCurrentLocationSpotCacheRepository(
+        dataStoreRecentCurrentLocationSpotCacheRepository: DataStoreRecentCurrentLocationSpotCacheRepository,
+    ): RecentCurrentLocationSpotCacheRepository
 }
 
 @Module
 @InstallIn(SingletonComponent::class)
-object MapCacheProvideModule {
+object SpotCacheProvideModule {
 
     @Provides
     @Singleton

--- a/data/src/main/java/com/team/yeogibeoryeo/data/time/SystemTimeProvider.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/time/SystemTimeProvider.kt
@@ -1,0 +1,10 @@
+package com.team.yeogibeoryeo.data.time
+
+import com.team.yeogibeoryeo.domain.time.TimeProvider
+import javax.inject.Inject
+
+class SystemTimeProvider @Inject constructor() : TimeProvider {
+    override fun currentTimeMillis(): Long {
+        return System.currentTimeMillis()
+    }
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/time/di/TimeDataModule.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/time/di/TimeDataModule.kt
@@ -1,0 +1,20 @@
+package com.team.yeogibeoryeo.data.time.di
+
+import com.team.yeogibeoryeo.data.time.SystemTimeProvider
+import com.team.yeogibeoryeo.domain.time.TimeProvider
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class TimeDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindTimeProvider(
+        systemTimeProvider: SystemTimeProvider,
+    ): TimeProvider
+}

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/cache/RecentCurrentLocationSpotCacheMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/cache/RecentCurrentLocationSpotCacheMapperTest.kt
@@ -1,0 +1,91 @@
+package com.team.yeogibeoryeo.data.spot.cache
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.model.RecentCurrentLocationSpotCacheEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RecentCurrentLocationSpotCacheMapperTest {
+
+    @Test
+    fun `domain cache entry를 dto로 변환할 때 검색 결과와 저장 시각을 유지한다`() {
+        val spot = sampleSpot(
+            id = "spot-1",
+            coordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+        )
+        val entry = RecentCurrentLocationSpotCacheEntry(
+            spots = listOf(spot),
+            savedAtMillis = 1_200_000L,
+        )
+
+        val dto = entry.toDto()
+
+        assertEquals(1_200_000L, dto.savedAtMillis)
+        assertEquals(1, dto.spots.size)
+        assertEquals("spot-1", dto.spots.first().id)
+        assertEquals(CollectionSpotType.STANDARD_BAG_STORE.name, dto.spots.first().type)
+        assertEquals(37.5666102, dto.spots.first().coordinate?.latitude)
+        assertEquals(126.9783881, dto.spots.first().coordinate?.longitude)
+    }
+
+    @Test
+    fun `dto를 domain cache entry로 변환할 때 수거 장소 좌표와 부가 정보를 복원한다`() {
+        val dto = RecentCurrentLocationSpotCacheDto(
+            spots = listOf(
+                CollectionSpotCacheDto(
+                    id = "spot-1",
+                    name = "수거 장소",
+                    type = CollectionSpotType.RECYCLING_CENTER.name,
+                    address = "서울특별시 영등포구",
+                    detailLocation = "1층 입구",
+                    coordinate = CoordinateCacheDto(latitude = 37.1, longitude = 127.1),
+                    distanceMeter = 120,
+                    isBookmarked = true,
+                ),
+            ),
+            savedAtMillis = 1_200_000L,
+        )
+
+        val entry = dto.toDomain()
+
+        assertEquals(1_200_000L, entry.savedAtMillis)
+        assertEquals(CollectionSpotType.RECYCLING_CENTER, entry.spots.first().type)
+        assertEquals(Coordinate(latitude = 37.1, longitude = 127.1), entry.spots.first().coordinate)
+        assertEquals("1층 입구", entry.spots.first().detailLocation)
+        assertEquals(120, entry.spots.first().distanceMeter)
+        assertEquals(true, entry.spots.first().isBookmarked)
+    }
+
+    @Test
+    fun `coordinate가 없는 장소도 cache dto로 변환할 수 있다`() {
+        val entry = RecentCurrentLocationSpotCacheEntry(
+            spots = listOf(sampleSpot(id = "spot-without-coordinate", coordinate = null)),
+            savedAtMillis = 1_200_000L,
+        )
+
+        val dto = entry.toDto()
+        val restoredEntry = dto.toDomain()
+
+        assertNull(dto.spots.first().coordinate)
+        assertNull(restoredEntry.spots.first().coordinate)
+    }
+
+    private fun sampleSpot(
+        id: String,
+        coordinate: Coordinate?,
+    ): CollectionSpot {
+        return CollectionSpot(
+            id = id,
+            name = "수거 장소 $id",
+            type = CollectionSpotType.STANDARD_BAG_STORE,
+            address = "서울특별시 영등포구",
+            detailLocation = null,
+            coordinate = coordinate,
+            distanceMeter = null,
+            isBookmarked = false,
+        )
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/RecentCurrentLocationSpotCacheEntry.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/RecentCurrentLocationSpotCacheEntry.kt
@@ -1,14 +1,4 @@
-package com.team.yeogibeoryeo.presentation.map.cache
-
-import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
-
-interface RecentCurrentLocationSpotCache {
-    suspend fun getRecentCurrentLocationSpots(): RecentCurrentLocationSpotCacheEntry?
-
-    suspend fun saveRecentCurrentLocationSpots(entry: RecentCurrentLocationSpotCacheEntry)
-
-    suspend fun clearRecentCurrentLocationSpots()
-}
+package com.team.yeogibeoryeo.domain.spot.model
 
 data class RecentCurrentLocationSpotCacheEntry(
     val spots: List<CollectionSpot>,

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/RecentCurrentLocationSpotCacheRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/RecentCurrentLocationSpotCacheRepository.kt
@@ -1,0 +1,11 @@
+package com.team.yeogibeoryeo.domain.spot.repository
+
+import com.team.yeogibeoryeo.domain.spot.model.RecentCurrentLocationSpotCacheEntry
+
+interface RecentCurrentLocationSpotCacheRepository {
+    suspend fun getRecentCurrentLocationSpots(): RecentCurrentLocationSpotCacheEntry?
+
+    suspend fun saveRecentCurrentLocationSpots(entry: RecentCurrentLocationSpotCacheEntry)
+
+    suspend fun clearRecentCurrentLocationSpots()
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/ClearRecentCurrentLocationSpotsUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/ClearRecentCurrentLocationSpotsUseCase.kt
@@ -1,0 +1,12 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import com.team.yeogibeoryeo.domain.spot.repository.RecentCurrentLocationSpotCacheRepository
+import javax.inject.Inject
+
+class ClearRecentCurrentLocationSpotsUseCase @Inject constructor(
+    private val repository: RecentCurrentLocationSpotCacheRepository,
+) {
+    suspend operator fun invoke() {
+        repository.clearRecentCurrentLocationSpots()
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/GetFreshRecentCurrentLocationSpotsUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/GetFreshRecentCurrentLocationSpotsUseCase.kt
@@ -1,0 +1,19 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import com.team.yeogibeoryeo.domain.spot.model.RecentCurrentLocationSpotCacheEntry
+import com.team.yeogibeoryeo.domain.spot.repository.RecentCurrentLocationSpotCacheRepository
+import com.team.yeogibeoryeo.domain.time.TimeProvider
+import javax.inject.Inject
+
+class GetFreshRecentCurrentLocationSpotsUseCase @Inject constructor(
+    private val repository: RecentCurrentLocationSpotCacheRepository,
+    private val timeProvider: TimeProvider,
+) {
+    suspend operator fun invoke(): RecentCurrentLocationSpotCacheEntry? {
+        val entry = repository.getRecentCurrentLocationSpots() ?: return null
+
+        return entry.takeIf {
+            it.isFresh(nowMillis = timeProvider.currentTimeMillis())
+        }
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SaveRecentCurrentLocationSpotsUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SaveRecentCurrentLocationSpotsUseCase.kt
@@ -1,0 +1,21 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.RecentCurrentLocationSpotCacheEntry
+import com.team.yeogibeoryeo.domain.spot.repository.RecentCurrentLocationSpotCacheRepository
+import com.team.yeogibeoryeo.domain.time.TimeProvider
+import javax.inject.Inject
+
+class SaveRecentCurrentLocationSpotsUseCase @Inject constructor(
+    private val repository: RecentCurrentLocationSpotCacheRepository,
+    private val timeProvider: TimeProvider,
+) {
+    suspend operator fun invoke(spots: List<CollectionSpot>) {
+        repository.saveRecentCurrentLocationSpots(
+            RecentCurrentLocationSpotCacheEntry(
+                spots = spots,
+                savedAtMillis = timeProvider.currentTimeMillis(),
+            ),
+        )
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/time/TimeProvider.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/time/TimeProvider.kt
@@ -1,0 +1,5 @@
+package com.team.yeogibeoryeo.domain.time
+
+interface TimeProvider {
+    fun currentTimeMillis(): Long
+}

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/RecentCurrentLocationSpotCacheUseCasesTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/RecentCurrentLocationSpotCacheUseCasesTest.kt
@@ -1,0 +1,129 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.RecentCurrentLocationSpotCacheEntry
+import com.team.yeogibeoryeo.domain.spot.repository.RecentCurrentLocationSpotCacheRepository
+import com.team.yeogibeoryeo.domain.time.TimeProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RecentCurrentLocationSpotCacheUseCasesTest {
+
+    @Test
+    fun `GetFreshRecentCurrentLocationSpotsUseCase는 TTL 이내 캐시를 반환한다`() =
+        runBlocking {
+            val cachedSpots = listOf(sampleSpot("cache"))
+            val repository = FakeRecentCurrentLocationSpotCacheRepository(
+                entry = RecentCurrentLocationSpotCacheEntry(
+                    spots = cachedSpots,
+                    savedAtMillis = TEST_NOW_MILLIS - FIVE_MINUTES_MILLIS,
+                ),
+            )
+            val useCase = GetFreshRecentCurrentLocationSpotsUseCase(
+                repository = repository,
+                timeProvider = FakeTimeProvider(TEST_NOW_MILLIS),
+            )
+
+            val result = useCase()
+
+            assertEquals(cachedSpots, result?.spots)
+        }
+
+    @Test
+    fun `GetFreshRecentCurrentLocationSpotsUseCase는 만료된 캐시를 반환하지 않는다`() =
+        runBlocking {
+            val repository = FakeRecentCurrentLocationSpotCacheRepository(
+                entry = RecentCurrentLocationSpotCacheEntry(
+                    spots = listOf(sampleSpot("expired")),
+                    savedAtMillis = TEST_NOW_MILLIS - ELEVEN_MINUTES_MILLIS,
+                ),
+            )
+            val useCase = GetFreshRecentCurrentLocationSpotsUseCase(
+                repository = repository,
+                timeProvider = FakeTimeProvider(TEST_NOW_MILLIS),
+            )
+
+            val result = useCase()
+
+            assertNull(result)
+        }
+
+    @Test
+    fun `GetFreshRecentCurrentLocationSpotsUseCase는 미래 시각 캐시를 반환하지 않는다`() =
+        runBlocking {
+            val repository = FakeRecentCurrentLocationSpotCacheRepository(
+                entry = RecentCurrentLocationSpotCacheEntry(
+                    spots = listOf(sampleSpot("future")),
+                    savedAtMillis = TEST_NOW_MILLIS + 1L,
+                ),
+            )
+            val useCase = GetFreshRecentCurrentLocationSpotsUseCase(
+                repository = repository,
+                timeProvider = FakeTimeProvider(TEST_NOW_MILLIS),
+            )
+
+            val result = useCase()
+
+            assertNull(result)
+        }
+
+    @Test
+    fun `SaveRecentCurrentLocationSpotsUseCase는 TimeProvider 기준 시각으로 캐시를 저장한다`() =
+        runBlocking {
+            val spots = listOf(sampleSpot("saved"))
+            val repository = FakeRecentCurrentLocationSpotCacheRepository()
+            val useCase = SaveRecentCurrentLocationSpotsUseCase(
+                repository = repository,
+                timeProvider = FakeTimeProvider(TEST_NOW_MILLIS),
+            )
+
+            useCase(spots)
+
+            assertEquals(spots, repository.entry?.spots)
+            assertEquals(TEST_NOW_MILLIS, repository.entry?.savedAtMillis)
+        }
+
+    private fun sampleSpot(id: String): CollectionSpot {
+        return CollectionSpot(
+            id = id,
+            name = "수거 장소 $id",
+            type = CollectionSpotType.STANDARD_BAG_STORE,
+            address = "서울특별시 영등포구",
+            detailLocation = null,
+            coordinate = null,
+            distanceMeter = null,
+            isBookmarked = false,
+        )
+    }
+
+    private class FakeRecentCurrentLocationSpotCacheRepository(
+        var entry: RecentCurrentLocationSpotCacheEntry? = null,
+    ) : RecentCurrentLocationSpotCacheRepository {
+        override suspend fun getRecentCurrentLocationSpots(): RecentCurrentLocationSpotCacheEntry? {
+            return entry
+        }
+
+        override suspend fun saveRecentCurrentLocationSpots(entry: RecentCurrentLocationSpotCacheEntry) {
+            this.entry = entry
+        }
+
+        override suspend fun clearRecentCurrentLocationSpots() {
+            entry = null
+        }
+    }
+
+    private class FakeTimeProvider(
+        private val nowMillis: Long,
+    ) : TimeProvider {
+        override fun currentTimeMillis(): Long = nowMillis
+    }
+
+    private companion object {
+        const val TEST_NOW_MILLIS = 20 * 60 * 1_000L
+        const val FIVE_MINUTES_MILLIS = 5 * 60 * 1_000L
+        const val ELEVEN_MINUTES_MILLIS = 11 * 60 * 1_000L
+    }
+}

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.google.ksp)
     alias(libs.plugins.hilt.android)
 }
@@ -49,8 +48,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
-    implementation(libs.androidx.datastore.preferences)
-    implementation(libs.kotlinx.serialization.json)
 
     // Location
     implementation(libs.google.android.gms.play.services.location)

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -6,10 +6,10 @@ import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
+import com.team.yeogibeoryeo.domain.spot.usecase.GetFreshRecentCurrentLocationSpotsUseCase
+import com.team.yeogibeoryeo.domain.spot.usecase.SaveRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByKeywordUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByLocationUseCase
-import com.team.yeogibeoryeo.presentation.map.cache.RecentCurrentLocationSpotCache
-import com.team.yeogibeoryeo.presentation.map.cache.RecentCurrentLocationSpotCacheEntry
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationProvider
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationResult
 import com.team.yeogibeoryeo.presentation.map.location.LocationPermissionChecker
@@ -30,7 +30,8 @@ class CollectionSpotMapViewModel @Inject constructor(
     private val filterCollectionSpotsUseCase: FilterCollectionSpotsUseCase,
     private val currentLocationProvider: CurrentLocationProvider,
     private val locationPermissionChecker: LocationPermissionChecker,
-    private val recentCurrentLocationSpotCache: RecentCurrentLocationSpotCache,
+    private val getFreshRecentCurrentLocationSpotsUseCase: GetFreshRecentCurrentLocationSpotsUseCase,
+    private val saveRecentCurrentLocationSpotsUseCase: SaveRecentCurrentLocationSpotsUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CollectionSpotMapUiState())
@@ -163,12 +164,7 @@ class CollectionSpotMapViewModel @Inject constructor(
             if (!canApplyCurrentLocationResult()) return
 
             updateSpotResult(spots)
-            recentCurrentLocationSpotCache.saveRecentCurrentLocationSpots(
-                RecentCurrentLocationSpotCacheEntry(
-                    spots = spots,
-                    savedAtMillis = System.currentTimeMillis(),
-                ),
-            )
+            saveRecentCurrentLocationSpotsUseCase(spots)
         } catch (throwable: Throwable) {
             if (throwable is CancellationException) throw throwable
 
@@ -240,10 +236,9 @@ class CollectionSpotMapViewModel @Inject constructor(
         hasRequestedInitialCurrentLocationSearch = true
         spotSearchJob?.cancel()
         spotSearchJob = viewModelScope.launch {
-            val cachedEntry = recentCurrentLocationSpotCache.getRecentCurrentLocationSpots()
-            val hasFreshCache = cachedEntry?.isFresh(System.currentTimeMillis()) == true
+            val cachedEntry = getFreshRecentCurrentLocationSpotsUseCase()
 
-            if (hasFreshCache && canStartInitialCurrentLocationSearch()) {
+            if (cachedEntry != null && canStartInitialCurrentLocationSearch()) {
                 showCachedCurrentLocationSpots(cachedEntry.spots)
                 refreshCurrentLocationSilently()
                 return@launch
@@ -324,6 +319,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 it.copy(
                     isLoading = true,
                     hasSearched = true,
+                    searchKeyword = "",
                     errorMessage = null,
                     locationNoticeMessage = null,
                     selectedSpot = null,

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -3,12 +3,15 @@ package com.team.yeogibeoryeo.presentation.map
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.model.RecentCurrentLocationSpotCacheEntry
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
+import com.team.yeogibeoryeo.domain.spot.repository.RecentCurrentLocationSpotCacheRepository
 import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
+import com.team.yeogibeoryeo.domain.spot.usecase.GetFreshRecentCurrentLocationSpotsUseCase
+import com.team.yeogibeoryeo.domain.spot.usecase.SaveRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByKeywordUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByLocationUseCase
-import com.team.yeogibeoryeo.presentation.map.cache.RecentCurrentLocationSpotCache
-import com.team.yeogibeoryeo.presentation.map.cache.RecentCurrentLocationSpotCacheEntry
+import com.team.yeogibeoryeo.domain.time.TimeProvider
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationProvider
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationResult
 import com.team.yeogibeoryeo.presentation.map.location.LocationPermissionChecker
@@ -189,6 +192,34 @@ class CollectionSpotMapViewModelTest {
         }
 
     @Test
+    fun `키워드 검색 후 현재 위치 검색을 실행하면 검색어를 비우고 현재 위치 결과를 반영한다`() =
+        runTest {
+            val keywordSpot = sampleSpot("keyword", CollectionSpotType.OTHER)
+            val locationSpot = sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)
+            val repository = FakeCollectionSpotRepository(
+                keywordSpots = listOf(keywordSpot),
+                locationSpots = listOf(locationSpot),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+            )
+
+            viewModel.onSearchKeywordChanged("용답동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+            viewModel.searchByCurrentLocation()
+            advanceUntilIdle()
+
+            assertEquals("", viewModel.uiState.value.searchKeyword)
+            assertEquals(listOf(locationSpot), viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.CURRENT_LOCATION, viewModel.uiState.value.searchMode)
+            assertFalse(viewModel.uiState.value.isLoading)
+        }
+
+    @Test
     fun `지도 진입 시 위치 권한이 있으면 현재 위치 검색을 자동 실행한다`() =
         runTest {
             val currentCoordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881)
@@ -357,7 +388,7 @@ class CollectionSpotMapViewModelTest {
         runTest {
             val locationResult = CompletableDeferred<CurrentLocationResult>()
             val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
-            val cache = FakeRecentCurrentLocationSpotCache(
+            val cache = FakeRecentCurrentLocationSpotCacheRepository(
                 entry = freshCacheEntry(listOf(cachedSpot)),
             )
             val repository = FakeCollectionSpotRepository(
@@ -369,7 +400,7 @@ class CollectionSpotMapViewModelTest {
                     locationResult.await()
                 },
                 hasFineLocationPermission = true,
-                recentCurrentLocationSpotCache = cache,
+                recentCurrentLocationSpotCacheRepository = cache,
             )
 
             viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
@@ -381,11 +412,42 @@ class CollectionSpotMapViewModelTest {
         }
 
     @Test
+    fun `캐시 결과에서도 필터칩 선택 시 정상 필터링된다`() =
+        runTest {
+            val locationResult = CompletableDeferred<CurrentLocationResult>()
+            val standardBagSpot = sampleSpot("cache-standard", CollectionSpotType.STANDARD_BAG_STORE)
+            val recyclingCenterSpot = sampleSpot("cache-recycling", CollectionSpotType.RECYCLING_CENTER)
+            val cache = FakeRecentCurrentLocationSpotCacheRepository(
+                entry = freshCacheEntry(
+                    spots = listOf(standardBagSpot, recyclingCenterSpot),
+                ),
+            )
+            val repository = FakeCollectionSpotRepository(
+                locationSpots = listOf(sampleSpot("refresh", CollectionSpotType.OTHER)),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationProvider = FakeCurrentLocationProvider {
+                    locationResult.await()
+                },
+                hasFineLocationPermission = true,
+                recentCurrentLocationSpotCacheRepository = cache,
+            )
+
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+            viewModel.onSpotTypeClick(CollectionSpotType.RECYCLING_CENTER)
+
+            assertEquals(setOf(CollectionSpotType.RECYCLING_CENTER), viewModel.uiState.value.selectedTypes)
+            assertEquals(listOf(recyclingCenterSpot), viewModel.uiState.value.spots)
+            assertEquals(0, repository.locationSearchCallCount)
+        }
+
+    @Test
     fun `유효한 캐시 표시 후 refresh 성공 시 화면 결과와 캐시를 최신 결과로 교체한다`() =
         runTest {
             val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
             val refreshedSpot = sampleSpot("refresh", CollectionSpotType.RECYCLING_CENTER)
-            val cache = FakeRecentCurrentLocationSpotCache(
+            val cache = FakeRecentCurrentLocationSpotCacheRepository(
                 entry = freshCacheEntry(listOf(cachedSpot)),
             )
             val repository = FakeCollectionSpotRepository(locationSpots = listOf(refreshedSpot))
@@ -395,7 +457,7 @@ class CollectionSpotMapViewModelTest {
                     Coordinate(latitude = 37.5666102, longitude = 126.9783881),
                 ),
                 hasFineLocationPermission = true,
-                recentCurrentLocationSpotCache = cache,
+                recentCurrentLocationSpotCacheRepository = cache,
             )
 
             viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
@@ -411,7 +473,7 @@ class CollectionSpotMapViewModelTest {
     fun `유효한 캐시 표시 후 refresh 실패 시 기존 캐시 결과를 유지한다`() =
         runTest {
             val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
-            val cache = FakeRecentCurrentLocationSpotCache(
+            val cache = FakeRecentCurrentLocationSpotCacheRepository(
                 entry = freshCacheEntry(listOf(cachedSpot)),
             )
             val repository = FakeCollectionSpotRepository()
@@ -419,7 +481,7 @@ class CollectionSpotMapViewModelTest {
                 repository = repository,
                 currentLocationResult = CurrentLocationResult.NotFound,
                 hasFineLocationPermission = true,
-                recentCurrentLocationSpotCache = cache,
+                recentCurrentLocationSpotCacheRepository = cache,
             )
 
             viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
@@ -439,13 +501,13 @@ class CollectionSpotMapViewModelTest {
         runTest {
             val currentCoordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881)
             val expectedSpot = sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)
-            val cache = FakeRecentCurrentLocationSpotCache()
+            val cache = FakeRecentCurrentLocationSpotCacheRepository()
             val repository = FakeCollectionSpotRepository(locationSpots = listOf(expectedSpot))
             val viewModel = createViewModel(
                 repository = repository,
                 currentLocationResult = CurrentLocationResult.Found(currentCoordinate),
                 hasFineLocationPermission = true,
-                recentCurrentLocationSpotCache = cache,
+                recentCurrentLocationSpotCacheRepository = cache,
             )
 
             viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
@@ -462,7 +524,7 @@ class CollectionSpotMapViewModelTest {
         runTest {
             val expiredSpot = sampleSpot("expired", CollectionSpotType.OTHER)
             val expectedSpot = sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)
-            val cache = FakeRecentCurrentLocationSpotCache(
+            val cache = FakeRecentCurrentLocationSpotCacheRepository(
                 entry = RecentCurrentLocationSpotCacheEntry(
                     spots = listOf(expiredSpot),
                     savedAtMillis = 0L,
@@ -475,7 +537,7 @@ class CollectionSpotMapViewModelTest {
                     Coordinate(latitude = 37.5666102, longitude = 126.9783881),
                 ),
                 hasFineLocationPermission = true,
-                recentCurrentLocationSpotCache = cache,
+                recentCurrentLocationSpotCacheRepository = cache,
             )
 
             viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
@@ -489,7 +551,7 @@ class CollectionSpotMapViewModelTest {
     fun `위치 권한이 없으면 캐시가 있어도 자동 표시하지 않는다`() =
         runTest {
             val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
-            val cache = FakeRecentCurrentLocationSpotCache(
+            val cache = FakeRecentCurrentLocationSpotCacheRepository(
                 entry = freshCacheEntry(listOf(cachedSpot)),
             )
             val repository = FakeCollectionSpotRepository()
@@ -499,7 +561,7 @@ class CollectionSpotMapViewModelTest {
                     Coordinate(latitude = 37.5666102, longitude = 126.9783881),
                 ),
                 hasFineLocationPermission = false,
-                recentCurrentLocationSpotCache = cache,
+                recentCurrentLocationSpotCacheRepository = cache,
             )
 
             viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
@@ -517,7 +579,7 @@ class CollectionSpotMapViewModelTest {
             val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
             val keywordSpot = sampleSpot("keyword", CollectionSpotType.OTHER)
             val refreshSpot = sampleSpot("refresh", CollectionSpotType.RECYCLING_CENTER)
-            val cache = FakeRecentCurrentLocationSpotCache(
+            val cache = FakeRecentCurrentLocationSpotCacheRepository(
                 entry = freshCacheEntry(listOf(cachedSpot)),
             )
             val repository = FakeCollectionSpotRepository(
@@ -530,7 +592,7 @@ class CollectionSpotMapViewModelTest {
                     locationResult.await()
                 },
                 hasFineLocationPermission = true,
-                recentCurrentLocationSpotCache = cache,
+                recentCurrentLocationSpotCacheRepository = cache,
             )
 
             viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
@@ -553,14 +615,14 @@ class CollectionSpotMapViewModelTest {
     fun `현재 위치 버튼 수동 검색 성공 시 캐시를 갱신한다`() =
         runTest {
             val expectedSpot = sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)
-            val cache = FakeRecentCurrentLocationSpotCache()
+            val cache = FakeRecentCurrentLocationSpotCacheRepository()
             val repository = FakeCollectionSpotRepository(locationSpots = listOf(expectedSpot))
             val viewModel = createViewModel(
                 repository = repository,
                 currentLocationResult = CurrentLocationResult.Found(
                     Coordinate(latitude = 37.5666102, longitude = 126.9783881),
                 ),
-                recentCurrentLocationSpotCache = cache,
+                recentCurrentLocationSpotCacheRepository = cache,
             )
 
             viewModel.searchByCurrentLocation()
@@ -573,12 +635,12 @@ class CollectionSpotMapViewModelTest {
     fun `키워드 검색 성공 시 캐시를 갱신하지 않는다`() =
         runTest {
             val keywordSpot = sampleSpot("keyword", CollectionSpotType.OTHER)
-            val cache = FakeRecentCurrentLocationSpotCache()
+            val cache = FakeRecentCurrentLocationSpotCacheRepository()
             val repository = FakeCollectionSpotRepository(keywordSpots = listOf(keywordSpot))
             val viewModel = createViewModel(
                 repository = repository,
                 currentLocationResult = CurrentLocationResult.NotFound,
-                recentCurrentLocationSpotCache = cache,
+                recentCurrentLocationSpotCacheRepository = cache,
             )
 
             viewModel.onSearchKeywordChanged("문래동")
@@ -593,13 +655,16 @@ class CollectionSpotMapViewModelTest {
         repository: FakeCollectionSpotRepository,
         currentLocationResult: CurrentLocationResult,
         hasFineLocationPermission: Boolean = true,
-        recentCurrentLocationSpotCache: RecentCurrentLocationSpotCache = FakeRecentCurrentLocationSpotCache(),
+        recentCurrentLocationSpotCacheRepository: RecentCurrentLocationSpotCacheRepository =
+            FakeRecentCurrentLocationSpotCacheRepository(),
+        timeProvider: TimeProvider = FakeTimeProvider(),
     ): CollectionSpotMapViewModel {
         return createViewModel(
             repository = repository,
             currentLocationProvider = FakeCurrentLocationProvider(currentLocationResult),
             hasFineLocationPermission = hasFineLocationPermission,
-            recentCurrentLocationSpotCache = recentCurrentLocationSpotCache,
+            recentCurrentLocationSpotCacheRepository = recentCurrentLocationSpotCacheRepository,
+            timeProvider = timeProvider,
         )
     }
 
@@ -607,7 +672,9 @@ class CollectionSpotMapViewModelTest {
         repository: FakeCollectionSpotRepository,
         currentLocationProvider: CurrentLocationProvider,
         hasFineLocationPermission: Boolean = true,
-        recentCurrentLocationSpotCache: RecentCurrentLocationSpotCache = FakeRecentCurrentLocationSpotCache(),
+        recentCurrentLocationSpotCacheRepository: RecentCurrentLocationSpotCacheRepository =
+            FakeRecentCurrentLocationSpotCacheRepository(),
+        timeProvider: TimeProvider = FakeTimeProvider(),
     ): CollectionSpotMapViewModel {
         return CollectionSpotMapViewModel(
             searchCollectionSpotsByKeywordUseCase = SearchCollectionSpotsByKeywordUseCase(repository),
@@ -615,7 +682,14 @@ class CollectionSpotMapViewModelTest {
             filterCollectionSpotsUseCase = FilterCollectionSpotsUseCase(),
             currentLocationProvider = currentLocationProvider,
             locationPermissionChecker = FakeLocationPermissionChecker(hasFineLocationPermission),
-            recentCurrentLocationSpotCache = recentCurrentLocationSpotCache,
+            getFreshRecentCurrentLocationSpotsUseCase = GetFreshRecentCurrentLocationSpotsUseCase(
+                repository = recentCurrentLocationSpotCacheRepository,
+                timeProvider = timeProvider,
+            ),
+            saveRecentCurrentLocationSpotsUseCase = SaveRecentCurrentLocationSpotsUseCase(
+                repository = recentCurrentLocationSpotCacheRepository,
+                timeProvider = timeProvider,
+            ),
         )
     }
 
@@ -624,7 +698,7 @@ class CollectionSpotMapViewModelTest {
     ): RecentCurrentLocationSpotCacheEntry {
         return RecentCurrentLocationSpotCacheEntry(
             spots = spots,
-            savedAtMillis = System.currentTimeMillis(),
+            savedAtMillis = TEST_NOW_MILLIS,
         )
     }
 
@@ -657,9 +731,15 @@ class CollectionSpotMapViewModelTest {
         override fun hasFineLocationPermission(): Boolean = hasFineLocationPermission
     }
 
-    private class FakeRecentCurrentLocationSpotCache(
+    private class FakeTimeProvider(
+        private val nowMillis: Long = TEST_NOW_MILLIS,
+    ) : TimeProvider {
+        override fun currentTimeMillis(): Long = nowMillis
+    }
+
+    private class FakeRecentCurrentLocationSpotCacheRepository(
         var entry: RecentCurrentLocationSpotCacheEntry? = null,
-    ) : RecentCurrentLocationSpotCache {
+    ) : RecentCurrentLocationSpotCacheRepository {
         var getCallCount = 0
             private set
         var saveCallCount = 0
@@ -712,5 +792,9 @@ class CollectionSpotMapViewModelTest {
         }
 
         override suspend fun geocodeSpot(spot: CollectionSpot): CollectionSpot = spot
+    }
+
+    private companion object {
+        const val TEST_NOW_MILLIS = 20 * 60 * 1_000L
     }
 }


### PR DESCRIPTION
## 작업 내용

| 구분 | 내용 |
| --- | --- |
| Domain | 최근 현재 위치 검색 결과 캐시 entry, repository interface, usecase, TimeProvider 추가 |
| Data | DataStore 기반 캐시 repository, DTO/mapper, SystemTimeProvider, Hilt binding 추가 |
| Presentation | `presentation/map/cache` 구현 제거 및 ViewModel의 cache repository 직접 의존 제거 |
| ViewModel | `GetFreshRecentCurrentLocationSpotsUseCase`, `SaveRecentCurrentLocationSpotsUseCase` 중심으로 캐시 접근 정리 |
| Test | ViewModel/usecase/mapper 테스트 보강 |
| Bug Fix | 키워드 검색 후 `내 주변 검색` 클릭 시 검색어가 남아 현재 위치 결과가 반영되지 않던 이슈 수정 |

## 유지한 정책

| 정책 | 반영 여부 |
| --- | --- |
| TTL 10분 유지 | 반영 |
| 정확한 사용자 현재 위치 기준 좌표 미저장 | 반영 |
| 최근 현재 위치 기반 검색 성공 결과 목록 + 저장 시각만 캐시 | 반영 |
| 유효 캐시 즉시 표시 후 silent refresh | 반영 |
| refresh 실패 시 기존 캐시 결과 유지 | 반영 |
| 키워드 검색 결과 덮어쓰기 방지 | 반영 |
| 현재 위치 버튼 수동 검색 성공 시 캐시 갱신 | 반영 |
| 키워드 검색 성공 시 캐시 미갱신 | 반영 |
| 위치 권한 없으면 캐시 자동 표시하지 않음 | 반영 |

## DataStore를 유지한 이유

이번 PR은 새로운 저장 정책을 도입하는 작업이 아니라, #82에서 구현한 최근 현재 위치 검색 결과 캐시 책임을 Clean Architecture 구조로 분리하는 리팩토링입니다.

현재 캐시 정책은 다음 성격에 가깝습니다.

| 기준 | 현재 정책 |
| --- | --- |
| 저장 목적 | Map 진입 시 최근 검색 결과를 짧게 재사용 |
| TTL | 10분 |
| 저장 대상 | 최근 현재 위치 기반 검색 결과 목록과 저장 시각 |
| 쿼리 필요성 | 복잡한 조회/정렬/관계형 쿼리 없음 |
| 좌표 정책 | 사용자 현재 위치 기준 좌표는 저장하지 않음 |
| 사용 범위 | 현재는 Map 화면 캐시 UX 중심 |

그래서 이번 단계에서는 Room으로 전환하지 않고 DataStore를 유지했습니다.

다만 홈 화면에서 최근 주변 수거 장소를 보여주거나, 즐겨찾기/추천 장소와 연결하거나, 장소별 상태를 관계형으로 관리해야 하는 요구가 생기면 Room 기반 local table로 확장하는 것이 더 적절하다고 보고 후속 후보로 남겼습니다.

## 검증

| 항목 | 결과 |
| --- | --- |
| `./gradlew.bat :domain:test` | 성공 |
| `./gradlew.bat :data:testDebugUnitTest` | 성공 |
| `./gradlew.bat :presentation:testDebugUnitTest` | 성공 |
| `./gradlew.bat :app:assembleDebug` | 성공 |
| 실제 기기 Map 진입 / 캐시 즉시 표시 / silent refresh | 확인 |
| 키워드 검색 결과가 refresh에 덮이지 않는지 | 확인 |
| `용답동` 검색 후 `내 주변 검색` 전환 | 확인 |
| 필터칩 / 마커 / 카드 / BottomSheet 동작 | 확인 |

## 이번 PR에서 하지 않은 작업

| 제외 항목 | 비고 |
| --- | --- |
| Room 전환 | 저장 정책 확장 시 후속 검토 |
| 홈 화면 최근 주변 수거 장소 UI | 후속 후보 |
| 즐겨찾기/추천 장소 연계 | 후속 후보 |
| 위치 실패 상태별 안내 UX | #95에서 진행 예정 |
| CurrentLocationProvider 구조 변경 | 제외 |
| 위치 권한 처리 구조 변경 | 제외 |
| NaverMap overlay / locationTrackingMode 변경 | 제외 |
| `/getSpot` remote 검색 로직 변경 | 제외 |

Refs #92