### PR TITLE
feat: 현재 위치 검색 실패 안내 UX 개선

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -1,5 +1,8 @@
 package com.team.yeogibeoryeo.presentation.map
 
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -14,6 +17,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -39,6 +43,7 @@ fun CollectionSpotMapScreen(
     modifier: Modifier = Modifier,
     viewModel: CollectionSpotMapViewModel = hiltViewModel(),
 ) {
+    val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val hasFineLocationPermission = rememberFineLocationPermissionGranted()
     var hasGrantedLocationPermissionInSession by rememberSaveable {
@@ -91,6 +96,9 @@ fun CollectionSpotMapScreen(
         onMyLocationPermissionRequest = {
             requestMyLocationTracking()
         },
+        onLocationNoticeActionClick = { action ->
+            context.startActivity(action.toIntent(context.packageName))
+        },
         onTypeClick = viewModel::onSpotTypeClick,
         onSpotClick = viewModel::onSpotClick,
         modifier = modifier,
@@ -107,6 +115,7 @@ private fun CollectionSpotMapContent(
     onSearchClick: () -> Unit,
     onCurrentLocationClick: () -> Unit,
     onMyLocationPermissionRequest: () -> Unit,
+    onLocationNoticeActionClick: (MapLocationNoticeAction) -> Unit,
     onTypeClick: (CollectionSpotType) -> Unit,
     onSpotClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
@@ -118,6 +127,9 @@ private fun CollectionSpotMapContent(
     var sheetLevel by remember { mutableStateOf(MapSheetLevel.Hidden) }
     var sheetRevealRequest by remember { mutableStateOf(0) }
     val selectedSpot = uiState.selectedSpot
+    val hasNoticeOrError = uiState.locationNotice != null ||
+        uiState.locationNoticeMessage != null ||
+        uiState.errorMessage != null
     val mapLocationTrackingMode = when {
         !isLocationPermissionGranted -> LocationTrackingMode.None
         locationTrackingMode == LocationTrackingMode.None -> LocationTrackingMode.NoFollow
@@ -135,6 +147,7 @@ private fun CollectionSpotMapContent(
         uiState.isLoading,
         uiState.searchMode,
         uiState.errorMessage,
+        uiState.locationNotice,
         uiState.locationNoticeMessage,
     ) {
         when {
@@ -143,9 +156,13 @@ private fun CollectionSpotMapContent(
                 sheetLevel = MapSheetLevel.Hidden
             }
 
-            uiState.isLoading || uiState.errorMessage != null || uiState.locationNoticeMessage != null -> {
+            uiState.isLoading || hasNoticeOrError -> {
                 mapUiMode = MapUiMode.ResultList
-                sheetLevel = MapSheetLevel.Peek
+                sheetLevel = if (hasNoticeOrError) {
+                    MapSheetLevel.Medium
+                } else {
+                    MapSheetLevel.Peek
+                }
             }
 
             uiState.hasSearched && mapUiMode == MapUiMode.Browsing -> {
@@ -274,9 +291,11 @@ private fun CollectionSpotMapContent(
                             isLoading = uiState.isLoading,
                             hasSearched = uiState.hasSearched,
                             selectedTypes = uiState.selectedTypes,
+                            locationNotice = uiState.locationNotice,
                             locationNoticeMessage = uiState.locationNoticeMessage,
                             errorMessage = uiState.errorMessage,
                             onTypeClick = onTypeClick,
+                            onLocationNoticeActionClick = onLocationNoticeActionClick,
                             onSpotClick = { spot ->
                                 onLocationTrackingModeChange(LocationTrackingMode.NoFollow)
                                 mapUiMode = MapUiMode.SpotDetail
@@ -294,6 +313,7 @@ private fun CollectionSpotMapContent(
 
 private val CollectionSpotMapUiState.shouldShowBottomSheet: Boolean
     get() = isLoading ||
+        locationNotice != null ||
         locationNoticeMessage != null ||
         errorMessage != null ||
         hasSearched ||
@@ -336,6 +356,7 @@ private fun CollectionSpotMapContentPreview() {
                 onSearchClick = {},
                 onCurrentLocationClick = {},
                 onMyLocationPermissionRequest = {},
+                onLocationNoticeActionClick = {},
                 onTypeClick = {},
                 onSpotClick = {},
             )
@@ -345,3 +366,17 @@ private fun CollectionSpotMapContentPreview() {
 
 private val MyLocationButtonHorizontalPadding = 16.dp
 private val MyLocationButtonBottomPadding = 16.dp
+
+private fun MapLocationNoticeAction.toIntent(packageName: String): Intent {
+    return when (this) {
+        MapLocationNoticeAction.OpenAppSettings -> Intent(
+            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+        ).apply {
+            data = Uri.fromParts("package", packageName, null)
+        }
+
+        MapLocationNoticeAction.OpenLocationSettings -> Intent(
+            Settings.ACTION_LOCATION_SOURCE_SETTINGS,
+        )
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapUiState.kt
@@ -12,6 +12,7 @@ data class CollectionSpotMapUiState(
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
     val hasSearched: Boolean = false,
+    val locationNotice: MapLocationNotice? = null,
     val locationNoticeMessage: String? = null,
 ) {
     val isEmpty: Boolean

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -77,6 +77,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     it.hasSearched
                 },
                 errorMessage = null,
+                locationNotice = null,
                 locationNoticeMessage = null,
                 searchMode = if (shouldCancelCurrentLocationSearch) {
                     MapSearchMode.KEYWORD
@@ -102,6 +103,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     isLoading = false,
                     hasSearched = false,
                     errorMessage = "검색어를 입력해주세요.",
+                    locationNotice = null,
                     locationNoticeMessage = null,
                     searchMode = MapSearchMode.KEYWORD,
                 )
@@ -116,6 +118,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     isLoading = true,
                     hasSearched = true,
                     errorMessage = null,
+                    locationNotice = null,
                     locationNoticeMessage = null,
                     selectedSpot = null,
                     searchMode = MapSearchMode.KEYWORD,
@@ -133,7 +136,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 if (throwable is CancellationException) throw throwable
 
                 updateSpotFailure(
-                    message = throwable.message ?: "수거 장소를 불러오지 못했습니다.",
+                    message = MapLocationNotices.SpotSearchFailureMessage,
                 )
             }
         }
@@ -170,7 +173,7 @@ class CollectionSpotMapViewModel @Inject constructor(
 
             if (!preservePreviousResultOnFailure) {
                 updateSpotFailure(
-                    message = throwable.message ?: "현재 위치 주변 수거 장소를 불러오지 못했습니다.",
+                    message = MapLocationNotices.CurrentLocationSpotSearchFailureMessage,
                 )
             }
         }
@@ -215,7 +218,8 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isLoading = false,
                 hasSearched = false,
                 errorMessage = null,
-                locationNoticeMessage = "현재 위치 검색은 정확한 위치 권한을 허용하면 사용할 수 있어요. 직접 동네나 주소를 검색할 수도 있습니다.",
+                locationNotice = MapLocationNotices.PermissionDenied,
+                locationNoticeMessage = MapLocationNotices.PermissionDenied.message,
                 searchMode = MapSearchMode.KEYWORD,
             )
         }
@@ -263,7 +267,25 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isLoading = false,
                 hasSearched = false,
                 errorMessage = null,
-                locationNoticeMessage = "현재 위치를 확인하지 못했습니다. 직접 동네나 주소를 검색해 주세요.",
+                locationNotice = MapLocationNotices.CurrentLocationUnavailable,
+                locationNoticeMessage = MapLocationNotices.CurrentLocationUnavailable.message,
+                searchMode = MapSearchMode.KEYWORD,
+            )
+        }
+    }
+
+    fun onLocationServiceDisabled() {
+        originalSpots = emptyList()
+
+        _uiState.update {
+            it.copy(
+                spots = emptyList(),
+                selectedSpot = null,
+                isLoading = false,
+                hasSearched = false,
+                errorMessage = null,
+                locationNotice = MapLocationNotices.LocationServiceDisabled,
+                locationNoticeMessage = MapLocationNotices.LocationServiceDisabled.message,
                 searchMode = MapSearchMode.KEYWORD,
             )
         }
@@ -290,6 +312,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isLoading = false,
                 hasSearched = true,
                 errorMessage = null,
+                locationNotice = null,
                 locationNoticeMessage = null,
             )
         }
@@ -305,6 +328,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isLoading = false,
                 hasSearched = true,
                 errorMessage = message,
+                locationNotice = null,
                 locationNoticeMessage = null,
             )
         }
@@ -321,6 +345,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     hasSearched = true,
                     searchKeyword = "",
                     errorMessage = null,
+                    locationNotice = null,
                     locationNoticeMessage = null,
                     selectedSpot = null,
                     searchMode = MapSearchMode.CURRENT_LOCATION,
@@ -339,6 +364,12 @@ class CollectionSpotMapViewModel @Inject constructor(
             CurrentLocationResult.NotFound -> {
                 if (!preservePreviousResultOnFailure) {
                     onCurrentLocationNotFound()
+                }
+            }
+
+            CurrentLocationResult.LocationServiceDisabled -> {
+                if (!preservePreviousResultOnFailure) {
+                    onLocationServiceDisabled()
                 }
             }
 
@@ -365,6 +396,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isLoading = false,
                 hasSearched = true,
                 errorMessage = null,
+                locationNotice = null,
                 locationNoticeMessage = null,
                 searchMode = MapSearchMode.CURRENT_LOCATION,
             )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/MapLocationNotice.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/MapLocationNotice.kt
@@ -1,0 +1,12 @@
+package com.team.yeogibeoryeo.presentation.map
+
+data class MapLocationNotice(
+    val title: String,
+    val message: String,
+    val action: MapLocationNoticeAction? = null,
+)
+
+enum class MapLocationNoticeAction {
+    OpenAppSettings,
+    OpenLocationSettings,
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/MapLocationNotices.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/MapLocationNotices.kt
@@ -1,0 +1,24 @@
+package com.team.yeogibeoryeo.presentation.map
+
+object MapLocationNotices {
+    const val SpotSearchFailureMessage = "네트워크 연결을 확인한 뒤 다시 시도해 주세요."
+    const val CurrentLocationSpotSearchFailureMessage =
+        "네트워크 연결을 확인한 뒤 다시 시도하거나 직접 동네명/주소를 검색해 주세요."
+
+    val PermissionDenied = MapLocationNotice(
+        title = "위치 권한이 필요합니다.",
+        message = "현재 위치 검색은 정확한 위치 권한을 허용하면 사용할 수 있어요. 직접 동네나 주소를 검색할 수도 있습니다.",
+        action = MapLocationNoticeAction.OpenAppSettings,
+    )
+
+    val LocationServiceDisabled = MapLocationNotice(
+        title = "위치 서비스가 꺼져 있습니다.",
+        message = "기기의 위치 서비스가 꺼져 있어 현재 위치를 확인할 수 없어요. 위치 서비스를 켠 뒤 다시 시도하거나 직접 동네명/주소를 검색해 주세요.",
+        action = MapLocationNoticeAction.OpenLocationSettings,
+    )
+
+    val CurrentLocationUnavailable = MapLocationNotice(
+        title = "현재 위치를 확인하지 못했습니다.",
+        message = "현재 위치를 확인하지 못했습니다. 잠시 후 다시 시도하거나 직접 동네명/주소를 검색해 주세요.",
+    )
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/EmptySpotResult.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/EmptySpotResult.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -18,6 +19,8 @@ fun EmptySpotResult(
     modifier: Modifier = Modifier,
     title: String = "검색 결과가 없습니다.",
     description: String = "다른 동네명이나 주소로 다시 검색해 주세요.",
+    actionLabel: String? = null,
+    onActionClick: (() -> Unit)? = null,
 ) {
     Column(
         modifier = modifier
@@ -38,6 +41,15 @@ fun EmptySpotResult(
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+
+        if (actionLabel != null && onActionClick != null) {
+            TextButton(
+                onClick = onActionClick,
+                modifier = Modifier.padding(top = 12.dp),
+            ) {
+                Text(text = actionLabel)
+            }
+        }
     }
 }
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.presentation.map.MapLocationNotice
+import com.team.yeogibeoryeo.presentation.map.MapLocationNoticeAction
 
 @Composable
 fun SpotBottomSheetContent(
@@ -26,12 +28,18 @@ fun SpotBottomSheetContent(
     isLoading: Boolean,
     hasSearched: Boolean,
     selectedTypes: Set<CollectionSpotType>,
+    locationNotice: MapLocationNotice?,
     locationNoticeMessage: String?,
     errorMessage: String?,
     onTypeClick: (CollectionSpotType) -> Unit,
+    onLocationNoticeActionClick: (MapLocationNoticeAction) -> Unit,
     onSpotClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val hasNoticeOrError = locationNotice != null ||
+        locationNoticeMessage != null ||
+        errorMessage != null
+
     Column(
         modifier = modifier.fillMaxWidth(),
     ) {
@@ -40,7 +48,7 @@ fun SpotBottomSheetContent(
             hasSearched = hasSearched,
         )
 
-        if (hasSearched && !isLoading) {
+        if (hasSearched && !isLoading && !hasNoticeOrError) {
             SpotFilterChipRow(
                 selectedTypes = selectedTypes,
                 onTypeClick = onTypeClick,
@@ -51,6 +59,17 @@ fun SpotBottomSheetContent(
         when {
             isLoading -> {
                 SpotBottomSheetLoading()
+            }
+
+            locationNotice != null -> {
+                EmptySpotResult(
+                    title = locationNotice.title,
+                    description = locationNotice.message,
+                    actionLabel = locationNotice.action?.toActionLabel(),
+                    onActionClick = locationNotice.action?.let { action ->
+                        { onLocationNoticeActionClick(action) }
+                    },
+                )
             }
 
             locationNoticeMessage != null -> {
@@ -167,9 +186,11 @@ private fun SpotBottomSheetContentPreview() {
                 isLoading = false,
                 hasSearched = true,
                 selectedTypes = setOf(CollectionSpotType.BATTERY_BIN),
+                locationNotice = null,
                 locationNoticeMessage = null,
                 errorMessage = null,
                 onTypeClick = {},
+                onLocationNoticeActionClick = {},
                 onSpotClick = {},
             )
         }
@@ -187,9 +208,11 @@ private fun SpotBottomSheetContentLoadingPreview() {
                 isLoading = true,
                 hasSearched = true,
                 selectedTypes = emptySet(),
+                locationNotice = null,
                 locationNoticeMessage = null,
                 errorMessage = null,
                 onTypeClick = {},
+                onLocationNoticeActionClick = {},
                 onSpotClick = {},
             )
         }
@@ -207,9 +230,11 @@ private fun SpotBottomSheetContentEmptyPreview() {
                 isLoading = false,
                 hasSearched = true,
                 selectedTypes = emptySet(),
+                locationNotice = null,
                 locationNoticeMessage = null,
                 errorMessage = null,
                 onTypeClick = {},
+                onLocationNoticeActionClick = {},
                 onSpotClick = {},
             )
         }
@@ -278,3 +303,10 @@ private fun sampleSpotBottomSheetSpots(): List<CollectionSpot> {
 }
 
 private val SpotBottomSheetListMaxHeight = 560.dp
+
+private fun MapLocationNoticeAction.toActionLabel(): String {
+    return when (this) {
+        MapLocationNoticeAction.OpenAppSettings -> "앱 설정 열기"
+        MapLocationNoticeAction.OpenLocationSettings -> "위치 설정 열기"
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/AndroidCurrentLocationProvider.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/AndroidCurrentLocationProvider.kt
@@ -1,8 +1,11 @@
 package com.team.yeogibeoryeo.presentation.map.location
 
 import android.annotation.SuppressLint
+import android.content.Context
+import android.location.LocationManager
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -10,12 +13,17 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 class AndroidCurrentLocationProvider @Inject constructor(
     private val fusedLocationProviderClient: FusedLocationProviderClient,
     private val locationPermissionChecker: LocationPermissionChecker,
+    @ApplicationContext private val context: Context,
 ) : CurrentLocationProvider {
 
     @SuppressLint("MissingPermission")
     override suspend fun getCurrentLocation(): CurrentLocationResult {
         if (!locationPermissionChecker.hasFineLocationPermission()) {
             return CurrentLocationResult.PermissionDenied
+        }
+
+        if (!context.isLocationServiceEnabled()) {
+            return CurrentLocationResult.LocationServiceDisabled
         }
 
         return try {
@@ -49,5 +57,14 @@ class AndroidCurrentLocationProvider @Inject constructor(
         } catch (exception: SecurityException) {
             CurrentLocationResult.PermissionDenied
         }
+    }
+
+    private fun Context.isLocationServiceEnabled(): Boolean {
+        return runCatching {
+            val locationManager = getSystemService(LocationManager::class.java)
+
+            locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER) ||
+                locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
+        }.getOrDefault(true)
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/CurrentLocationProvider.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/location/CurrentLocationProvider.kt
@@ -13,5 +13,7 @@ sealed interface CurrentLocationResult {
 
     data object PermissionDenied : CurrentLocationResult
 
+    data object LocationServiceDisabled : CurrentLocationResult
+
     data object NotFound : CurrentLocationResult
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -50,6 +50,12 @@ class CollectionSpotMapViewModelTest {
                 "현재 위치 검색은 정확한 위치 권한을 허용하면 사용할 수 있어요. 직접 동네나 주소를 검색할 수도 있습니다.",
                 viewModel.uiState.value.locationNoticeMessage,
             )
+            assertEquals("위치 권한이 필요합니다.", viewModel.uiState.value.locationNotice?.title)
+            assertEquals(
+                viewModel.uiState.value.locationNotice?.message,
+                viewModel.uiState.value.locationNoticeMessage,
+            )
+            assertEquals(MapLocationNoticeAction.OpenAppSettings, viewModel.uiState.value.locationNotice?.action)
         }
 
     @Test
@@ -68,9 +74,42 @@ class CollectionSpotMapViewModelTest {
             assertFalse(viewModel.uiState.value.isLoading)
             assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
             assertEquals(
-                "현재 위치를 확인하지 못했습니다. 직접 동네나 주소를 검색해 주세요.",
+                "현재 위치를 확인하지 못했습니다. 잠시 후 다시 시도하거나 직접 동네명/주소를 검색해 주세요.",
                 viewModel.uiState.value.locationNoticeMessage,
             )
+            assertEquals("현재 위치를 확인하지 못했습니다.", viewModel.uiState.value.locationNotice?.title)
+            assertEquals(
+                viewModel.uiState.value.locationNotice?.message,
+                viewModel.uiState.value.locationNoticeMessage,
+            )
+            assertNull(viewModel.uiState.value.locationNotice?.action)
+        }
+
+    @Test
+    fun `위치 서비스가 꺼져 있으면 위치 설정 안내를 표시한다`() =
+        runTest {
+            val repository = FakeCollectionSpotRepository()
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.LocationServiceDisabled,
+            )
+
+            viewModel.searchByCurrentLocation()
+
+            assertEquals(0, repository.locationSearchCallCount)
+            assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
+            assertEquals(
+                "기기의 위치 서비스가 꺼져 있어 현재 위치를 확인할 수 없어요. 위치 서비스를 켠 뒤 다시 시도하거나 직접 동네명/주소를 검색해 주세요.",
+                viewModel.uiState.value.locationNoticeMessage,
+            )
+            assertEquals("위치 서비스가 꺼져 있습니다.", viewModel.uiState.value.locationNotice?.title)
+            assertEquals(
+                viewModel.uiState.value.locationNotice?.message,
+                viewModel.uiState.value.locationNoticeMessage,
+            )
+            assertEquals(MapLocationNoticeAction.OpenLocationSettings, viewModel.uiState.value.locationNotice?.action)
         }
 
     @Test
@@ -95,6 +134,58 @@ class CollectionSpotMapViewModelTest {
             assertNull(viewModel.uiState.value.locationNoticeMessage)
             assertNull(viewModel.uiState.value.errorMessage)
             assertFalse(viewModel.uiState.value.isLoading)
+        }
+
+    @Test
+    fun `현재 위치 주변 수거 장소 검색 실패 시 errorMessage를 표시하고 notice는 설정하지 않는다`() =
+        runTest {
+            val repository = FakeCollectionSpotRepository(
+                locationSearchThrowable = IllegalStateException(
+                    "Unable to resolve host \"apis.data.go.kr\": No address associated with hostname",
+                ),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+            )
+
+            viewModel.searchByCurrentLocation()
+
+            assertEquals(1, repository.locationSearchCallCount)
+            assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertEquals(
+                "네트워크 연결을 확인한 뒤 다시 시도하거나 직접 동네명/주소를 검색해 주세요.",
+                viewModel.uiState.value.errorMessage,
+            )
+            assertNull(viewModel.uiState.value.locationNotice)
+            assertNull(viewModel.uiState.value.locationNoticeMessage)
+        }
+
+    @Test
+    fun `키워드 검색 실패 시 원문 예외 대신 안내 문구를 표시한다`() =
+        runTest {
+            val repository = FakeCollectionSpotRepository(
+                keywordSearchThrowable = IllegalStateException(
+                    "Unable to resolve host \"apis.data.go.kr\": No address associated with hostname",
+                ),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.onSearchKeywordChanged("용답동")
+            viewModel.searchByKeyword()
+
+            assertEquals(listOf("용답동"), repository.keywords)
+            assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertEquals("네트워크 연결을 확인한 뒤 다시 시도해 주세요.", viewModel.uiState.value.errorMessage)
+            assertNull(viewModel.uiState.value.locationNotice)
+            assertNull(viewModel.uiState.value.locationNoticeMessage)
         }
 
     @Test
@@ -188,7 +279,44 @@ class CollectionSpotMapViewModelTest {
             assertEquals(listOf("문래동"), repository.keywords)
             assertEquals(listOf(expectedSpot), viewModel.uiState.value.spots)
             assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
+            assertNull(viewModel.uiState.value.locationNotice)
             assertNull(viewModel.uiState.value.locationNoticeMessage)
+            assertNull(viewModel.uiState.value.errorMessage)
+        }
+
+    @Test
+    fun `현재 위치 검색 실패 안내 후 재시도하면 이전 notice를 새 실패 상태로 갱신한다`() =
+        runTest {
+            val firstResult = CompletableDeferred<CurrentLocationResult>()
+            val secondResult = CompletableDeferred<CurrentLocationResult>()
+            var requestCount = 0
+            val repository = FakeCollectionSpotRepository()
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationProvider = FakeCurrentLocationProvider {
+                    requestCount += 1
+                    if (requestCount == 1) {
+                        firstResult.await()
+                    } else {
+                        secondResult.await()
+                    }
+                },
+            )
+
+            viewModel.searchByCurrentLocation()
+            firstResult.complete(CurrentLocationResult.NotFound)
+            advanceUntilIdle()
+            viewModel.searchByCurrentLocation()
+            secondResult.complete(CurrentLocationResult.LocationServiceDisabled)
+            advanceUntilIdle()
+
+            assertEquals("위치 서비스가 꺼져 있습니다.", viewModel.uiState.value.locationNotice?.title)
+            assertEquals(MapLocationNoticeAction.OpenLocationSettings, viewModel.uiState.value.locationNotice?.action)
+            assertEquals(
+                viewModel.uiState.value.locationNotice?.message,
+                viewModel.uiState.value.locationNoticeMessage,
+            )
+            assertNull(viewModel.uiState.value.errorMessage)
         }
 
     @Test
@@ -490,6 +618,7 @@ class CollectionSpotMapViewModelTest {
             assertEquals(listOf(cachedSpot), viewModel.uiState.value.spots)
             assertEquals(MapSearchMode.CURRENT_LOCATION, viewModel.uiState.value.searchMode)
             assertFalse(viewModel.uiState.value.isLoading)
+            assertNull(viewModel.uiState.value.locationNotice)
             assertNull(viewModel.uiState.value.locationNoticeMessage)
             assertNull(viewModel.uiState.value.errorMessage)
             assertEquals(0, repository.locationSearchCallCount)
@@ -569,6 +698,8 @@ class CollectionSpotMapViewModelTest {
             assertEquals(0, cache.getCallCount)
             assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
             assertFalse(viewModel.uiState.value.hasSearched)
+            assertNull(viewModel.uiState.value.locationNotice)
+            assertNull(viewModel.uiState.value.locationNoticeMessage)
             assertEquals(0, repository.locationSearchCallCount)
         }
 
@@ -766,6 +897,8 @@ class CollectionSpotMapViewModelTest {
     private class FakeCollectionSpotRepository(
         private val keywordSpots: List<CollectionSpot> = emptyList(),
         private val locationSpots: List<CollectionSpot> = emptyList(),
+        private val keywordSearchThrowable: Throwable? = null,
+        private val locationSearchThrowable: Throwable? = null,
     ) : CollectionSpotRepository {
         val keywords = mutableListOf<String>()
         var locationSearchCallCount = 0
@@ -777,6 +910,7 @@ class CollectionSpotMapViewModelTest {
             types: Set<CollectionSpotType>,
         ): List<CollectionSpot> {
             keywords += keyword
+            keywordSearchThrowable?.let { throw it }
             return keywordSpots
         }
 
@@ -788,6 +922,7 @@ class CollectionSpotMapViewModelTest {
             locationSearchCallCount += 1
             lastLocationCoordinate = coordinate
             lastRadiusMeter = radiusMeter
+            locationSearchThrowable?.let { throw it }
             return locationSpots
         }
 


### PR DESCRIPTION
## 작업 내용

Refs #95

Map 화면에서 현재 위치 검색 실패 상황을 원인별로 구분해 사용자 안내를 개선했습니다.

| 구분 | 내용 |
| --- | --- |
| 위치 권한 없음 | 위치 권한이 없는 경우 안내 메시지와 앱 설정 이동 액션을 표시 |
| 위치 서비스 꺼짐 | 기기 위치 서비스가 꺼진 경우 별도 안내 상태 추가 |
| 일시적 위치 조회 실패 | 권한은 있지만 현재 위치를 가져오지 못한 경우 재시도/직접 검색 안내 표시 |
| 네트워크/API 실패 | 원문 예외 메시지 대신 사용자 친화적인 안내 문구 표시 |
| UI 개선 | 실패/안내 상태에서는 필터칩을 숨겨 안내 문구가 바로 보이도록 조정 |

## 주요 변경 사항

| 파일/영역 | 변경 내용 |
| --- | --- |
| `CurrentLocationResult` | `LocationServiceDisabled` 실패 상태 추가 |
| `AndroidCurrentLocationProvider` | 위치 서비스 꺼짐 상태 감지 |
| `MapLocationNotice` | 실패 안내 `title` / `message` / `action` 구조화 |
| `MapLocationNotices` | 안내 문구와 액션 정책 분리 |
| `CollectionSpotMapViewModel` | 실패 원인별 notice/error 상태 설정 |
| `SpotBottomSheetContent` | notice 우선 표시 및 action button 연결 |
| `CollectionSpotMapScreen` | 앱 설정 / 위치 설정 이동 Intent 처리 |
| `CollectionSpotMapViewModelTest` | 실패 상태별 ViewModel 테스트 보강 |

## 검증

| 항목 | 결과 |
| --- | --- |
| 위치 권한 없음 상태에서 `내 주변 검색` 클릭 시 Android 권한 팝업 표시 | 확인 |
| 권한 거부 후 다시 `내 주변 검색` 클릭 시 앱 설정 안내 표시 | 확인 |
| 네트워크 OFF 상태에서 현재 위치 주변 검색 실패 안내 표시 | 확인 |
| 네트워크/API 실패 시 원문 예외 대신 안내 문구 표시 | 확인 |
| 기존 키워드 검색 동작 | 확인 |
| 기존 필터칩 / 마커 / BottomSheet 동작 | 확인 |
| 캐시 결과 표시 후 silent refresh 실패 시 캐시 유지 | 확인 |

## 테스트

```bash
./gradlew.bat :presentation:compileDebugKotlin
./gradlew.bat :presentation:testDebugUnitTest --tests com.team.yeogibeoryeo.presentation.map.CollectionSpotMapViewModelTest
```
## 스크린샷

| 위치 권한 거부 후 안내 | 네트워크/API 실패 안내 | Android 위치 권한 요청 팝업 |
| --- | --- | --- |
| <img width="280" alt="위치 권한이 필요합니다 안내" src="https://github.com/user-attachments/assets/2969cd70-d168-4ac9-9d2f-4a2eed545570" /> | <img width="280" alt="네트워크 연결 안내" src="https://github.com/user-attachments/assets/8fc80107-492a-49cb-b688-2c68cb3188f8" /> | <img width="280" alt="Android 위치 권한 요청 팝업" src="https://github.com/user-attachments/assets/165674df-05bd-4901-b329-d3cb9801e0d7" /> |

## 참고

- 이번 작업은 현재 위치 검색 실패 상태별 안내 UX 개선에 집중했습니다.
- `/getSpot` 원격 검색 로직은 변경하지 않았습니다.
- `CurrentLocationProvider` 구조는 대규모로 변경하지 않고, 위치 서비스 꺼짐 감지만 최소 추가했습니다.
- `NaverMap overlay` / `locationTrackingMode` 관련 코드는 변경하지 않았습니다.
- 최근 현재 위치 검색 결과 캐시 구조는 변경하지 않았습니다.
