### PR TITLE
feat: 지역명 직접 검색 다중 후보 선택 UX 구현

### DIFF
--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCase.kt
@@ -25,9 +25,11 @@ class ResolveRegionFromKeywordUseCase @Inject constructor(
 
         return when {
             candidates.size == 1 -> ResolveRegionFromKeywordResult.Resolved(candidates.first())
-            candidates.size > 1 -> ResolveRegionFromKeywordResult.Ambiguous
-            parsedRegion != null -> ResolveRegionFromKeywordResult.Resolved(parsedRegion)
-            else -> ResolveRegionFromKeywordResult.NotFound
+            candidates.size > 1 -> ResolveRegionFromKeywordResult.Ambiguous(candidates)
+            else -> resolveSigunguKeyword(
+                keyword = keyword,
+                fallbackRegion = parsedRegion
+            )
         }
     }
 
@@ -39,8 +41,22 @@ class ResolveRegionFromKeywordUseCase @Inject constructor(
 
         return when {
             candidates.size == 1 -> ResolveRegionFromKeywordResult.Resolved(candidates.first())
-            candidates.hasExactSigunguMatch(sigungu) -> ResolveRegionFromKeywordResult.Ambiguous
+            candidates.hasExactSigunguMatch(sigungu) -> ResolveRegionFromKeywordResult.Ambiguous(candidates)
             else -> ResolveRegionFromKeywordResult.Resolved(parsedRegion)
+        }
+    }
+
+    private suspend fun resolveSigunguKeyword(
+        keyword: String,
+        fallbackRegion: Region? = null
+    ): ResolveRegionFromKeywordResult {
+        val candidates = regionOptionsRepository.findRegionsBySigunguKeyword(keyword)
+
+        return when {
+            candidates.size == 1 -> ResolveRegionFromKeywordResult.Resolved(candidates.first())
+            candidates.size > 1 -> ResolveRegionFromKeywordResult.Ambiguous(candidates)
+            fallbackRegion != null -> ResolveRegionFromKeywordResult.Resolved(fallbackRegion)
+            else -> ResolveRegionFromKeywordResult.NotFound
         }
     }
 
@@ -63,7 +79,9 @@ sealed interface ResolveRegionFromKeywordResult {
         val region: Region
     ) : ResolveRegionFromKeywordResult
 
-    data object Ambiguous : ResolveRegionFromKeywordResult
+    data class Ambiguous(
+        val candidates: List<Region>
+    ) : ResolveRegionFromKeywordResult
 
     data object NotFound : ResolveRegionFromKeywordResult
 }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCase.kt
@@ -21,15 +21,25 @@ class ResolveRegionFromKeywordUseCase @Inject constructor(
         }
 
         val eupmyeondongKeyword = parsedRegion?.eupmyeondong ?: keyword
-        val candidates = regionOptionsRepository.findRegionsByEupmyeondongKeyword(eupmyeondongKeyword)
+        val eupmyeondongCandidates = regionOptionsRepository.findRegionsByEupmyeondongKeyword(
+            eupmyeondongKeyword
+        )
+        val sigunguCandidates = regionOptionsRepository.findRegionsBySigunguKeyword(keyword)
+        val candidates = (sigunguCandidates + eupmyeondongCandidates)
+            .distinctBy { region ->
+                listOf(
+                    region.sido.orEmpty(),
+                    region.sigungu.orEmpty(),
+                    region.eupmyeondong.orEmpty()
+                )
+            }
+            .sortedWith(REGION_CANDIDATE_COMPARATOR)
 
         return when {
             candidates.size == 1 -> ResolveRegionFromKeywordResult.Resolved(candidates.first())
             candidates.size > 1 -> ResolveRegionFromKeywordResult.Ambiguous(candidates)
-            else -> resolveSigunguKeyword(
-                keyword = keyword,
-                fallbackRegion = parsedRegion
-            )
+            parsedRegion != null -> ResolveRegionFromKeywordResult.Resolved(parsedRegion)
+            else -> ResolveRegionFromKeywordResult.NotFound
         }
     }
 
@@ -46,20 +56,6 @@ class ResolveRegionFromKeywordUseCase @Inject constructor(
         }
     }
 
-    private suspend fun resolveSigunguKeyword(
-        keyword: String,
-        fallbackRegion: Region? = null
-    ): ResolveRegionFromKeywordResult {
-        val candidates = regionOptionsRepository.findRegionsBySigunguKeyword(keyword)
-
-        return when {
-            candidates.size == 1 -> ResolveRegionFromKeywordResult.Resolved(candidates.first())
-            candidates.size > 1 -> ResolveRegionFromKeywordResult.Ambiguous(candidates)
-            fallbackRegion != null -> ResolveRegionFromKeywordResult.Resolved(fallbackRegion)
-            else -> ResolveRegionFromKeywordResult.NotFound
-        }
-    }
-
     private fun List<Region>.hasExactSigunguMatch(
         sigungu: String
     ): Boolean =
@@ -72,6 +68,14 @@ class ResolveRegionFromKeywordUseCase @Inject constructor(
         sido.isNullOrBlank() &&
             !sigungu.isNullOrBlank() &&
             eupmyeondong.isNullOrBlank()
+
+    private companion object {
+        val REGION_CANDIDATE_COMPARATOR = compareBy<Region>(
+            { region -> region.sido.orEmpty() },
+            { region -> region.sigungu.orEmpty() },
+            { region -> region.eupmyeondong.orEmpty() }
+        )
+    }
 }
 
 sealed interface ResolveRegionFromKeywordResult {

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalGuideLookupResult.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalGuideLookupResult.kt
@@ -5,6 +5,10 @@ sealed interface RegionalGuideLookupResult {
         val guide: RegionalDisposalGuide
     ) : RegionalGuideLookupResult
 
+    data class Candidates(
+        val guides: List<RegionalDisposalGuide>
+    ) : RegionalGuideLookupResult
+
     data object NotFound : RegionalGuideLookupResult
 
     data object CandidateNotFound : RegionalGuideLookupResult

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
@@ -32,7 +32,7 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
             candidates = filteredCandidates,
             requestedRegion = query.displayRegion,
             sigunguQuery = query.sigunguQuery
-        ) ?: return RegionalGuideLookupResult.CandidateNotFound
+        ) ?: return filteredCandidates.toCandidateResultOrNotFound(query.displayRegion)
 
         return RegionalGuideLookupResult.Success(
             guide = selectedGuide.withDisplayRegion(query.displayRegion)
@@ -64,9 +64,7 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
 
         if (!eupmyeondong.isNullOrBlank()) {
             return candidates.firstOrNull { guide ->
-                guide.targetRegionName?.trim() == eupmyeondong
-            } ?: candidates.firstOrNull { guide ->
-                guide.targetRegionName?.contains(eupmyeondong) == true
+                guide.targetRegionName.matchesEupmyeondong(eupmyeondong)
             } ?: candidates.firstOrNull { guide ->
                 guide.targetRegionName.isSejongDongArea() &&
                     eupmyeondong in SEJONG_DONG_AREA_NAMES
@@ -77,6 +75,41 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
 
         return null
     }
+
+    private fun List<RegionalDisposalGuide>.toCandidateResultOrNotFound(
+        displayRegion: Region
+    ): RegionalGuideLookupResult {
+        if (!displayRegion.eupmyeondong.isNullOrBlank() || size <= 1) {
+            return RegionalGuideLookupResult.CandidateNotFound
+        }
+
+        return RegionalGuideLookupResult.Candidates(
+            guides = map { guide -> guide.withDisplayRegion(displayRegion) }
+        )
+    }
+
+    private fun String?.matchesEupmyeondong(
+        eupmyeondong: String
+    ): Boolean {
+        val targetRegionName = this?.trim().orEmpty()
+        if (targetRegionName.isBlank()) return false
+
+        if (targetRegionName == eupmyeondong || targetRegionName.contains(eupmyeondong)) {
+            return true
+        }
+
+        val normalizedEupmyeondong = eupmyeondong.removeAdministrativeSuffix()
+
+        return targetRegionName
+            .split(TARGET_REGION_DELIMITER)
+            .map { token -> token.trim().removeAdministrativeSuffix() }
+            .any { token -> token == normalizedEupmyeondong }
+    }
+
+    private fun String.removeAdministrativeSuffix(): String =
+        removeSuffix(EUP)
+            .removeSuffix(MYEON)
+            .removeSuffix(DONG)
 
     private fun RegionalDisposalGuide.withDisplayRegion(
         displayRegion: Region
@@ -115,6 +148,11 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
         const val OVERALL_ALL = "전체"
         const val OVERALL_WHOLE_AREA = "전역"
         const val OVERALL_WITHIN_REGION = "관내"
+        const val EUP = "읍"
+        const val MYEON = "면"
+        const val DONG = "동"
+
+        val TARGET_REGION_DELIMITER = Regex("[,+/\\s]+")
 
         val SEJONG_DONG_AREA_NAMES = setOf(
             "한솔동",

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.team.yeogibeoryeo.domain.region.repository.RegionOptionsRepository
 import com.team.yeogibeoryeo.domain.region.repository.RegionRepository
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ResolveRegionFromKeywordUseCaseTest {
@@ -85,7 +86,8 @@ class ResolveRegionFromKeywordUseCaseTest {
 
         val result = useCase("중앙동")
 
-        assertEquals(ResolveRegionFromKeywordResult.Ambiguous, result)
+        assertTrue(result is ResolveRegionFromKeywordResult.Ambiguous)
+        assertEquals(2, (result as ResolveRegionFromKeywordResult.Ambiguous).candidates.size)
     }
 
     @Test
@@ -112,7 +114,8 @@ class ResolveRegionFromKeywordUseCaseTest {
 
         val result = useCase("온양")
 
-        assertEquals(ResolveRegionFromKeywordResult.Ambiguous, result)
+        assertTrue(result is ResolveRegionFromKeywordResult.Ambiguous)
+        assertEquals(2, (result as ResolveRegionFromKeywordResult.Ambiguous).candidates.size)
     }
 
     @Test
@@ -210,7 +213,70 @@ class ResolveRegionFromKeywordUseCaseTest {
 
         val result = useCase("중구")
 
-        assertEquals(ResolveRegionFromKeywordResult.Ambiguous, result)
+        assertTrue(result is ResolveRegionFromKeywordResult.Ambiguous)
+        assertEquals(2, (result as ResolveRegionFromKeywordResult.Ambiguous).candidates.size)
+    }
+
+    @Test
+    fun `접미사 없는 시군구 검색어가 유일하면 상위 지역을 보완하고 읍면동은 비워둔다`() = runBlocking {
+        val useCase = ResolveRegionFromKeywordUseCase(
+            repository = FakeRegionRepository(
+                resolvedRegion = null
+            ),
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                regions = listOf(
+                    Region(
+                        sido = "울산광역시",
+                        sigungu = "울주군",
+                        eupmyeondong = "온양읍"
+                    ),
+                    Region(
+                        sido = "울산광역시",
+                        sigungu = "울주군",
+                        eupmyeondong = "언양읍"
+                    )
+                )
+            )
+        )
+
+        val result = useCase("울주")
+
+        val region = (result as ResolveRegionFromKeywordResult.Resolved).region
+
+        assertEquals("울산광역시", region.sido)
+        assertEquals("울주군", region.sigungu)
+        assertEquals(null, region.eupmyeondong)
+    }
+
+    @Test
+    fun `부분 지역으로 파싱됐더라도 시군구 후보가 유일하면 시군구로 보완한다`() = runBlocking {
+        val useCase = ResolveRegionFromKeywordUseCase(
+            repository = FakeRegionRepository(
+                resolvedRegion = Region(eupmyeondong = "울주")
+            ),
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                regions = listOf(
+                    Region(
+                        sido = "울산광역시",
+                        sigungu = "울주군",
+                        eupmyeondong = "온양읍"
+                    ),
+                    Region(
+                        sido = "울산광역시",
+                        sigungu = "울주군",
+                        eupmyeondong = "언양읍"
+                    )
+                )
+            )
+        )
+
+        val result = useCase("울주")
+
+        val region = (result as ResolveRegionFromKeywordResult.Resolved).region
+
+        assertEquals("울산광역시", region.sido)
+        assertEquals("울주군", region.sigungu)
+        assertEquals(null, region.eupmyeondong)
     }
 
     private class FakeRegionRepository(
@@ -275,6 +341,15 @@ class ResolveRegionFromKeywordUseCaseTest {
                     region.sigungu.orEmpty()
                 )
             }
+                .map { region ->
+                    region.copy(eupmyeondong = null)
+                }
+                .distinctBy { region ->
+                    listOf(
+                        region.sido.orEmpty(),
+                        region.sigungu.orEmpty()
+                    )
+                }
         }
     }
 }

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCaseTest.kt
@@ -119,6 +119,51 @@ class ResolveRegionFromKeywordUseCaseTest {
     }
 
     @Test
+    fun `검색어가 시군구와 읍면동 후보에 모두 포함되면 함께 후보로 반환한다`() = runBlocking {
+        val useCase = ResolveRegionFromKeywordUseCase(
+            repository = FakeRegionRepository(
+                resolvedRegion = null
+            ),
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                regions = listOf(
+                    Region(
+                        sido = "경기도",
+                        sigungu = "수원시 장안구",
+                        eupmyeondong = "파장동"
+                    ),
+                    Region(
+                        sido = "부산광역시",
+                        sigungu = "기장군",
+                        eupmyeondong = "장안읍"
+                    )
+                )
+            )
+        )
+
+        val result = useCase("장안")
+
+        val candidates = (result as ResolveRegionFromKeywordResult.Ambiguous).candidates
+
+        assertEquals(2, candidates.size)
+        assertEquals(
+            Region(
+                sido = "경기도",
+                sigungu = "수원시 장안구",
+                eupmyeondong = null
+            ),
+            candidates[0]
+        )
+        assertEquals(
+            Region(
+                sido = "부산광역시",
+                sigungu = "기장군",
+                eupmyeondong = "장안읍"
+            ),
+            candidates[1]
+        )
+    }
+
+    @Test
     fun `검색어로 해석할 지역이 없으면 NotFound를 반환한다`() = runBlocking {
         val useCase = ResolveRegionFromKeywordUseCase(
             repository = FakeRegionRepository(

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
@@ -1,4 +1,4 @@
-package com.team.yeogibeoryeo.domain.regionalguide.usecase
+﻿package com.team.yeogibeoryeo.domain.regionalguide.usecase
 
 import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
@@ -173,7 +173,41 @@ class SelectRegionalGuideCandidateUseCaseTest {
     }
 
     @Test
-    fun `읍면동 없이 복수 후보가 있으면 전체 적용 후보가 있어도 임의 선택하지 않는다`() {
+    fun `읍면동 접미사가 없는 대상지역 토큰도 선택 읍면동과 매칭한다`() {
+        val result = useCase(
+            candidates = listOf(
+                guide(
+                    sido = "울산광역시",
+                    sigungu = "울주군",
+                    targetRegionName = "범서, 온양, 웅촌, 언양, 삼남, 상북, 온산, 청량, 서생"
+                ),
+                guide(
+                    sido = "울산광역시",
+                    sigungu = "울주군",
+                    targetRegionName = "두동, 두서, 삼동"
+                )
+            ),
+            query = query(
+                displayRegion = Region(
+                    sido = "울산광역시",
+                    sigungu = "울주군",
+                    eupmyeondong = "온양읍"
+                ),
+                sigunguQuery = "울주군"
+            )
+        )
+
+        val guide = (result as RegionalGuideLookupResult.Success).guide
+
+        assertEquals("온양읍", guide.region.eupmyeondong)
+        assertEquals(
+            "범서, 온양, 웅촌, 언양, 삼남, 상북, 온산, 청량, 서생",
+            guide.targetRegionName
+        )
+    }
+
+    @Test
+    fun `읍면동 없이 복수 후보가 있으면 전체 적용 후보가 있어도 후보 목록을 반환한다`() {
         val result = useCase(
             candidates = listOf(
                 guide(sido = "경기도", sigungu = "수원시", targetRegionName = "수원시 전체"),
@@ -185,7 +219,11 @@ class SelectRegionalGuideCandidateUseCaseTest {
             )
         )
 
-        assertEquals(RegionalGuideLookupResult.CandidateNotFound, result)
+        val candidates = (result as RegionalGuideLookupResult.Candidates).guides
+
+        assertEquals(2, candidates.size)
+        assertEquals("수원시 전체", candidates[0].targetRegionName)
+        assertEquals("일부 권역", candidates[1].targetRegionName)
     }
 
     @Test
@@ -204,7 +242,7 @@ class SelectRegionalGuideCandidateUseCaseTest {
     }
 
     @Test
-    fun `읍면동 없이 복수 권역 후보만 있으면 임의 선택하지 않는다`() {
+    fun `읍면동 없이 복수 권역 후보만 있으면 후보 목록을 반환한다`() {
         val result = useCase(
             candidates = listOf(
                 guide(sido = "인천광역시", sigungu = "중구", targetRegionName = "신흥동+율목동"),
@@ -216,7 +254,11 @@ class SelectRegionalGuideCandidateUseCaseTest {
             )
         )
 
-        assertEquals(RegionalGuideLookupResult.CandidateNotFound, result)
+        val candidates = (result as RegionalGuideLookupResult.Candidates).guides
+
+        assertEquals(2, candidates.size)
+        assertEquals("신흥동+율목동", candidates[0].targetRegionName)
+        assertEquals("신포동+연안동", candidates[1].targetRegionName)
     }
 
     @Test

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
@@ -1,4 +1,4 @@
-﻿package com.team.yeogibeoryeo.presentation.regionalguide
+package com.team.yeogibeoryeo.presentation.regionalguide
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -33,12 +33,15 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionSelectorSection
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideAmbiguousResult
+import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideCandidateResult
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideEmptyResult
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideSearchBar
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideSummaryCard
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalWasteScheduleCard
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideCandidateUiModel
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalWasteScheduleUiModel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionSearchCandidateUiModel
 
 @Composable
 fun RegionalGuideRoute(
@@ -72,6 +75,8 @@ fun RegionalGuideRoute(
         onSigunguSelected = viewModel::onSigunguSelected,
         onEupmyeondongSelected = viewModel::onEupmyeondongSelected,
         onRegionSelectionSearchClick = viewModel::onRegionSelectionSearchClick,
+        onCandidateClick = viewModel::onRegionCandidateSelected,
+        onGuideCandidateClick = viewModel::onRegionalGuideCandidateSelected,
         modifier = modifier,
     )
 }
@@ -88,12 +93,24 @@ fun RegionalGuideScreen(
     onSigunguSelected: (String) -> Unit,
     onEupmyeondongSelected: (String) -> Unit,
     onRegionSelectionSearchClick: () -> Unit,
+    onCandidateClick: (RegionSearchCandidateUiModel) -> Unit,
+    onGuideCandidateClick: (RegionalGuideCandidateUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var isRegionSelectorExpanded by rememberSaveable { mutableStateOf(false) }
-    val compactRegionText = uiState.queryOrNull()
+    val ambiguousState = uiState as? RegionalGuideUiState.Ambiguous
+    val guideCandidatesState = uiState as? RegionalGuideUiState.GuideCandidates
+    val hasSearchCandidates = ambiguousState != null || guideCandidatesState != null
+    val compactRegionText = when (uiState) {
+        is RegionalGuideUiState.Success ->
+            regionSelectorUiState.selectedRegionText ?: uiState.query
+
+        else -> uiState.queryOrNull()
+    }
     val isRegionSelectorCompact =
         uiState !is RegionalGuideUiState.Idle &&
+            uiState !is RegionalGuideUiState.Ambiguous &&
+            uiState !is RegionalGuideUiState.GuideCandidates &&
             !isRegionSelectorExpanded &&
             compactRegionText != null
 
@@ -129,6 +146,25 @@ fun RegionalGuideScreen(
                 keyword = searchKeyword,
                 onKeywordChange = onSearchKeywordChange,
                 onSearchClick = onSearchClick,
+                candidateContent = if (hasSearchCandidates) {
+                    {
+                        if (ambiguousState != null) {
+                            RegionalGuideAmbiguousResult(
+                                candidates = ambiguousState.candidates,
+                                onCandidateClick = onCandidateClick,
+                            )
+                        }
+
+                        if (guideCandidatesState != null) {
+                            RegionalGuideCandidateResult(
+                                candidates = guideCandidatesState.candidates,
+                                onCandidateClick = onGuideCandidateClick,
+                            )
+                        }
+                    }
+                } else {
+                    null
+                },
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -155,6 +191,8 @@ fun RegionalGuideScreen(
         RegionalGuideContent(
             uiState = uiState,
             onRetryClick = onRetryClick,
+            onCandidateClick = onCandidateClick,
+            onGuideCandidateClick = onGuideCandidateClick,
             modifier = Modifier
                 .weight(1f)
                 .padding(horizontal = 20.dp),
@@ -169,6 +207,7 @@ private fun RegionalGuideUiState.queryOrNull(): String? =
         is RegionalGuideUiState.Success -> query
         is RegionalGuideUiState.Empty -> query
         is RegionalGuideUiState.Ambiguous -> query
+        is RegionalGuideUiState.GuideCandidates -> query
         is RegionalGuideUiState.Error -> query
     }?.takeIf { query -> query.isNotBlank() }
 
@@ -176,6 +215,8 @@ private fun RegionalGuideUiState.queryOrNull(): String? =
 private fun RegionalGuideContent(
     uiState: RegionalGuideUiState,
     onRetryClick: () -> Unit,
+    onCandidateClick: (RegionSearchCandidateUiModel) -> Unit,
+    onGuideCandidateClick: (RegionalGuideCandidateUiModel) -> Unit,
     modifier: Modifier = Modifier
 ) {
     when (uiState) {
@@ -205,10 +246,11 @@ private fun RegionalGuideContent(
         }
 
         is RegionalGuideUiState.Ambiguous -> {
-            RegionalGuideAmbiguousResult(
-                message = uiState.message,
-                modifier = modifier
-            )
+            Spacer(modifier = modifier)
+        }
+
+        is RegionalGuideUiState.GuideCandidates -> {
+            Spacer(modifier = modifier)
         }
 
         is RegionalGuideUiState.Error -> {
@@ -333,6 +375,8 @@ private fun RegionalGuideScreenIdlePreview() {
             onSigunguSelected = {},
             onEupmyeondongSelected = {},
             onRegionSelectionSearchClick = {},
+            onCandidateClick = {},
+            onGuideCandidateClick = {},
         )
     }
 }
@@ -356,6 +400,8 @@ private fun RegionalGuideScreenLoadingPreview() {
             onSigunguSelected = {},
             onEupmyeondongSelected = {},
             onRegionSelectionSearchClick = {},
+            onCandidateClick = {},
+            onGuideCandidateClick = {},
         )
     }
 }
@@ -413,6 +459,8 @@ private fun RegionalGuideScreenSuccessPreview() {
             onSigunguSelected = {},
             onEupmyeondongSelected = {},
             onRegionSelectionSearchClick = {},
+            onCandidateClick = {},
+            onGuideCandidateClick = {},
         )
     }
 }
@@ -437,6 +485,8 @@ private fun RegionalGuideScreenEmptyPreview() {
             onSigunguSelected = {},
             onEupmyeondongSelected = {},
             onRegionSelectionSearchClick = {},
+            onCandidateClick = {},
+            onGuideCandidateClick = {},
         )
     }
 }
@@ -448,7 +498,19 @@ private fun RegionalGuideScreenAmbiguousPreview() {
         RegionalGuideScreen(
             uiState = RegionalGuideUiState.Ambiguous(
                 query = "신흥동",
-                message = "여러 지역이 검색됩니다. 시도나 시군구를 함께 입력해주세요."
+                message = "여러 지역이 검색됩니다. 원하는 지역을 선택해주세요.",
+                candidates = listOf(
+                    RegionSearchCandidateUiModel(
+                        sido = "인천광역시",
+                        sigungu = "중구",
+                        eupmyeondong = "신흥동",
+                    ),
+                    RegionSearchCandidateUiModel(
+                        sido = "대전광역시",
+                        sigungu = "동구",
+                        eupmyeondong = "신흥동",
+                    ),
+                )
             ),
             searchKeyword = "신흥동",
             regionSelectorUiState = RegionSelectorUiState(
@@ -461,6 +523,54 @@ private fun RegionalGuideScreenAmbiguousPreview() {
             onSigunguSelected = {},
             onEupmyeondongSelected = {},
             onRegionSelectionSearchClick = {},
+            onCandidateClick = {},
+            onGuideCandidateClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RegionalGuideScreenGuideCandidatesPreview() {
+    MaterialTheme {
+        RegionalGuideScreen(
+            uiState = RegionalGuideUiState.GuideCandidates(
+                query = "울주군",
+                message = "여러 배출 권역이 검색됩니다. 해당하는 권역을 선택해주세요.",
+                candidates = listOf(
+                    RegionalGuideCandidateUiModel(
+                        guide = previewRegionalGuide(
+                            regionName = "울산광역시 울주군",
+                            targetRegionName = "범서, 온양, 웅촌, 언양, 삼남, 상북, 온산, 청량, 서생"
+                        ),
+                        sido = "울산광역시",
+                        sigungu = "울주군",
+                        eupmyeondong = null
+                    ),
+                    RegionalGuideCandidateUiModel(
+                        guide = previewRegionalGuide(
+                            regionName = "울산광역시 울주군",
+                            targetRegionName = "두동, 두서, 삼동"
+                        ),
+                        sido = "울산광역시",
+                        sigungu = "울주군",
+                        eupmyeondong = null
+                    ),
+                )
+            ),
+            searchKeyword = "울주군",
+            regionSelectorUiState = RegionSelectorUiState(
+                sidoOptions = listOf("서울특별시", "울산광역시", "경기도"),
+            ),
+            onSearchKeywordChange = {},
+            onSearchClick = {},
+            onRetryClick = {},
+            onSidoSelected = {},
+            onSigunguSelected = {},
+            onEupmyeondongSelected = {},
+            onRegionSelectionSearchClick = {},
+            onCandidateClick = {},
+            onGuideCandidateClick = {},
         )
     }
 }
@@ -485,6 +595,23 @@ private fun RegionalGuideScreenErrorPreview() {
             onSigunguSelected = {},
             onEupmyeondongSelected = {},
             onRegionSelectionSearchClick = {},
+            onCandidateClick = {},
+            onGuideCandidateClick = {},
         )
     }
 }
+
+private fun previewRegionalGuide(
+    regionName: String,
+    targetRegionName: String
+): RegionalGuideUiModel =
+    RegionalGuideUiModel(
+        regionName = regionName,
+        managementZoneName = regionName,
+        targetRegionName = targetRegionName,
+        disposalPlaceType = "문전수거",
+        disposalPlaceDescription = "문전",
+        schedules = emptyList(),
+        uncollectedDays = "토, 일",
+        departmentInfo = "환경자원과"
+    )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideUiState.kt
@@ -1,6 +1,8 @@
 ﻿package com.team.yeogibeoryeo.presentation.regionalguide
 
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideCandidateUiModel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionSearchCandidateUiModel
 
 sealed interface RegionalGuideUiState {
     data object Idle : RegionalGuideUiState
@@ -21,7 +23,14 @@ sealed interface RegionalGuideUiState {
 
     data class Ambiguous(
         val query: String,
-        val message: String
+        val message: String,
+        val candidates: List<RegionSearchCandidateUiModel>
+    ) : RegionalGuideUiState
+
+    data class GuideCandidates(
+        val query: String,
+        val message: String,
+        val candidates: List<RegionalGuideCandidateUiModel>
     ) : RegionalGuideUiState
 
     data class Error(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
@@ -13,6 +13,9 @@ import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideFailureReas
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideLookupResult
 import com.team.yeogibeoryeo.domain.regionalguide.usecase.GetRegionalDisposalGuideUseCase
 import com.team.yeogibeoryeo.presentation.regionalguide.mapper.toUiModel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideCandidateUiModel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionSearchCandidateUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
@@ -162,6 +165,30 @@ class RegionalGuideViewModel @Inject constructor(
         }
     }
 
+    fun onRegionCandidateSelected(candidate: RegionSearchCandidateUiModel) {
+        if (!candidate.isValid) return
+
+        val region = candidate.toRegion()
+        applyRegionSelection(region)
+        searchBySelectedRegion(
+            query = candidate.displayText,
+            region = region
+        )
+    }
+
+    fun onRegionalGuideCandidateSelected(candidate: RegionalGuideCandidateUiModel) {
+        val query = (uiState.value as? RegionalGuideUiState.GuideCandidates)
+            ?.query
+            ?: candidate.displayText
+
+        applyRegionSelection(candidate.toRegion())
+
+        _uiState.value = RegionalGuideUiState.Success(
+            query = query,
+            guide = candidate.guide
+        )
+    }
+
     fun searchByKeyword(keyword: String) {
         val trimmedKeyword = keyword.trim()
 
@@ -182,10 +209,12 @@ class RegionalGuideViewModel @Inject constructor(
 
             try {
                 when (val result = resolveRegionFromKeywordUseCase(trimmedKeyword)) {
-                    ResolveRegionFromKeywordResult.Ambiguous -> {
+                    is ResolveRegionFromKeywordResult.Ambiguous -> {
                         _uiState.value = RegionalGuideUiState.Ambiguous(
                             query = trimmedKeyword,
-                            message = "여러 지역이 검색됩니다. 시도나 시군구를 함께 입력해주세요."
+                            message = "여러 지역이 검색됩니다. 원하는 지역을 선택해주세요.",
+                            candidates = result.candidates
+                                .map { region -> region.toCandidateUiModel() }
                         )
                     }
 
@@ -197,6 +226,7 @@ class RegionalGuideViewModel @Inject constructor(
                     }
 
                     is ResolveRegionFromKeywordResult.Resolved -> {
+                        applyRegionSelection(result.region)
                         loadRegionalGuide(
                             query = trimmedKeyword,
                             region = result.region
@@ -243,6 +273,7 @@ class RegionalGuideViewModel @Inject constructor(
                     return@launch
                 }
 
+                applyRegionSelection(region)
                 loadRegionalGuide(
                     query = trimmedAddress,
                     region = region
@@ -308,6 +339,55 @@ class RegionalGuideViewModel @Inject constructor(
         }
     }
 
+    private fun applyRegionSelection(region: Region) {
+        val selectedSido = region.sido
+        val selectedSigungu = region.sigungu
+
+        sigunguOptionsJob?.cancel()
+        eupmyeondongOptionsJob?.cancel()
+
+        _regionSelectorUiState.update { state ->
+            state.copy(
+                selectedSido = selectedSido,
+                selectedSigungu = selectedSigungu,
+                selectedEupmyeondong = region.eupmyeondong,
+                sigunguOptions = emptyList(),
+                eupmyeondongOptions = emptyList()
+            )
+        }
+
+        if (!selectedSido.isNullOrBlank()) {
+            sigunguOptionsJob = viewModelScope.launch {
+                val sigunguOptions = getSigunguOptionsUseCase(selectedSido)
+
+                _regionSelectorUiState.update { state ->
+                    if (state.selectedSido == selectedSido) {
+                        state.copy(sigunguOptions = sigunguOptions)
+                    } else {
+                        state
+                    }
+                }
+            }
+        }
+
+        if (!selectedSido.isNullOrBlank() && !selectedSigungu.isNullOrBlank()) {
+            eupmyeondongOptionsJob = viewModelScope.launch {
+                val eupmyeondongOptions = getEupmyeondongOptionsUseCase(
+                    sido = selectedSido,
+                    sigungu = selectedSigungu
+                )
+
+                _regionSelectorUiState.update { state ->
+                    if (state.selectedSido == selectedSido && state.selectedSigungu == selectedSigungu) {
+                        state.copy(eupmyeondongOptions = eupmyeondongOptions)
+                    } else {
+                        state
+                    }
+                }
+            }
+        }
+    }
+
     private suspend fun loadRegionalGuide(
         query: String,
         region: Region
@@ -324,6 +404,19 @@ class RegionalGuideViewModel @Inject constructor(
             is RegionalGuideLookupResult.Success -> RegionalGuideUiState.Success(
                 query = query,
                 guide = guide.toUiModel()
+            )
+
+            is RegionalGuideLookupResult.Candidates -> RegionalGuideUiState.GuideCandidates(
+                query = query,
+                message = "여러 배출 권역이 검색됩니다. 해당하는 권역을 선택해주세요.",
+                candidates = guides.map { guide ->
+                    RegionalGuideCandidateUiModel(
+                        guide = guide.toUiModel(),
+                        sido = guide.region.sido,
+                        sigungu = guide.region.sigungu,
+                        eupmyeondong = guide.region.eupmyeondong
+                    )
+                }
             )
 
             RegionalGuideLookupResult.NotFound -> RegionalGuideUiState.Empty(
@@ -355,6 +448,27 @@ class RegionalGuideViewModel @Inject constructor(
                 "지역별 배출 가이드를 조회하는 중 오류가 발생했습니다."
         }
     }
+
+    private fun Region.toCandidateUiModel(): RegionSearchCandidateUiModel =
+        RegionSearchCandidateUiModel(
+            sido = sido,
+            sigungu = sigungu,
+            eupmyeondong = eupmyeondong
+        )
+
+    private fun RegionSearchCandidateUiModel.toRegion(): Region =
+        Region(
+            sido = sido,
+            sigungu = sigungu,
+            eupmyeondong = eupmyeondong
+        )
+
+    private fun RegionalGuideCandidateUiModel.toRegion(): Region =
+        Region(
+            sido = sido,
+            sigungu = sigungu,
+            eupmyeondong = eupmyeondong
+        )
 
     private sealed interface RegionalGuideRequest {
         data class Keyword(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -47,6 +48,7 @@ class RegionalGuideViewModel @Inject constructor(
         _regionSelectorUiState.asStateFlow()
 
     private var guideLookupJob: Job? = null
+    private var keywordSuggestionJob: Job? = null
     private var sigunguOptionsJob: Job? = null
     private var eupmyeondongOptionsJob: Job? = null
     private var lastRequest: RegionalGuideRequest? = null
@@ -57,6 +59,8 @@ class RegionalGuideViewModel @Inject constructor(
 
     fun onSearchKeywordChanged(keyword: String) {
         _searchKeyword.value = keyword
+        clearStaleCandidateState(keyword)
+        scheduleKeywordSuggestion(keyword)
     }
 
     fun onSidoSelected(sido: String) {
@@ -177,6 +181,8 @@ class RegionalGuideViewModel @Inject constructor(
     }
 
     fun onRegionalGuideCandidateSelected(candidate: RegionalGuideCandidateUiModel) {
+        keywordSuggestionJob?.cancel()
+
         val query = (uiState.value as? RegionalGuideUiState.GuideCandidates)
             ?.query
             ?: candidate.displayText
@@ -192,6 +198,7 @@ class RegionalGuideViewModel @Inject constructor(
     fun searchByKeyword(keyword: String) {
         val trimmedKeyword = keyword.trim()
 
+        keywordSuggestionJob?.cancel()
         guideLookupJob?.cancel()
 
         if (trimmedKeyword.isBlank()) {
@@ -247,6 +254,7 @@ class RegionalGuideViewModel @Inject constructor(
     fun loadByAddress(address: String) {
         val trimmedAddress = address.trim()
 
+        keywordSuggestionJob?.cancel()
         guideLookupJob?.cancel()
 
         if (trimmedAddress.isBlank()) {
@@ -291,6 +299,7 @@ class RegionalGuideViewModel @Inject constructor(
 
     fun resetState() {
         guideLookupJob?.cancel()
+        keywordSuggestionJob?.cancel()
         sigunguOptionsJob?.cancel()
         eupmyeondongOptionsJob?.cancel()
         lastRequest = null
@@ -309,10 +318,59 @@ class RegionalGuideViewModel @Inject constructor(
         }
     }
 
+    private fun clearStaleCandidateState(keyword: String) {
+        val trimmedKeyword = keyword.trim()
+        val candidateQuery = when (val state = uiState.value) {
+            is RegionalGuideUiState.Ambiguous -> state.query
+            is RegionalGuideUiState.GuideCandidates -> state.query
+            else -> return
+        }
+
+        if (candidateQuery != trimmedKeyword) {
+            _uiState.value = RegionalGuideUiState.Idle
+        }
+    }
+
+    private fun scheduleKeywordSuggestion(keyword: String) {
+        keywordSuggestionJob?.cancel()
+
+        val trimmedKeyword = keyword.trim()
+        if (trimmedKeyword.isBlank()) return
+
+        keywordSuggestionJob = viewModelScope.launch {
+            delay(KEYWORD_SUGGESTION_DEBOUNCE_MILLIS)
+
+            if (searchKeyword.value.trim() != trimmedKeyword) return@launch
+
+            try {
+                when (val result = resolveRegionFromKeywordUseCase(trimmedKeyword)) {
+                    is ResolveRegionFromKeywordResult.Ambiguous -> {
+                        if (searchKeyword.value.trim() == trimmedKeyword) {
+                            _uiState.value = RegionalGuideUiState.Ambiguous(
+                                query = trimmedKeyword,
+                                message = "?щ윭 吏??씠 寃?됰맗?덈떎. ?먰븯??吏??쓣 ?좏깮?댁＜?몄슂.",
+                                candidates = result.candidates
+                                    .map { region -> region.toCandidateUiModel() }
+                            )
+                        }
+                    }
+
+                    ResolveRegionFromKeywordResult.NotFound,
+                    is ResolveRegionFromKeywordResult.Resolved -> Unit
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // 자동 후보 추천은 보조 UX이므로 실패해도 기존 화면 상태를 유지합니다.
+            }
+        }
+    }
+
     private fun searchBySelectedRegion(
         query: String,
         region: Region
     ) {
+        keywordSuggestionJob?.cancel()
         guideLookupJob?.cancel()
 
         lastRequest = RegionalGuideRequest.SelectedRegion(
@@ -483,5 +541,9 @@ class RegionalGuideViewModel @Inject constructor(
             val query: String,
             val region: Region
         ) : RegionalGuideRequest
+    }
+
+    private companion object {
+        const val KEYWORD_SUGGESTION_DEBOUNCE_MILLIS = 400L
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
@@ -20,11 +20,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -219,7 +219,7 @@ class RegionalGuideViewModel @Inject constructor(
                     is ResolveRegionFromKeywordResult.Ambiguous -> {
                         _uiState.value = RegionalGuideUiState.Ambiguous(
                             query = trimmedKeyword,
-                            message = "여러 지역이 검색됩니다. 원하는 지역을 선택해주세요.",
+                            message = AMBIGUOUS_REGION_MESSAGE,
                             candidates = result.candidates
                                 .map { region -> region.toCandidateUiModel() }
                         )
@@ -348,7 +348,7 @@ class RegionalGuideViewModel @Inject constructor(
                         if (searchKeyword.value.trim() == trimmedKeyword) {
                             _uiState.value = RegionalGuideUiState.Ambiguous(
                                 query = trimmedKeyword,
-                                message = "?щ윭 吏??씠 寃?됰맗?덈떎. ?먰븯??吏??쓣 ?좏깮?댁＜?몄슂.",
+                                message = AMBIGUOUS_REGION_MESSAGE,
                                 candidates = result.candidates
                                     .map { region -> region.toCandidateUiModel() }
                             )
@@ -361,7 +361,7 @@ class RegionalGuideViewModel @Inject constructor(
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Exception) {
-                // 자동 후보 추천은 보조 UX이므로 실패해도 기존 화면 상태를 유지합니다.
+                // 입력 중 후보 추천은 명시 조회가 아니므로 실패해도 현재 화면 상태를 유지합니다.
             }
         }
     }
@@ -545,5 +545,6 @@ class RegionalGuideViewModel @Inject constructor(
 
     private companion object {
         const val KEYWORD_SUGGESTION_DEBOUNCE_MILLIS = 400L
+        const val AMBIGUOUS_REGION_MESSAGE = "여러 지역이 검색됩니다. 원하는 지역을 선택해주세요."
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideCandidateList.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideCandidateList.kt
@@ -1,0 +1,129 @@
+package com.team.yeogibeoryeo.presentation.regionalguide.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+
+@Composable
+internal fun <T> RegionalGuideCandidateList(
+    candidates: List<T>,
+    key: (T) -> Any,
+    onCandidateClick: (T) -> Unit,
+    modifier: Modifier = Modifier,
+    itemContent: @Composable (T) -> Unit,
+) {
+    val listState = rememberLazyListState()
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(max = CANDIDATE_LIST_MAX_HEIGHT)
+            .background(MaterialTheme.colorScheme.surface)
+    ) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            itemsIndexed(
+                items = candidates,
+                key = { _, candidate -> key(candidate) }
+            ) { index, candidate ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                        .clickable {
+                            onCandidateClick(candidate)
+                        }
+                ) {
+                    itemContent(candidate)
+                }
+
+                if (index < candidates.lastIndex) {
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                }
+            }
+        }
+
+        RegionalGuideCandidateScrollbar(
+            listState = listState,
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(end = 2.dp)
+        )
+    }
+}
+
+@Composable
+private fun RegionalGuideCandidateScrollbar(
+    listState: LazyListState,
+    modifier: Modifier = Modifier,
+) {
+    val layoutInfo = listState.layoutInfo
+    val totalItemsCount = layoutInfo.totalItemsCount
+    val visibleItemsCount = layoutInfo.visibleItemsInfo.size
+
+    if (totalItemsCount == 0 || visibleItemsCount == 0 || visibleItemsCount >= totalItemsCount) {
+        return
+    }
+
+    BoxWithConstraints(
+        modifier = modifier
+            .fillMaxHeight()
+            .width(SCROLLBAR_WIDTH)
+    ) {
+        val density = LocalDensity.current
+        val containerHeightPx = with(density) { maxHeight.toPx() }
+        val thumbHeightPx = (containerHeightPx * visibleItemsCount / totalItemsCount)
+            .coerceAtLeast(MIN_SCROLLBAR_THUMB_HEIGHT_PX)
+        val scrollableItemsCount = (totalItemsCount - visibleItemsCount).coerceAtLeast(1)
+        val offsetFraction = listState.firstVisibleItemIndex.toFloat() / scrollableItemsCount
+        val thumbOffsetPx = ((containerHeightPx - thumbHeightPx) * offsetFraction).roundToInt()
+
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .width(SCROLLBAR_WIDTH)
+                .clip(RoundedCornerShape(SCROLLBAR_RADIUS))
+                .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = SCROLLBAR_TRACK_ALPHA))
+        )
+
+        Box(
+            modifier = Modifier
+                .offset { IntOffset(x = 0, y = thumbOffsetPx) }
+                .width(SCROLLBAR_WIDTH)
+                .fillMaxHeight(thumbHeightPx / containerHeightPx)
+                .clip(RoundedCornerShape(SCROLLBAR_RADIUS))
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = SCROLLBAR_THUMB_ALPHA))
+        )
+    }
+}
+
+private val CANDIDATE_LIST_MAX_HEIGHT = 260.dp
+private val SCROLLBAR_WIDTH = 3.dp
+private val SCROLLBAR_RADIUS = 999.dp
+private const val SCROLLBAR_TRACK_ALPHA = 0.35f
+private const val SCROLLBAR_THUMB_ALPHA = 0.85f
+private const val MIN_SCROLLBAR_THUMB_HEIGHT_PX = 24f

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideCandidateList.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideCandidateList.kt
@@ -48,7 +48,7 @@ internal fun <T> RegionalGuideCandidateList(
         ) {
             itemsIndexed(
                 items = candidates,
-                key = { _, candidate -> key(candidate) }
+                key = { index, candidate -> "${key(candidate)}-$index" }
             ) { index, candidate ->
                 Box(
                     modifier = Modifier

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideCandidateResult.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideCandidateResult.kt
@@ -10,20 +10,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionSearchCandidateUiModel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideCandidateUiModel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
 
 @Composable
-fun RegionalGuideAmbiguousResult(
-    candidates: List<RegionSearchCandidateUiModel>,
-    onCandidateClick: (RegionSearchCandidateUiModel) -> Unit,
+fun RegionalGuideCandidateResult(
+    candidates: List<RegionalGuideCandidateUiModel>,
+    onCandidateClick: (RegionalGuideCandidateUiModel) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val validCandidates = candidates.filter { candidate -> candidate.isValid }
-
     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
 
     RegionalGuideCandidateList(
-        candidates = validCandidates,
+        candidates = candidates,
         key = { candidate -> candidate.displayText },
         onCandidateClick = onCandidateClick,
         modifier = modifier
@@ -40,8 +39,8 @@ private fun RegionalGuideCandidateRowText(
     Text(
         text = text,
         style = MaterialTheme.typography.bodyLarge,
-        fontWeight = FontWeight.Medium,
         color = MaterialTheme.colorScheme.onSurface,
+        fontWeight = FontWeight.Medium,
         modifier = modifier
             .fillMaxWidth()
             .padding(
@@ -55,33 +54,39 @@ private fun RegionalGuideCandidateRowText(
 
 @Preview(showBackground = true)
 @Composable
-private fun RegionalGuideAmbiguousResultPreview() {
+private fun RegionalGuideCandidateResultPreview() {
     MaterialTheme {
-        RegionalGuideAmbiguousResult(
+        RegionalGuideCandidateResult(
             candidates = listOf(
-                RegionSearchCandidateUiModel(
-                    sido = "서울특별시",
-                    sigungu = "중구",
-                    eupmyeondong = null,
-                ),
-                RegionSearchCandidateUiModel(
-                    sido = "대구광역시",
-                    sigungu = "중구",
-                    eupmyeondong = null,
-                ),
-                RegionSearchCandidateUiModel(
-                    sido = "인천광역시",
-                    sigungu = "중구",
-                    eupmyeondong = null,
-                ),
-                RegionSearchCandidateUiModel(
+                RegionalGuideCandidateUiModel(
+                    guide = previewGuide("범서, 온양, 웅촌, 언양, 삼남, 상북, 온산, 청량, 서생"),
                     sido = "울산광역시",
-                    sigungu = "중구",
-                    eupmyeondong = null,
+                    sigungu = "울주군",
+                    eupmyeondong = null
+                ),
+                RegionalGuideCandidateUiModel(
+                    guide = previewGuide("두동, 두서, 삼동"),
+                    sido = "울산광역시",
+                    sigungu = "울주군",
+                    eupmyeondong = null
                 ),
             ),
             onCandidateClick = {},
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = 16.dp)
         )
     }
 }
+
+private fun previewGuide(
+    targetRegionName: String
+): RegionalGuideUiModel =
+    RegionalGuideUiModel(
+        regionName = "울산광역시 울주군",
+        managementZoneName = "울산광역시 울주군",
+        targetRegionName = targetRegionName,
+        disposalPlaceType = "문전수거",
+        disposalPlaceDescription = "문전",
+        schedules = emptyList(),
+        uncollectedDays = "토, 일",
+        departmentInfo = "환경자원과"
+    )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
@@ -1,63 +1,122 @@
 package com.team.yeogibeoryeo.presentation.regionalguide.components
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Button
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun RegionalGuideSearchBar(
     keyword: String,
     onKeywordChange: (String) -> Unit,
     onSearchClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    candidateContent: (@Composable ColumnScope.() -> Unit)? = null,
 ) {
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.CenterVertically
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val hasCandidates = candidateContent != null
+
+    fun submitSearch() {
+        if (keyword.isBlank()) return
+
+        focusManager.clearFocus()
+        keyboardController?.hide()
+        onSearchClick()
+    }
+
+    Column(
+        modifier = modifier.fillMaxWidth()
     ) {
         OutlinedTextField(
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = SEARCH_FIELD_MIN_HEIGHT),
             value = keyword,
             onValueChange = onKeywordChange,
             singleLine = true,
-            label = {
-                Text(text = "지역명")
-            },
             placeholder = {
-                Text(text = "예: 영등포구, 세종 새롬동")
+                Text(text = "지역명 또는 주소를 검색해주세요.")
+            },
+            trailingIcon = {
+                IconButton(
+                    onClick = ::submitSearch,
+                    enabled = keyword.isNotBlank()
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Search,
+                        contentDescription = "검색"
+                    )
+                }
+            },
+            shape = if (hasCandidates) {
+                SEARCH_FIELD_EXPANDED_SHAPE
+            } else {
+                SEARCH_FIELD_DEFAULT_SHAPE
             },
             keyboardOptions = KeyboardOptions(
                 imeAction = ImeAction.Search
             ),
             keyboardActions = KeyboardActions(
                 onSearch = {
-                    onSearchClick()
+                    submitSearch()
                 }
             )
         )
 
-        Button(
-            onClick = onSearchClick,
-            enabled = keyword.isNotBlank()
-        ) {
-            Text(text = "검색")
+        if (candidateContent != null) {
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = SEARCH_CANDIDATE_CONTAINER_SHAPE,
+                color = MaterialTheme.colorScheme.surface,
+                shadowElevation = SEARCH_CANDIDATE_ELEVATION,
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    candidateContent()
+                }
+            }
         }
     }
 }
+
+private val SEARCH_FIELD_MIN_HEIGHT = 56.dp
+private val SEARCH_FIELD_DEFAULT_SHAPE = RoundedCornerShape(12.dp)
+private val SEARCH_FIELD_EXPANDED_SHAPE = RoundedCornerShape(
+    topStart = 12.dp,
+    topEnd = 12.dp,
+    bottomStart = 0.dp,
+    bottomEnd = 0.dp,
+)
+private val SEARCH_CANDIDATE_CONTAINER_SHAPE = RoundedCornerShape(
+    topStart = 0.dp,
+    topEnd = 0.dp,
+    bottomStart = 12.dp,
+    bottomEnd = 12.dp,
+)
+private val SEARCH_CANDIDATE_ELEVATION = 3.dp
 
 @Preview(showBackground = true)
 @Composable

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionSearchCandidateUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionSearchCandidateUiModel.kt
@@ -1,0 +1,19 @@
+package com.team.yeogibeoryeo.presentation.regionalguide.model
+
+data class RegionSearchCandidateUiModel(
+    val sido: String?,
+    val sigungu: String?,
+    val eupmyeondong: String?
+) {
+    val displayText: String =
+        listOfNotNull(
+            sido,
+            sigungu,
+            eupmyeondong
+        )
+            .filter { regionName -> regionName.isNotBlank() }
+            .joinToString(" > ")
+
+    val isValid: Boolean
+        get() = displayText.isNotBlank()
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
@@ -1,0 +1,14 @@
+package com.team.yeogibeoryeo.presentation.regionalguide.model
+
+data class RegionalGuideCandidateUiModel(
+    val guide: RegionalGuideUiModel,
+    val sido: String?,
+    val sigungu: String?,
+    val eupmyeondong: String?
+) {
+    val displayText: String =
+        guide.targetRegionName
+            ?.takeIf { targetRegionName -> targetRegionName.isNotBlank() }
+            ?: guide.managementZoneName
+            ?: guide.regionName
+}

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModelTest.kt
@@ -196,6 +196,181 @@ class RegionalGuideViewModelTest {
         assertTrue(viewModel.uiState.value is RegionalGuideUiState.Success)
     }
 
+    @Test
+    fun `ambiguous keyword search exposes region candidates`() = runTest {
+        val viewModel = createViewModel(
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                keywordRegions = listOf(
+                    Region(
+                        sido = "울산광역시",
+                        sigungu = "울주군",
+                        eupmyeondong = "온양읍"
+                    ),
+                    Region(
+                        sido = "충청남도",
+                        sigungu = "아산시",
+                        eupmyeondong = "온양1동"
+                    )
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("온양")
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value as RegionalGuideUiState.Ambiguous
+
+        assertEquals("온양", state.query)
+        assertEquals(2, state.candidates.size)
+        assertEquals("울산광역시 > 울주군 > 온양읍", state.candidates.first().displayText)
+    }
+
+    @Test
+    fun `candidate selection runs selected region lookup and updates selector state`() = runTest {
+        val regionalGuideRepository = FakeRegionalDisposalGuideRepository(
+            candidates = listOf(
+                sampleGuide(
+                    sido = "울산광역시",
+                    sigungu = "울주군",
+                    targetRegionName = "온양읍"
+                )
+            )
+        )
+        val viewModel = createViewModel(
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                sigunguOptionsBySido = mapOf(
+                    "울산광역시" to listOf("울주군")
+                ),
+                eupmyeondongOptionsByRegion = mapOf(
+                    "울산광역시" to mapOf(
+                        "울주군" to listOf("온양읍")
+                    )
+                ),
+                keywordRegions = listOf(
+                    Region(
+                        sido = "울산광역시",
+                        sigungu = "울주군",
+                        eupmyeondong = "온양읍"
+                    ),
+                    Region(
+                        sido = "충청남도",
+                        sigungu = "아산시",
+                        eupmyeondong = "온양1동"
+                    )
+                )
+            ),
+            regionalGuideRepository = regionalGuideRepository
+        )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("온양")
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        val candidate = (viewModel.uiState.value as RegionalGuideUiState.Ambiguous)
+            .candidates
+            .first()
+
+        viewModel.onRegionCandidateSelected(candidate)
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value is RegionalGuideUiState.Success)
+        assertEquals("울주군", regionalGuideRepository.queries.single().sigunguQuery)
+
+        with(viewModel.regionSelectorUiState.value) {
+            assertEquals("울산광역시", selectedSido)
+            assertEquals("울주군", selectedSigungu)
+            assertEquals("온양읍", selectedEupmyeondong)
+        }
+    }
+
+    @Test
+    fun `regional guide lookup exposes multiple guide candidates`() = runTest {
+        val viewModel = createViewModel(
+            regionRepository = FakeRegionRepository(
+                resolvedRegion = Region(sigungu = "울주군")
+            ),
+            regionalGuideRepository = FakeRegionalDisposalGuideRepository(
+                candidates = listOf(
+                    sampleGuide(
+                        sido = "울산광역시",
+                        sigungu = "울주군",
+                        targetRegionName = "범서, 온양, 웅촌, 언양, 삼남, 상북, 온산, 청량, 서생"
+                    ),
+                    sampleGuide(
+                        sido = "울산광역시",
+                        sigungu = "울주군",
+                        targetRegionName = "두동, 두서, 삼동"
+                    )
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("울주군")
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value as RegionalGuideUiState.GuideCandidates
+
+        assertEquals("울주군", state.query)
+        assertEquals(2, state.candidates.size)
+        assertEquals(
+            "범서, 온양, 웅촌, 언양, 삼남, 상북, 온산, 청량, 서생",
+            state.candidates.first().displayText
+        )
+    }
+
+    @Test
+    fun `regional guide candidate selection shows selected guide`() = runTest {
+        val viewModel = createViewModel(
+            regionRepository = FakeRegionRepository(
+                resolvedRegion = Region(sigungu = "울주군")
+            ),
+            regionalGuideRepository = FakeRegionalDisposalGuideRepository(
+                candidates = listOf(
+                    sampleGuide(
+                        sido = "울산광역시",
+                        sigungu = "울주군",
+                        targetRegionName = "범서, 온양, 웅촌, 언양, 삼남, 상북, 온산, 청량, 서생"
+                    ),
+                    sampleGuide(
+                        sido = "울산광역시",
+                        sigungu = "울주군",
+                        targetRegionName = "두동, 두서, 삼동"
+                    )
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("울주군")
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        val candidate = (viewModel.uiState.value as RegionalGuideUiState.GuideCandidates)
+            .candidates
+            .first()
+
+        viewModel.onRegionalGuideCandidateSelected(candidate)
+
+        val state = viewModel.uiState.value as RegionalGuideUiState.Success
+
+        assertEquals("울주군", state.query)
+        assertEquals(
+            "범서, 온양, 웅촌, 언양, 삼남, 상북, 온산, 청량, 서생",
+            state.guide.targetRegionName
+        )
+
+        with(viewModel.regionSelectorUiState.value) {
+            assertEquals("울산광역시", selectedSido)
+            assertEquals("울주군", selectedSigungu)
+            assertNull(selectedEupmyeondong)
+        }
+    }
+
     private fun createViewModel(
         regionRepository: RegionRepository = FakeRegionRepository(),
         regionOptionsRepository: RegionOptionsRepository = FakeRegionOptionsRepository(),
@@ -233,10 +408,12 @@ class RegionalGuideViewModelTest {
         )
     }
 
-    private class FakeRegionRepository : RegionRepository {
+    private class FakeRegionRepository(
+        private val resolvedRegion: Region? = null
+    ) : RegionRepository {
         override fun extractRegionFromAddress(address: String): Region? = null
 
-        override suspend fun resolveRegionFromKeyword(keyword: String): Region? = null
+        override suspend fun resolveRegionFromKeyword(keyword: String): Region? = resolvedRegion
 
         override suspend fun resolveRegionFromCoordinate(
             latitude: Double,
@@ -249,6 +426,7 @@ class RegionalGuideViewModelTest {
         private val sigunguOptionsBySido: Map<String, List<String>> = emptyMap(),
         private val eupmyeondongOptionsByRegion: Map<String, Map<String, List<String>>> = emptyMap(),
         private val delayedSigunguOptionsBySido: Map<String, CompletableDeferred<List<String>>> = emptyMap(),
+        private val keywordRegions: List<Region> = emptyList(),
     ) : RegionOptionsRepository {
 
         override suspend fun getSidoOptions(): List<String> = sidoOptions
@@ -271,11 +449,33 @@ class RegionalGuideViewModelTest {
 
         override suspend fun findRegionsByEupmyeondongKeyword(
             keyword: String
-        ): List<Region> = emptyList()
+        ): List<Region> {
+            val exactMatches = keywordRegions.filter { region -> region.eupmyeondong == keyword }
+
+            return exactMatches.ifEmpty {
+                keywordRegions.filter { region ->
+                    region.eupmyeondong?.startsWith(keyword) == true
+                }
+            }
+        }
 
         override suspend fun findRegionsBySigunguKeyword(
             keyword: String
-        ): List<Region> = emptyList()
+        ): List<Region> {
+            val exactMatches = keywordRegions.filter { region -> region.sigungu == keyword }
+
+            val prefixMatches = exactMatches.ifEmpty {
+                keywordRegions.filter { region ->
+                    region.sigungu?.startsWith(keyword) == true
+                }
+            }
+
+            return prefixMatches.ifEmpty {
+                keywordRegions.filter { region ->
+                    region.sigungu?.contains(keyword) == true
+                }
+            }
+        }
     }
 
     private class FakeRegionalDisposalGuideRepository(

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModelTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -228,6 +229,72 @@ class RegionalGuideViewModelTest {
     }
 
     @Test
+    fun `keyword input shows region candidates after debounce without explicit search`() = runTest {
+        val viewModel = createViewModel(
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                keywordRegions = listOf(
+                    Region(
+                        sido = "SidoA",
+                        sigungu = "SigunguA",
+                        eupmyeondong = "onyang"
+                    ),
+                    Region(
+                        sido = "SidoB",
+                        sigungu = "SigunguB",
+                        eupmyeondong = "onyang2"
+                    )
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("on")
+        advanceTimeBy(399)
+
+        assertEquals(RegionalGuideUiState.Idle, viewModel.uiState.value)
+
+        advanceTimeBy(1)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value as RegionalGuideUiState.Ambiguous
+
+        assertEquals("on", state.query)
+        assertEquals(2, state.candidates.size)
+    }
+
+    @Test
+    fun `candidate list is cleared when keyword changes after ambiguous search`() = runTest {
+        val viewModel = createViewModel(
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                keywordRegions = listOf(
+                    Region(
+                        sido = "SidoA",
+                        sigungu = "SigunguA",
+                        eupmyeondong = "onyang"
+                    ),
+                    Region(
+                        sido = "SidoB",
+                        sigungu = "SigunguB",
+                        eupmyeondong = "onyang2"
+                    )
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("on")
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value is RegionalGuideUiState.Ambiguous)
+
+        viewModel.onSearchKeywordChanged("o")
+
+        assertEquals("o", viewModel.searchKeyword.value)
+        assertEquals(RegionalGuideUiState.Idle, viewModel.uiState.value)
+    }
+
+    @Test
     fun `candidate selection runs selected region lookup and updates selector state`() = runTest {
         val regionalGuideRepository = FakeRegionalDisposalGuideRepository(
             candidates = listOf(
@@ -321,6 +388,41 @@ class RegionalGuideViewModelTest {
             "범서, 온양, 웅촌, 언양, 삼남, 상북, 온산, 청량, 서생",
             state.candidates.first().displayText
         )
+    }
+
+    @Test
+    fun `guide candidate list is cleared when keyword changes after guide candidate search`() = runTest {
+        val viewModel = createViewModel(
+            regionRepository = FakeRegionRepository(
+                resolvedRegion = Region(sido = "SidoA", sigungu = "SigunguA")
+            ),
+            regionalGuideRepository = FakeRegionalDisposalGuideRepository(
+                candidates = listOf(
+                    sampleGuide(
+                        sido = "SidoA",
+                        sigungu = "SigunguA",
+                        targetRegionName = "zone1"
+                    ),
+                    sampleGuide(
+                        sido = "SidoA",
+                        sigungu = "SigunguA",
+                        targetRegionName = "zone2"
+                    )
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("SigunguA")
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value is RegionalGuideUiState.GuideCandidates)
+
+        viewModel.onSearchKeywordChanged("Sigungu")
+
+        assertEquals("Sigungu", viewModel.searchKeyword.value)
+        assertEquals(RegionalGuideUiState.Idle, viewModel.uiState.value)
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용

- 지역명 직접 검색 결과가 여러 후보로 해석되는 경우 후보 리스트를 표시하도록 구현했습니다.
- 검색창 하단에 후보 리스트를 표시하고, 후보 선택 시 선택한 지역 기준으로 지역 가이드 조회 흐름에 연결했습니다.
- 직접 검색 시 읍면동 후보와 시군구 후보를 함께 조회하도록 수정했습니다.
- `장안`처럼 시군구 후보와 읍면동 후보가 함께 존재하는 검색어도 후보 리스트에 모두 표시되도록 보완했습니다.
- 후보 목록을 시도 / 시군구 / 읍면동 기준 가나다순으로 정렬했습니다.
- `/info` 응답에서 복수 배출 권역 후보가 내려오는 경우 후보 리스트를 표시하고 선택할 수 있도록 연결했습니다.
- 후보 선택 시 지역 선택 상태와 조회 결과가 함께 갱신되도록 처리했습니다.
- 중복 표시명을 가진 후보에서도 LazyColumn key가 충돌하지 않도록 보완했습니다.
- 지역 후보 및 배출 권역 후보 선택 관련 테스트를 추가했습니다.

## 테스트

- [x] `:domain:test --tests "com.team.yeogibeoryeo.domain.region.*"` 성공
- [x] `:domain:test --tests "com.team.yeogibeoryeo.domain.regionalguide.*"` 성공
- [x] `:presentation:testDebugUnitTest --tests "com.team.yeogibeoryeo.presentation.regionalguide.RegionalGuideViewModelTest"` 성공
- [x] 에뮬레이터에서 주요 검색 케이스 확인
  - `온양` 검색 시 후보 리스트 표시
  - `장안` 검색 시 `경기도 > 수원시 장안구`, `부산광역시 > 기장군 > 장안읍` 후보 표시
  - `울주` 또는 `울주군` 조회 시 배출 권역 후보 표시
  - `경기도 > 성남시 중원구` 선택 시 앱 종료 없이 후보 또는 결과 표시
- [x] GitHub Actions CI 통과 확인

## 스크린샷

| 직접 검색 후보 리스트 | 배출 권역 후보 리스트 |
|---|---|
| `장안` 검색 화면 | `울주군` 조회 후 권역 후보 화면 |
| <img width="1344" height="2992" alt="Screenshot_20260605_185806" src="https://github.com/user-attachments/assets/2d745cf5-e050-4241-8884-65fcfc258dfa" /> | <img width="1344" height="2992" alt="Screenshot_20260605_185832" src="https://github.com/user-attachments/assets/93ad42bc-15ed-4fa0-915c-2e1a661a6d0b" /> |

## 후속 작업

- 지역 가이드 선택형 UI의 시군구 옵션을 `/info` 제공 지역 기준으로 정리하는 작업은 #105에서 진행합니다.
- 지도 화면에서 선택한 장소 주소를 지역 가이드 화면으로 전달하는 Navigation 연결은 #61에서 진행합니다.
- 지도 연결 후 `/getSpot` 주소 기반 조회 흐름에서 추가 예외 케이스가 있으면 별도 보완합니다.

## 관련 이슈

- Related #103
- Follow-up of #60