### PR TITLE
refactor: 지역 가이드 선택 옵션을 info 제공 지역 기준으로 정리

### DIFF
--- a/data/src/main/assets/region/regional_guide_regions.json
+++ b/data/src/main/assets/region/regional_guide_regions.json
@@ -1,0 +1,870 @@
+[
+    {
+        "sidoName":  "강원특별자치도",
+        "sigunguName":  "강릉시"
+    },
+    {
+        "sidoName":  "강원특별자치도",
+        "sigunguName":  "고성군"
+    },
+    {
+        "sidoName":  "강원특별자치도",
+        "sigunguName":  "동해시"
+    },
+    {
+        "sidoName":  "강원특별자치도",
+        "sigunguName":  "삼척시"
+    },
+    {
+        "sidoName":  "강원특별자치도",
+        "sigunguName":  "양구군"
+    },
+    {
+        "sidoName":  "강원특별자치도",
+        "sigunguName":  "양양군"
+    },
+    {
+        "sidoName":  "강원특별자치도",
+        "sigunguName":  "영월군"
+    },
+    {
+        "sidoName":  "강원특별자치도",
+        "sigunguName":  "원주시"
+    },
+    {
+        "sidoName":  "강원특별자치도",
+        "sigunguName":  "인제군"
+    },
+    {
+        "sidoName":  "강원특별자치도",
+        "sigunguName":  "정선군"
+    },
+    {
+        "sidoName":  "강원특별자치도",
+        "sigunguName":  "춘천시"
+    },
+    {
+        "sidoName":  "강원특별자치도",
+        "sigunguName":  "태백시"
+    },
+    {
+        "sidoName":  "강원특별자치도",
+        "sigunguName":  "평창군"
+    },
+    {
+        "sidoName":  "강원특별자치도",
+        "sigunguName":  "홍천군"
+    },
+    {
+        "sidoName":  "강원특별자치도",
+        "sigunguName":  "횡성군"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "가평군"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "고양시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "과천시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "광명시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "광주시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "구리시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "군포시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "김포시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "남양주"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "동두천"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "부천시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "성남시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "수원시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "시흥시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "안성시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "안양시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "양주시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "양평군"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "여주시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "연천군"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "오산시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "용인시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "의왕시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "의정부시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "이천시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "파주시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "평택시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "포천시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "하남시"
+    },
+    {
+        "sidoName":  "경기도",
+        "sigunguName":  "화성시"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "거제시"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "거창군"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "고성군"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "김해시"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "남해군"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "밀양시"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "사천시"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "산청군"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "양산시"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "의령군"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "진주시"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "창녕군"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "창원시"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "통영시"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "하동군"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "함양군"
+    },
+    {
+        "sidoName":  "경상남도",
+        "sigunguName":  "합천군"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "경산시"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "경주시"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "고령군"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "구미시"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "김천시"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "문경시"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "봉화군"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "상주시"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "성주군"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "안동시"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "영덕군"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "영양군"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "영주시"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "영천시"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "예천군"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "울릉군"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "울진군"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "의성군"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "청도군"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "청송군"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "칠곡군"
+    },
+    {
+        "sidoName":  "경상북도",
+        "sigunguName":  "포항시"
+    },
+    {
+        "sidoName":  "광주광역시",
+        "sigunguName":  "광산구"
+    },
+    {
+        "sidoName":  "광주광역시",
+        "sigunguName":  "남구"
+    },
+    {
+        "sidoName":  "광주광역시",
+        "sigunguName":  "동구"
+    },
+    {
+        "sidoName":  "광주광역시",
+        "sigunguName":  "북구"
+    },
+    {
+        "sidoName":  "광주광역시",
+        "sigunguName":  "서구"
+    },
+    {
+        "sidoName":  "대구광역시",
+        "sigunguName":  "군위군"
+    },
+    {
+        "sidoName":  "대구광역시",
+        "sigunguName":  "남구"
+    },
+    {
+        "sidoName":  "대구광역시",
+        "sigunguName":  "달서구"
+    },
+    {
+        "sidoName":  "대구광역시",
+        "sigunguName":  "달성군"
+    },
+    {
+        "sidoName":  "대구광역시",
+        "sigunguName":  "동구"
+    },
+    {
+        "sidoName":  "대구광역시",
+        "sigunguName":  "북구"
+    },
+    {
+        "sidoName":  "대구광역시",
+        "sigunguName":  "서구"
+    },
+    {
+        "sidoName":  "대구광역시",
+        "sigunguName":  "수성구"
+    },
+    {
+        "sidoName":  "대구광역시",
+        "sigunguName":  "중구"
+    },
+    {
+        "sidoName":  "대전광역시",
+        "sigunguName":  "대덕구"
+    },
+    {
+        "sidoName":  "대전광역시",
+        "sigunguName":  "동구"
+    },
+    {
+        "sidoName":  "대전광역시",
+        "sigunguName":  "서구"
+    },
+    {
+        "sidoName":  "대전광역시",
+        "sigunguName":  "유성구"
+    },
+    {
+        "sidoName":  "대전광역시",
+        "sigunguName":  "중구"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "강서구"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "금정구"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "기장군"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "남구"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "동구"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "동래구"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "부산진구"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "북구"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "사상구"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "사하구"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "서구"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "수영구"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "연제구"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "영도구"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "중구"
+    },
+    {
+        "sidoName":  "부산광역시",
+        "sigunguName":  "해운대구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "강남구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "강북구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "강서구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "관악구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "광진구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "구로구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "금천구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "노원구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "동대문구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "동작구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "마포구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "서대문구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "서초구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "성동구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "성북구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "송파구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "양천구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "영등포구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "용산구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "은평구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "종로구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "중구"
+    },
+    {
+        "sidoName":  "서울특별시",
+        "sigunguName":  "중랑구"
+    },
+    {
+        "sidoName":  "세종특별자치시",
+        "sigunguName":  "없음"
+    },
+    {
+        "sidoName":  "울산광역시",
+        "sigunguName":  "남구"
+    },
+    {
+        "sidoName":  "울산광역시",
+        "sigunguName":  "동구"
+    },
+    {
+        "sidoName":  "울산광역시",
+        "sigunguName":  "북구"
+    },
+    {
+        "sidoName":  "울산광역시",
+        "sigunguName":  "울주군"
+    },
+    {
+        "sidoName":  "울산광역시",
+        "sigunguName":  "중구"
+    },
+    {
+        "sidoName":  "인천광역시",
+        "sigunguName":  "강화군"
+    },
+    {
+        "sidoName":  "인천광역시",
+        "sigunguName":  "계양구"
+    },
+    {
+        "sidoName":  "인천광역시",
+        "sigunguName":  "남동구"
+    },
+    {
+        "sidoName":  "인천광역시",
+        "sigunguName":  "동구"
+    },
+    {
+        "sidoName":  "인천광역시",
+        "sigunguName":  "미추홀구"
+    },
+    {
+        "sidoName":  "인천광역시",
+        "sigunguName":  "부평구"
+    },
+    {
+        "sidoName":  "인천광역시",
+        "sigunguName":  "서구"
+    },
+    {
+        "sidoName":  "인천광역시",
+        "sigunguName":  "연수구"
+    },
+    {
+        "sidoName":  "인천광역시",
+        "sigunguName":  "옹진군"
+    },
+    {
+        "sidoName":  "인천광역시",
+        "sigunguName":  "중구"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "강진군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "고흥군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "곡성군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "광양시"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "구례군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "나주시"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "담양군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "목포시"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "무안군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "보성군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "순천시"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "신안군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "여수시"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "영광군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "영암군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "완도군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "장성군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "장흥군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "진도군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "함평군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "해남군"
+    },
+    {
+        "sidoName":  "전라남도",
+        "sigunguName":  "화순군"
+    },
+    {
+        "sidoName":  "전북특별자치도",
+        "sigunguName":  "고창군"
+    },
+    {
+        "sidoName":  "전북특별자치도",
+        "sigunguName":  "군산시"
+    },
+    {
+        "sidoName":  "전북특별자치도",
+        "sigunguName":  "무주군"
+    },
+    {
+        "sidoName":  "전북특별자치도",
+        "sigunguName":  "부안군"
+    },
+    {
+        "sidoName":  "전북특별자치도",
+        "sigunguName":  "순창군"
+    },
+    {
+        "sidoName":  "전북특별자치도",
+        "sigunguName":  "완주군"
+    },
+    {
+        "sidoName":  "전북특별자치도",
+        "sigunguName":  "익산시"
+    },
+    {
+        "sidoName":  "전북특별자치도",
+        "sigunguName":  "임실군"
+    },
+    {
+        "sidoName":  "전북특별자치도",
+        "sigunguName":  "장수군"
+    },
+    {
+        "sidoName":  "전북특별자치도",
+        "sigunguName":  "전주시"
+    },
+    {
+        "sidoName":  "전북특별자치도",
+        "sigunguName":  "정읍시"
+    },
+    {
+        "sidoName":  "전북특별자치도",
+        "sigunguName":  "진안군"
+    },
+    {
+        "sidoName":  "제주특별자치도",
+        "sigunguName":  "서귀포시"
+    },
+    {
+        "sidoName":  "제주특별자치도",
+        "sigunguName":  "제주시"
+    },
+    {
+        "sidoName":  "충청남도",
+        "sigunguName":  "계룡시"
+    },
+    {
+        "sidoName":  "충청남도",
+        "sigunguName":  "금산군"
+    },
+    {
+        "sidoName":  "충청남도",
+        "sigunguName":  "논산시"
+    },
+    {
+        "sidoName":  "충청남도",
+        "sigunguName":  "당진시"
+    },
+    {
+        "sidoName":  "충청남도",
+        "sigunguName":  "보령시"
+    },
+    {
+        "sidoName":  "충청남도",
+        "sigunguName":  "부여군"
+    },
+    {
+        "sidoName":  "충청남도",
+        "sigunguName":  "서산시"
+    },
+    {
+        "sidoName":  "충청남도",
+        "sigunguName":  "서천군"
+    },
+    {
+        "sidoName":  "충청남도",
+        "sigunguName":  "아산시"
+    },
+    {
+        "sidoName":  "충청남도",
+        "sigunguName":  "천안시"
+    },
+    {
+        "sidoName":  "충청남도",
+        "sigunguName":  "청양군"
+    },
+    {
+        "sidoName":  "충청남도",
+        "sigunguName":  "태안군"
+    },
+    {
+        "sidoName":  "충청남도",
+        "sigunguName":  "홍성군"
+    },
+    {
+        "sidoName":  "충청북도",
+        "sigunguName":  "괴산군"
+    },
+    {
+        "sidoName":  "충청북도",
+        "sigunguName":  "단양군"
+    },
+    {
+        "sidoName":  "충청북도",
+        "sigunguName":  "보은군"
+    },
+    {
+        "sidoName":  "충청북도",
+        "sigunguName":  "영동군"
+    },
+    {
+        "sidoName":  "충청북도",
+        "sigunguName":  "옥천군"
+    },
+    {
+        "sidoName":  "충청북도",
+        "sigunguName":  "음성군"
+    },
+    {
+        "sidoName":  "충청북도",
+        "sigunguName":  "제천시"
+    },
+    {
+        "sidoName":  "충청북도",
+        "sigunguName":  "증평군"
+    },
+    {
+        "sidoName":  "충청북도",
+        "sigunguName":  "진천군"
+    },
+    {
+        "sidoName":  "충청북도",
+        "sigunguName":  "충주시"
+    }
+]

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapper.kt
@@ -1,0 +1,177 @@
+package com.team.yeogibeoryeo.data.region
+
+import com.team.yeogibeoryeo.data.region.local.dto.AdministrativeRegionDto
+import com.team.yeogibeoryeo.data.region.local.dto.RegionalGuideRegionDto
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideRegionKeyNormalizer
+
+internal object RegionOptionsMapper {
+
+    fun getSidoOptions(
+        regionalGuideRegions: List<RegionalGuideRegionDto>
+    ): List<String> {
+        return regionalGuideRegions
+            .map { region -> region.sidoName }
+            .filter { sido -> sido.isNotBlank() }
+            .distinct()
+            .sorted()
+    }
+
+    fun getSigunguOptions(
+        regionalGuideRegions: List<RegionalGuideRegionDto>,
+        sido: String
+    ): List<String> {
+        return regionalGuideRegions
+            .filter { region -> region.sidoName == sido }
+            .map { region -> region.toDisplaySigunguName() }
+            .filter { sigungu -> sigungu.isNotBlank() }
+            .distinct()
+            .sorted()
+    }
+
+    fun getEupmyeondongOptions(
+        administrativeRegions: List<AdministrativeRegionDto>,
+        sido: String,
+        sigungu: String
+    ): List<String> {
+        return administrativeRegions
+            .filter { region ->
+                region.sidoName == sido &&
+                    region.toInfoSigunguOptionName() == sigungu
+            }
+            .map { region -> region.eupmyeondongName }
+            .filter { eupmyeondong -> eupmyeondong.isNotBlank() }
+            .distinct()
+            .sorted()
+    }
+
+    fun findSigunguRegions(
+        administrativeRegions: List<AdministrativeRegionDto>,
+        regionalGuideRegions: List<RegionalGuideRegionDto>,
+        keyword: String
+    ): List<Region> {
+        val targetKeyword = keyword.trim()
+        if (targetKeyword.isBlank()) return emptyList()
+
+        val regionalGuideMatches = regionalGuideRegions
+            .findByRegionName(targetKeyword) { region -> region.toDisplaySigunguName() }
+
+        if (regionalGuideMatches.isNotEmpty()) {
+            return regionalGuideMatches
+                .map { region -> region.toRegion() }
+                .distinctByRegion()
+                .sortedWith(REGION_NAME_COMPARATOR)
+        }
+
+        return administrativeRegions
+            .findByRegionName(targetKeyword) { region -> region.sigunguName }
+            .map { region -> region.toSigunguRegion() }
+            .distinctByRegion()
+            .sortedWith(REGION_NAME_COMPARATOR)
+    }
+
+    fun normalizeRegionForRegionalGuide(
+        region: Region,
+        regionalGuideRegions: List<RegionalGuideRegionDto>
+    ): Region {
+        val sido = region.sido?.trim()?.takeIf { sido -> sido.isNotBlank() }
+            ?: return region
+
+        if (sido == SEJONG_SIDO) {
+            return region.copy(
+                sido = sido,
+                sigungu = SEJONG_SIDO
+            )
+        }
+
+        val sigungu = region.sigungu
+            ?.trim()
+            ?.takeIf { sigungu -> sigungu.isNotBlank() }
+            ?: return region.copy(sido = sido)
+
+        val normalizedSigungu = RegionalGuideRegionKeyNormalizer.normalizeSigungu(sigungu)
+        val regionalGuideRegion = regionalGuideRegions.firstOrNull { regionalGuideRegion ->
+            regionalGuideRegion.sidoName == sido &&
+                regionalGuideRegion.sigunguName == normalizedSigungu
+        } ?: return region.copy(sido = sido)
+
+        return region.copy(
+            sido = sido,
+            sigungu = regionalGuideRegion.toDisplaySigunguName()
+        )
+    }
+
+    private fun RegionalGuideRegionDto.toDisplaySigunguName(): String {
+        return if (sidoName == SEJONG_SIDO && sigunguName == NO_SIGUNGU_NAME) {
+            sidoName
+        } else {
+            sigunguName
+        }
+    }
+
+    private fun AdministrativeRegionDto.toInfoSigunguOptionName(): String {
+        val sigungu = sigunguName.ifBlank {
+            return sidoName
+        }
+
+        return RegionalGuideRegionKeyNormalizer.normalizeSigungu(sigungu)
+    }
+
+    private fun RegionalGuideRegionDto.toRegion(): Region {
+        return RegionNormalizer.normalize(
+            Region(
+                sido = sidoName,
+                sigungu = sigunguName.ifBlank { null }
+            )
+        )
+    }
+
+    private fun AdministrativeRegionDto.toSigunguRegion(): Region {
+        return RegionNormalizer.normalize(
+            Region(
+                sido = sidoName,
+                sigungu = sigunguName.ifBlank { null },
+                eupmyeondong = null
+            )
+        )
+    }
+
+    private fun <T> List<T>.findByRegionName(
+        targetKeyword: String,
+        regionNameSelector: (T) -> String
+    ): List<T> {
+        val exactMatches = filter { region ->
+            regionNameSelector(region) == targetKeyword
+        }
+
+        val prefixMatches = exactMatches.ifEmpty {
+            filter { region ->
+                regionNameSelector(region).startsWith(targetKeyword)
+            }
+        }
+
+        return prefixMatches.ifEmpty {
+            filter { region ->
+                regionNameSelector(region).contains(targetKeyword)
+            }
+        }
+    }
+
+    private fun List<Region>.distinctByRegion(): List<Region> {
+        return distinctBy { region ->
+            listOf(
+                region.sido.orEmpty(),
+                region.sigungu.orEmpty()
+            )
+        }
+    }
+
+    private val REGION_NAME_COMPARATOR = compareBy<Region>(
+        { region -> region.sido.orEmpty() },
+        { region -> region.sigungu.orEmpty() },
+        { region -> region.eupmyeondong.orEmpty() }
+    )
+
+    private const val SEJONG_SIDO = "세종특별자치시"
+    private const val NO_SIGUNGU_NAME = "없음"
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapper.kt
@@ -37,7 +37,7 @@ internal object RegionOptionsMapper {
         return administrativeRegions
             .filter { region ->
                 region.sidoName == sido &&
-                    region.toInfoSigunguOptionName() == sigungu
+                    region.toInfoSigunguOptionName().isSameGuideSigunguName(sigungu)
             }
             .map { region -> region.eupmyeondongName }
             .filter { eupmyeondong -> eupmyeondong.isNotBlank() }
@@ -54,7 +54,7 @@ internal object RegionOptionsMapper {
         if (targetKeyword.isBlank()) return emptyList()
 
         val regionalGuideMatches = regionalGuideRegions
-            .findByRegionName(targetKeyword) { region -> region.toDisplaySigunguName() }
+            .findByGuideRegionName(targetKeyword)
 
         if (regionalGuideMatches.isNotEmpty()) {
             return regionalGuideMatches
@@ -92,7 +92,7 @@ internal object RegionOptionsMapper {
         val normalizedSigungu = RegionalGuideRegionKeyNormalizer.normalizeSigungu(sigungu)
         val regionalGuideRegion = regionalGuideRegions.firstOrNull { regionalGuideRegion ->
             regionalGuideRegion.sidoName == sido &&
-                regionalGuideRegion.sigunguName == normalizedSigungu
+                regionalGuideRegion.sigunguName.isSameGuideSigunguName(normalizedSigungu)
         } ?: return region.copy(sido = sido)
 
         return region.copy(
@@ -157,6 +157,42 @@ internal object RegionOptionsMapper {
         }
     }
 
+    private fun List<RegionalGuideRegionDto>.findByGuideRegionName(
+        targetKeyword: String
+    ): List<RegionalGuideRegionDto> {
+        val exactMatches = filter { region ->
+            region.toDisplaySigunguName().isSameGuideSigunguName(targetKeyword)
+        }
+
+        val normalizedKeyword = targetKeyword.toGuideSigunguCompareKey()
+        val prefixMatches = exactMatches.ifEmpty {
+            filter { region ->
+                region.toDisplaySigunguName()
+                    .toGuideSigunguCompareKey()
+                    .startsWith(normalizedKeyword)
+            }
+        }
+
+        return prefixMatches.ifEmpty {
+            filter { region ->
+                region.toDisplaySigunguName()
+                    .toGuideSigunguCompareKey()
+                    .contains(normalizedKeyword)
+            }
+        }
+    }
+
+    private fun String.isSameGuideSigunguName(
+        other: String
+    ): Boolean {
+        return this == other ||
+            toGuideSigunguCompareKey() == other.toGuideSigunguCompareKey()
+    }
+
+    private fun String.toGuideSigunguCompareKey(): String {
+        return trim().removeSuffix(CITY_SUFFIX)
+    }
+
     private fun List<Region>.distinctByRegion(): List<Region> {
         return distinctBy { region ->
             listOf(
@@ -174,4 +210,5 @@ internal object RegionOptionsMapper {
 
     private const val SEJONG_SIDO = "세종특별자치시"
     private const val NO_SIGUNGU_NAME = "없음"
+    private const val CITY_SUFFIX = "시"
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsRepositoryImpl.kt
@@ -1,51 +1,41 @@
 package com.team.yeogibeoryeo.data.region
 
 import com.team.yeogibeoryeo.data.region.local.RegionOptionsLocalDataSource
+import com.team.yeogibeoryeo.data.region.local.RegionalGuideRegionOptionsLocalDataSource
 import com.team.yeogibeoryeo.data.region.local.dto.AdministrativeRegionDto
 import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.region.repository.RegionOptionsRepository
 import javax.inject.Inject
 
 class RegionOptionsRepositoryImpl @Inject constructor(
-    private val localDataSource: RegionOptionsLocalDataSource
+    private val localDataSource: RegionOptionsLocalDataSource,
+    private val regionalGuideRegionOptionsLocalDataSource: RegionalGuideRegionOptionsLocalDataSource
 ) : RegionOptionsRepository {
 
     override suspend fun getSidoOptions(): List<String> {
-        return localDataSource.getRegions()
-            .map { region -> region.sidoName }
-            .filter { sido -> sido.isNotBlank() }
-            .distinct()
-            .sorted()
+        return RegionOptionsMapper.getSidoOptions(
+            regionalGuideRegions = regionalGuideRegionOptionsLocalDataSource.getRegions()
+        )
     }
 
     override suspend fun getSigunguOptions(
         sido: String
     ): List<String> {
-        return localDataSource.getRegions()
-            .filter { region -> region.sidoName == sido }
-            .map { region ->
-                region.sigunguName.ifBlank {
-                    region.sidoName
-                }
-            }
-            .filter { sigungu -> sigungu.isNotBlank() }
-            .distinct()
-            .sorted()
+        return RegionOptionsMapper.getSigunguOptions(
+            regionalGuideRegions = regionalGuideRegionOptionsLocalDataSource.getRegions(),
+            sido = sido
+        )
     }
 
     override suspend fun getEupmyeondongOptions(
         sido: String,
         sigungu: String
     ): List<String> {
-        return localDataSource.getRegions()
-            .filter { region ->
-                region.sidoName == sido &&
-                    region.sigunguName.ifBlank { region.sidoName } == sigungu
-            }
-            .map { region -> region.eupmyeondongName }
-            .filter { eupmyeondong -> eupmyeondong.isNotBlank() }
-            .distinct()
-            .sorted()
+        return RegionOptionsMapper.getEupmyeondongOptions(
+            administrativeRegions = localDataSource.getRegions(),
+            sido = sido,
+            sigungu = sigungu
+        )
     }
 
     override suspend fun findRegionsByEupmyeondongKeyword(
@@ -73,35 +63,20 @@ class RegionOptionsRepositoryImpl @Inject constructor(
     override suspend fun findRegionsBySigunguKeyword(
         keyword: String
     ): List<Region> {
-        val targetKeyword = keyword.trim()
-        if (targetKeyword.isBlank()) return emptyList()
+        return RegionOptionsMapper.findSigunguRegions(
+            administrativeRegions = localDataSource.getRegions(),
+            regionalGuideRegions = regionalGuideRegionOptionsLocalDataSource.getRegions(),
+            keyword = keyword
+        )
+    }
 
-        val regions = localDataSource.getRegions()
-        val exactMatches = regions.filter { region ->
-            region.sigunguName == targetKeyword
-        }
-
-        val prefixMatches = exactMatches.ifEmpty {
-            regions.filter { region ->
-                region.sigunguName.startsWith(targetKeyword)
-            }
-        }
-
-        val matchedRegions = prefixMatches.ifEmpty {
-            regions.filter { region ->
-                region.sigunguName.contains(targetKeyword)
-            }
-        }
-
-        return matchedRegions
-            .mapToSigunguRegion()
-            .distinctBy { region ->
-                listOf(
-                    region.sido.orEmpty(),
-                    region.sigungu.orEmpty()
-                )
-            }
-            .sortedWith(REGION_NAME_COMPARATOR)
+    override suspend fun normalizeRegionForRegionalGuide(
+        region: Region
+    ): Region {
+        return RegionOptionsMapper.normalizeRegionForRegionalGuide(
+            region = region,
+            regionalGuideRegions = regionalGuideRegionOptionsLocalDataSource.getRegions()
+        )
     }
 
     private fun List<AdministrativeRegionDto>.mapToRegion(): List<Region> {
@@ -116,19 +91,7 @@ class RegionOptionsRepositoryImpl @Inject constructor(
         }
     }
 
-    private fun List<AdministrativeRegionDto>.mapToSigunguRegion(): List<Region> {
-        return map { region ->
-            RegionNormalizer.normalize(
-                Region(
-                    sido = region.sidoName,
-                    sigungu = region.sigunguName.ifBlank { null },
-                    eupmyeondong = null
-                )
-            )
-        }
-    }
-
-    companion object {
+    private companion object {
         private val REGION_NAME_COMPARATOR = compareBy<Region>(
             { region -> region.sido.orEmpty() },
             { region -> region.sigungu.orEmpty() },

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/local/RegionalGuideRegionOptionsLocalDataSource.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/local/RegionalGuideRegionOptionsLocalDataSource.kt
@@ -1,0 +1,43 @@
+package com.team.yeogibeoryeo.data.region.local
+
+import android.content.Context
+import com.team.yeogibeoryeo.data.region.local.dto.RegionalGuideRegionDto
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+
+@Singleton
+class RegionalGuideRegionOptionsLocalDataSource @Inject constructor(
+    @param:ApplicationContext private val context: Context
+) {
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    private var cachedRegions: List<RegionalGuideRegionDto>? = null
+
+    suspend fun getRegions(): List<RegionalGuideRegionDto> {
+        return cachedRegions ?: loadRegions().also { regions ->
+            cachedRegions = regions
+        }
+    }
+
+    private suspend fun loadRegions(): List<RegionalGuideRegionDto> {
+        return withContext(Dispatchers.IO) {
+            val jsonText = context.assets
+                .open(REGIONAL_GUIDE_REGION_ASSET_PATH)
+                .bufferedReader()
+                .use { reader -> reader.readText() }
+
+            json.decodeFromString<List<RegionalGuideRegionDto>>(jsonText)
+        }
+    }
+
+    private companion object {
+        const val REGIONAL_GUIDE_REGION_ASSET_PATH = "region/regional_guide_regions.json"
+    }
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/local/dto/RegionalGuideRegionDto.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/local/dto/RegionalGuideRegionDto.kt
@@ -1,0 +1,9 @@
+package com.team.yeogibeoryeo.data.region.local.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegionalGuideRegionDto(
+    val sidoName: String,
+    val sigunguName: String
+)

--- a/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapperTest.kt
@@ -230,6 +230,84 @@ class RegionOptionsMapperTest {
     }
 
     @Test
+    fun `normalize region maps official city name to info key without city suffix`() {
+        val region = RegionOptionsMapper.normalizeRegionForRegionalGuide(
+            region = Region(
+                sido = "경기도",
+                sigungu = "남양주시",
+                eupmyeondong = "다산동"
+            ),
+            regionalGuideRegions = listOf(
+                RegionalGuideRegionDto(
+                    sidoName = "경기도",
+                    sigunguName = "남양주"
+                )
+            )
+        )
+
+        assertEquals(
+            Region(
+                sido = "경기도",
+                sigungu = "남양주",
+                eupmyeondong = "다산동"
+            ),
+            region
+        )
+    }
+
+    @Test
+    fun `eupmyeondong options map official city name to info key without city suffix`() {
+        val options = RegionOptionsMapper.getEupmyeondongOptions(
+            administrativeRegions = listOf(
+                administrativeRegion(
+                    sidoName = "경기도",
+                    sigunguName = "남양주시",
+                    eupmyeondongName = "다산동"
+                ),
+                administrativeRegion(
+                    sidoName = "경기도",
+                    sigunguName = "남양주시",
+                    eupmyeondongName = "별내동"
+                )
+            ),
+            sido = "경기도",
+            sigungu = "남양주"
+        )
+
+        assertEquals(listOf("다산동", "별내동"), options)
+    }
+
+    @Test
+    fun `sigungu keyword search maps official city keyword to info key without city suffix`() {
+        val regions = RegionOptionsMapper.findSigunguRegions(
+            administrativeRegions = listOf(
+                administrativeRegion(
+                    sidoName = "경기도",
+                    sigunguName = "동두천시",
+                    eupmyeondongName = "생연동"
+                )
+            ),
+            regionalGuideRegions = listOf(
+                RegionalGuideRegionDto(
+                    sidoName = "경기도",
+                    sigunguName = "동두천"
+                )
+            ),
+            keyword = "동두천시"
+        )
+
+        assertEquals(
+            listOf(
+                Region(
+                    sido = "경기도",
+                    sigungu = "동두천"
+                )
+            ),
+            regions
+        )
+    }
+
+    @Test
     fun `normalize region keeps original sigungu when info provided region does not exist`() {
         val region = RegionOptionsMapper.normalizeRegionForRegionalGuide(
             region = Region(

--- a/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapperTest.kt
@@ -1,0 +1,305 @@
+package com.team.yeogibeoryeo.data.region
+
+import com.team.yeogibeoryeo.data.region.local.dto.AdministrativeRegionDto
+import com.team.yeogibeoryeo.data.region.local.dto.RegionalGuideRegionDto
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideRegionKeyNormalizer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RegionOptionsMapperTest {
+
+    @Test
+    fun `sigungu options use regional guide info regions`() {
+        val options = RegionOptionsMapper.getSigunguOptions(
+            regionalGuideRegions = listOf(
+                RegionalGuideRegionDto(
+                    sidoName = "경기도",
+                    sigunguName = "성남시"
+                ),
+                RegionalGuideRegionDto(
+                    sidoName = "경기도",
+                    sigunguName = "수원시"
+                )
+            ),
+            sido = "경기도"
+        )
+
+        assertEquals(listOf("성남시", "수원시"), options)
+    }
+
+    @Test
+    fun `sigungu options do not expose administrative districts duplicated by info region`() {
+        val options = RegionOptionsMapper.getSigunguOptions(
+            regionalGuideRegions = listOf(
+                RegionalGuideRegionDto(
+                    sidoName = "경기도",
+                    sigunguName = "성남시"
+                ),
+                RegionalGuideRegionDto(
+                    sidoName = "경기도",
+                    sigunguName = "수원시"
+                )
+            ),
+            sido = "경기도"
+        )
+
+        assertEquals(false, "성남시 중원구" in options)
+        assertEquals(false, "수원시 장안구" in options)
+    }
+
+    @Test
+    fun `sejong sigungu option is displayed as sejong name instead of none`() {
+        val options = RegionOptionsMapper.getSigunguOptions(
+            regionalGuideRegions = listOf(
+                RegionalGuideRegionDto(
+                    sidoName = "세종특별자치시",
+                    sigunguName = "없음"
+                )
+            ),
+            sido = "세종특별자치시"
+        )
+
+        assertEquals(listOf("세종특별자치시"), options)
+    }
+
+    @Test
+    fun `eupmyeondong options map administrative district sigungu to info sigungu`() {
+        val options = RegionOptionsMapper.getEupmyeondongOptions(
+            administrativeRegions = listOf(
+                administrativeRegion(
+                    sidoName = "경기도",
+                    sigunguName = "수원시 장안구",
+                    eupmyeondongName = "파장동"
+                ),
+                administrativeRegion(
+                    sidoName = "경기도",
+                    sigunguName = "수원시 영통구",
+                    eupmyeondongName = "망포동"
+                ),
+                administrativeRegion(
+                    sidoName = "경기도",
+                    sigunguName = "성남시 중원구",
+                    eupmyeondongName = "중앙동"
+                )
+            ),
+            sido = "경기도",
+            sigungu = "수원시"
+        )
+
+        assertEquals(listOf("망포동", "파장동"), options)
+    }
+
+    @Test
+    fun `eupmyeondong options map sejong administrative regions to sejong display sigungu`() {
+        val options = RegionOptionsMapper.getEupmyeondongOptions(
+            administrativeRegions = listOf(
+                administrativeRegion(
+                    sidoName = "세종특별자치시",
+                    sigunguName = "",
+                    eupmyeondongName = "한솔동"
+                )
+            ),
+            sido = "세종특별자치시",
+            sigungu = "세종특별자치시"
+        )
+
+        assertEquals(listOf("한솔동"), options)
+    }
+
+    @Test
+    fun `sigungu keyword search prefers info provided city region over administrative districts`() {
+        val regions = RegionOptionsMapper.findSigunguRegions(
+            administrativeRegions = listOf(
+                administrativeRegion(
+                    sidoName = "경기도",
+                    sigunguName = "성남시 중원구",
+                    eupmyeondongName = "중앙동"
+                ),
+                administrativeRegion(
+                    sidoName = "경기도",
+                    sigunguName = "성남시 분당구",
+                    eupmyeondongName = "분당동"
+                )
+            ),
+            regionalGuideRegions = listOf(
+                RegionalGuideRegionDto(
+                    sidoName = "경기도",
+                    sigunguName = "성남시"
+                )
+            ),
+            keyword = "성남시"
+        )
+
+        assertEquals(
+            listOf(
+                Region(
+                    sido = "경기도",
+                    sigungu = "성남시"
+                )
+            ),
+            regions
+        )
+    }
+
+    @Test
+    fun `sigungu keyword search falls back to administrative district when info region does not exist`() {
+        val regions = RegionOptionsMapper.findSigunguRegions(
+            administrativeRegions = listOf(
+                administrativeRegion(
+                    sidoName = "경기도",
+                    sigunguName = "성남시 중원구",
+                    eupmyeondongName = "중앙동"
+                ),
+                administrativeRegion(
+                    sidoName = "경기도",
+                    sigunguName = "성남시 중원구",
+                    eupmyeondongName = "성남동"
+                )
+            ),
+            regionalGuideRegions = listOf(
+                RegionalGuideRegionDto(
+                    sidoName = "경기도",
+                    sigunguName = "성남시"
+                )
+            ),
+            keyword = "중원구"
+        )
+
+        assertEquals(
+            listOf(
+                Region(
+                    sido = "경기도",
+                    sigungu = "성남시 중원구",
+                    eupmyeondong = null
+                )
+            ),
+            regions
+        )
+    }
+
+    @Test
+    fun `sigungu keyword search maps administrative district to upper info query key`() {
+        val regions = RegionOptionsMapper.findSigunguRegions(
+            administrativeRegions = listOf(
+                administrativeRegion(
+                    sidoName = "경기도",
+                    sigunguName = "성남시 분당구",
+                    eupmyeondongName = "분당동"
+                )
+            ),
+            regionalGuideRegions = listOf(
+                RegionalGuideRegionDto(
+                    sidoName = "경기도",
+                    sigunguName = "성남시"
+                )
+            ),
+            keyword = "분당구"
+        )
+
+        assertEquals(
+            "성남시",
+            RegionalGuideRegionKeyNormalizer.normalizeSigungu(regions.first().sigungu.orEmpty())
+        )
+    }
+
+    @Test
+    fun `normalize region maps administrative district to info provided sigungu`() {
+        val region = RegionOptionsMapper.normalizeRegionForRegionalGuide(
+            region = Region(
+                sido = "경기도",
+                sigungu = "성남시 중원구",
+                eupmyeondong = "중앙동"
+            ),
+            regionalGuideRegions = listOf(
+                RegionalGuideRegionDto(
+                    sidoName = "경기도",
+                    sigunguName = "성남시"
+                )
+            )
+        )
+
+        assertEquals(
+            Region(
+                sido = "경기도",
+                sigungu = "성남시",
+                eupmyeondong = "중앙동"
+            ),
+            region
+        )
+    }
+
+    @Test
+    fun `normalize region keeps original sigungu when info provided region does not exist`() {
+        val region = RegionOptionsMapper.normalizeRegionForRegionalGuide(
+            region = Region(
+                sido = "경기도",
+                sigungu = "중원구",
+                eupmyeondong = null
+            ),
+            regionalGuideRegions = listOf(
+                RegionalGuideRegionDto(
+                    sidoName = "경기도",
+                    sigunguName = "성남시"
+                )
+            )
+        )
+
+        assertEquals(
+            Region(
+                sido = "경기도",
+                sigungu = "중원구",
+                eupmyeondong = null
+            ),
+            region
+        )
+    }
+
+    @Test
+    fun `normalize sejong region uses sejong display sigungu`() {
+        val region = RegionOptionsMapper.normalizeRegionForRegionalGuide(
+            region = Region(
+                sido = "세종특별자치시",
+                sigungu = null,
+                eupmyeondong = "한솔동"
+            ),
+            regionalGuideRegions = listOf(
+                RegionalGuideRegionDto(
+                    sidoName = "세종특별자치시",
+                    sigunguName = "없음"
+                )
+            )
+        )
+
+        assertEquals(
+            Region(
+                sido = "세종특별자치시",
+                sigungu = "세종특별자치시",
+                eupmyeondong = "한솔동"
+            ),
+            region
+        )
+    }
+
+    private fun administrativeRegion(
+        sidoName: String,
+        sigunguName: String,
+        eupmyeondongName: String
+    ): AdministrativeRegionDto {
+        val fullName = listOf(
+            sidoName,
+            sigunguName,
+            eupmyeondongName
+        )
+            .filter { regionName -> regionName.isNotBlank() }
+            .joinToString(" ")
+
+        return AdministrativeRegionDto(
+            adminCode = "",
+            sidoName = sidoName,
+            sigunguName = sigunguName,
+            eupmyeondongName = eupmyeondongName,
+            fullName = fullName
+        )
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/repository/RegionOptionsRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/repository/RegionOptionsRepository.kt
@@ -22,4 +22,8 @@ interface RegionOptionsRepository {
     suspend fun findRegionsBySigunguKeyword(
         keyword: String
     ): List<Region>
+
+    suspend fun normalizeRegionForRegionalGuide(
+        region: Region
+    ): Region
 }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/NormalizeRegionForRegionalGuideUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/NormalizeRegionForRegionalGuideUseCase.kt
@@ -1,0 +1,13 @@
+package com.team.yeogibeoryeo.domain.region.usecase
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.region.repository.RegionOptionsRepository
+import javax.inject.Inject
+
+class NormalizeRegionForRegionalGuideUseCase @Inject constructor(
+    private val repository: RegionOptionsRepository
+) {
+    suspend operator fun invoke(region: Region): Region {
+        return repository.normalizeRegionForRegionalGuide(region)
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCase.kt
@@ -52,6 +52,7 @@ class ResolveRegionFromKeywordUseCase @Inject constructor(
         return when {
             candidates.size == 1 -> ResolveRegionFromKeywordResult.Resolved(candidates.first())
             candidates.hasExactSigunguMatch(sigungu) -> ResolveRegionFromKeywordResult.Ambiguous(candidates)
+            sigungu.isAdministrativeDistrictName() -> ResolveRegionFromKeywordResult.NotFound
             else -> ResolveRegionFromKeywordResult.Resolved(parsedRegion)
         }
     }
@@ -69,7 +70,12 @@ class ResolveRegionFromKeywordUseCase @Inject constructor(
             !sigungu.isNullOrBlank() &&
             eupmyeondong.isNullOrBlank()
 
+    private fun String.isAdministrativeDistrictName(): Boolean =
+        endsWith(ADMINISTRATIVE_DISTRICT_SUFFIX)
+
     private companion object {
+        const val ADMINISTRATIVE_DISTRICT_SUFFIX = "구"
+
         val REGION_CANDIDATE_COMPARATOR = compareBy<Region>(
             { region -> region.sido.orEmpty() },
             { region -> region.sigungu.orEmpty() },

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalGuideRegionKeyNormalizer.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalGuideRegionKeyNormalizer.kt
@@ -1,0 +1,25 @@
+package com.team.yeogibeoryeo.domain.regionalguide.model
+
+object RegionalGuideRegionKeyNormalizer {
+
+    fun normalizeSigungu(sigungu: String): String {
+        val trimmedSigungu = sigungu.trim()
+        val firstToken = trimmedSigungu.split(Regex("\\s+"))
+            .firstOrNull()
+            ?.takeIf { token -> token.endsWith(CITY_SUFFIX) }
+
+        if (firstToken != null) return firstToken
+
+        val cityIndex = trimmedSigungu.indexOf(CITY_SUFFIX)
+        val districtIndex = trimmedSigungu.indexOf(DISTRICT_SUFFIX)
+
+        return if (cityIndex > 0 && districtIndex > cityIndex) {
+            trimmedSigungu.substring(startIndex = 0, endIndex = cityIndex + CITY_SUFFIX.length)
+        } else {
+            trimmedSigungu
+        }
+    }
+
+    private const val CITY_SUFFIX = "시"
+    private const val DISTRICT_SUFFIX = "구"
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/NormalizeRegionalGuideQueryUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/NormalizeRegionalGuideQueryUseCase.kt
@@ -1,6 +1,7 @@
 package com.team.yeogibeoryeo.domain.regionalguide.usecase
 
 import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideRegionKeyNormalizer
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideQuery
 import javax.inject.Inject
 
@@ -21,25 +22,8 @@ class NormalizeRegionalGuideQueryUseCase @Inject constructor() {
 
         return RegionalGuideQuery(
             displayRegion = region,
-            sigunguQuery = sigungu.toInfoSigunguQuery()
+            sigunguQuery = RegionalGuideRegionKeyNormalizer.normalizeSigungu(sigungu)
         )
-    }
-
-    private fun String.toInfoSigunguQuery(): String {
-        val firstToken = split(Regex("\\s+"))
-            .firstOrNull()
-            ?.takeIf { token -> token.endsWith("시") }
-
-        if (firstToken != null) return firstToken
-
-        val cityIndex = indexOf("시")
-        val guIndex = indexOf("구")
-
-        return if (cityIndex > 0 && guIndex > cityIndex) {
-            substring(startIndex = 0, endIndex = cityIndex + 1)
-        } else {
-            this
-        }
     }
 
     private companion object {

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
@@ -28,6 +28,12 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
             )
         }
 
+        filteredCandidates.selectSingleOverallCandidate(query.sigunguQuery)?.let { guide ->
+            return RegionalGuideLookupResult.Success(
+                guide = guide.withDisplayRegion(query.displayRegion)
+            )
+        }
+
         val selectedGuide = selectByTargetRegion(
             candidates = filteredCandidates,
             requestedRegion = query.displayRegion,
@@ -74,6 +80,25 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
         }
 
         return null
+    }
+
+    private fun List<RegionalDisposalGuide>.selectSingleOverallCandidate(
+        sigunguQuery: String
+    ): RegionalDisposalGuide? {
+        val targetRegionNames = map { guide ->
+            guide.targetRegionName
+                ?.trim()
+                .orEmpty()
+        }.distinct()
+
+        return if (
+            targetRegionNames.size == 1 &&
+            targetRegionNames.single().isOverallTarget(sigunguQuery)
+        ) {
+            firstOrNull()
+        } else {
+            null
+        }
     }
 
     private fun List<RegionalDisposalGuide>.toCandidateResultOrNotFound(

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/region/usecase/NormalizeRegionForRegionalGuideUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/region/usecase/NormalizeRegionForRegionalGuideUseCaseTest.kt
@@ -1,0 +1,58 @@
+package com.team.yeogibeoryeo.domain.region.usecase
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.region.repository.RegionOptionsRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NormalizeRegionForRegionalGuideUseCaseTest {
+
+    @Test
+    fun `normalizes administrative region through repository`() = runBlocking {
+        val normalizedRegion = Region(
+            sido = "경기도",
+            sigungu = "성남시",
+            eupmyeondong = "중앙동"
+        )
+        val useCase = NormalizeRegionForRegionalGuideUseCase(
+            repository = FakeRegionOptionsRepository(normalizedRegion)
+        )
+
+        val result = useCase(
+            Region(
+                sido = "경기도",
+                sigungu = "성남시 중원구",
+                eupmyeondong = "중앙동"
+            )
+        )
+
+        assertEquals(normalizedRegion, result)
+    }
+
+    private class FakeRegionOptionsRepository(
+        private val normalizedRegion: Region
+    ) : RegionOptionsRepository {
+
+        override suspend fun getSidoOptions(): List<String> = emptyList()
+
+        override suspend fun getSigunguOptions(sido: String): List<String> = emptyList()
+
+        override suspend fun getEupmyeondongOptions(
+            sido: String,
+            sigungu: String
+        ): List<String> = emptyList()
+
+        override suspend fun findRegionsByEupmyeondongKeyword(
+            keyword: String
+        ): List<Region> = emptyList()
+
+        override suspend fun findRegionsBySigunguKeyword(
+            keyword: String
+        ): List<Region> = emptyList()
+
+        override suspend fun normalizeRegionForRegionalGuide(
+            region: Region
+        ): Region = normalizedRegion
+    }
+}

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/region/usecase/ResolveRegionFromKeywordUseCaseTest.kt
@@ -237,6 +237,56 @@ class ResolveRegionFromKeywordUseCaseTest {
     }
 
     @Test
+    fun `행정구 단독 검색어가 행정구역 후보에 없으면 NotFound를 반환한다`() = runBlocking {
+        val useCase = ResolveRegionFromKeywordUseCase(
+            repository = FakeRegionRepository(
+                resolvedRegion = Region(sigungu = "중안구")
+            ),
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                regions = listOf(
+                    Region(
+                        sido = "경기도",
+                        sigungu = "성남시 중원구"
+                    ),
+                    Region(
+                        sido = "경기도",
+                        sigungu = "수원시 장안구"
+                    )
+                )
+            )
+        )
+
+        val result = useCase("중안구")
+
+        assertEquals(ResolveRegionFromKeywordResult.NotFound, result)
+    }
+
+    @Test
+    fun `행정구 단독 검색어가 행정구역 후보에 있으면 상위 지역을 보완한다`() = runBlocking {
+        val useCase = ResolveRegionFromKeywordUseCase(
+            repository = FakeRegionRepository(
+                resolvedRegion = Region(sigungu = "중원구")
+            ),
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                regions = listOf(
+                    Region(
+                        sido = "경기도",
+                        sigungu = "성남시 중원구"
+                    )
+                )
+            )
+        )
+
+        val result = useCase("중원구")
+
+        val region = (result as ResolveRegionFromKeywordResult.Resolved).region
+
+        assertEquals("경기도", region.sido)
+        assertEquals("성남시 중원구", region.sigungu)
+        assertEquals(null, region.eupmyeondong)
+    }
+
+    @Test
     fun `시도 없는 동일 시군구 후보가 여러 개면 임의로 보완하지 않는다`() = runBlocking {
         val useCase = ResolveRegionFromKeywordUseCase(
             repository = FakeRegionRepository(
@@ -396,5 +446,9 @@ class ResolveRegionFromKeywordUseCaseTest {
                     )
                 }
         }
+
+        override suspend fun normalizeRegionForRegionalGuide(
+            region: Region
+        ): Region = region
     }
 }

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalGuideRegionKeyNormalizerTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalGuideRegionKeyNormalizerTest.kt
@@ -1,0 +1,31 @@
+package com.team.yeogibeoryeo.domain.regionalguide.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RegionalGuideRegionKeyNormalizerTest {
+
+    @Test
+    fun `administrative district sigungu is normalized to info sigungu key`() {
+        assertEquals(
+            "수원시",
+            RegionalGuideRegionKeyNormalizer.normalizeSigungu("수원시 장안구")
+        )
+        assertEquals(
+            "성남시",
+            RegionalGuideRegionKeyNormalizer.normalizeSigungu("성남시 중원구")
+        )
+    }
+
+    @Test
+    fun `normal sigungu is kept as info sigungu key`() {
+        assertEquals(
+            "중구",
+            RegionalGuideRegionKeyNormalizer.normalizeSigungu("중구")
+        )
+        assertEquals(
+            "울주군",
+            RegionalGuideRegionKeyNormalizer.normalizeSigungu("울주군")
+        )
+    }
+}

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
@@ -227,6 +227,25 @@ class SelectRegionalGuideCandidateUseCaseTest {
     }
 
     @Test
+    fun `읍면동 없이 복수 후보의 대상지역이 모두 전체 적용이면 대표 후보를 선택한다`() {
+        val result = useCase(
+            candidates = listOf(
+                guide(sido = "경기도", sigungu = "성남시", targetRegionName = "없음"),
+                guide(sido = "경기도", sigungu = "성남시", targetRegionName = "없음")
+            ),
+            query = query(
+                displayRegion = Region(sido = "경기도", sigungu = "성남시"),
+                sigunguQuery = "성남시"
+            )
+        )
+
+        val guide = (result as RegionalGuideLookupResult.Success).guide
+
+        assertEquals("성남시", guide.region.sigungu)
+        assertEquals("없음", guide.targetRegionName)
+    }
+
+    @Test
     fun `조회 key와 일치하는 시군구 후보가 없으면 CandidateNotFound를 반환한다`() {
         val result = useCase(
             candidates = listOf(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionSelectorUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionSelectorUiState.kt
@@ -7,6 +7,7 @@ data class RegionSelectorUiState(
     val selectedSido: String? = null,
     val selectedSigungu: String? = null,
     val selectedEupmyeondong: String? = null,
+    val expandedDropdown: RegionSelectorDropdown? = null,
 ) {
     val selectedRegionText: String?
         get() = selectedRegionParts
@@ -29,4 +30,10 @@ data class RegionSelectorUiState(
             selectedSigungu,
             selectedEupmyeondong,
         )
+}
+
+enum class RegionSelectorDropdown {
+    SIDO,
+    SIGUNGU,
+    EUPMYEONDONG,
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
@@ -69,11 +69,13 @@ fun RegionalGuideRoute(
         searchKeyword = searchKeyword,
         regionSelectorUiState = regionSelectorUiState,
         onSearchKeywordChange = viewModel::onSearchKeywordChanged,
-        onSearchClick = viewModel::searchCurrentKeyword,
+        onSearchClick = viewModel::searchByKeyword,
         onRetryClick = viewModel::retryLastRequest,
         onSidoSelected = viewModel::onSidoSelected,
         onSigunguSelected = viewModel::onSigunguSelected,
         onEupmyeondongSelected = viewModel::onEupmyeondongSelected,
+        onRegionSelectorDropdownExpanded = viewModel::onRegionSelectorDropdownExpanded,
+        onRegionSelectorDropdownDismissed = viewModel::onRegionSelectorDropdownDismissed,
         onRegionSelectionSearchClick = viewModel::onRegionSelectionSearchClick,
         onCandidateClick = viewModel::onRegionCandidateSelected,
         onGuideCandidateClick = viewModel::onRegionalGuideCandidateSelected,
@@ -87,11 +89,13 @@ fun RegionalGuideScreen(
     searchKeyword: String,
     regionSelectorUiState: RegionSelectorUiState,
     onSearchKeywordChange: (String) -> Unit,
-    onSearchClick: () -> Unit,
+    onSearchClick: (String) -> Unit,
     onRetryClick: () -> Unit,
     onSidoSelected: (String) -> Unit,
     onSigunguSelected: (String) -> Unit,
     onEupmyeondongSelected: (String) -> Unit,
+    onRegionSelectorDropdownExpanded: (RegionSelectorDropdown) -> Unit = {},
+    onRegionSelectorDropdownDismissed: () -> Unit = {},
     onRegionSelectionSearchClick: () -> Unit,
     onCandidateClick: (RegionSearchCandidateUiModel) -> Unit,
     onGuideCandidateClick: (RegionalGuideCandidateUiModel) -> Unit,
@@ -113,6 +117,12 @@ fun RegionalGuideScreen(
             uiState !is RegionalGuideUiState.GuideCandidates &&
             !isRegionSelectorExpanded &&
             compactRegionText != null
+
+    LaunchedEffect(uiState) {
+        if (uiState is RegionalGuideUiState.Loading) {
+            isRegionSelectorExpanded = false
+        }
+    }
 
     Column(
         modifier = modifier
@@ -145,20 +155,32 @@ fun RegionalGuideScreen(
             RegionalGuideSearchBar(
                 keyword = searchKeyword,
                 onKeywordChange = onSearchKeywordChange,
-                onSearchClick = onSearchClick,
+                onSearchClick = { submittedKeyword ->
+                    isRegionSelectorExpanded = false
+                    onRegionSelectorDropdownDismissed()
+                    onSearchClick(submittedKeyword)
+                },
                 candidateContent = if (hasSearchCandidates) {
                     {
                         if (ambiguousState != null) {
                             RegionalGuideAmbiguousResult(
                                 candidates = ambiguousState.candidates,
-                                onCandidateClick = onCandidateClick,
+                                onCandidateClick = { candidate ->
+                                    isRegionSelectorExpanded = false
+                                    onRegionSelectorDropdownDismissed()
+                                    onCandidateClick(candidate)
+                                },
                             )
                         }
 
                         if (guideCandidatesState != null) {
                             RegionalGuideCandidateResult(
                                 candidates = guideCandidatesState.candidates,
-                                onCandidateClick = onGuideCandidateClick,
+                                onCandidateClick = { candidate ->
+                                    isRegionSelectorExpanded = false
+                                    onRegionSelectorDropdownDismissed()
+                                    onGuideCandidateClick(candidate)
+                                },
                             )
                         }
                     }
@@ -176,8 +198,11 @@ fun RegionalGuideScreen(
                 onSidoSelected = onSidoSelected,
                 onSigunguSelected = onSigunguSelected,
                 onEupmyeondongSelected = onEupmyeondongSelected,
+                onDropdownExpanded = onRegionSelectorDropdownExpanded,
+                onDropdownDismissed = onRegionSelectorDropdownDismissed,
                 onSearchClick = {
                     isRegionSelectorExpanded = false
+                    onRegionSelectorDropdownDismissed()
                     onRegionSelectionSearchClick()
                 },
                 onChangeClick = {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
@@ -7,6 +7,7 @@ import com.team.yeogibeoryeo.domain.region.usecase.ExtractRegionFromAddressUseCa
 import com.team.yeogibeoryeo.domain.region.usecase.GetEupmyeondongOptionsUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.GetSidoOptionsUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.GetSigunguOptionsUseCase
+import com.team.yeogibeoryeo.domain.region.usecase.NormalizeRegionForRegionalGuideUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.ResolveRegionFromKeywordUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.ResolveRegionFromKeywordResult
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideFailureReason
@@ -34,7 +35,8 @@ class RegionalGuideViewModel @Inject constructor(
     private val getRegionalDisposalGuideUseCase: GetRegionalDisposalGuideUseCase,
     private val getSidoOptionsUseCase: GetSidoOptionsUseCase,
     private val getSigunguOptionsUseCase: GetSigunguOptionsUseCase,
-    private val getEupmyeondongOptionsUseCase: GetEupmyeondongOptionsUseCase
+    private val getEupmyeondongOptionsUseCase: GetEupmyeondongOptionsUseCase,
+    private val normalizeRegionForRegionalGuideUseCase: NormalizeRegionForRegionalGuideUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<RegionalGuideUiState>(RegionalGuideUiState.Idle)
@@ -73,7 +75,8 @@ class RegionalGuideViewModel @Inject constructor(
                 selectedSigungu = null,
                 selectedEupmyeondong = null,
                 sigunguOptions = emptyList(),
-                eupmyeondongOptions = emptyList()
+                eupmyeondongOptions = emptyList(),
+                expandedDropdown = null
             )
         }
 
@@ -99,7 +102,8 @@ class RegionalGuideViewModel @Inject constructor(
             state.copy(
                 selectedSigungu = sigungu,
                 selectedEupmyeondong = null,
-                eupmyeondongOptions = emptyList()
+                eupmyeondongOptions = emptyList(),
+                expandedDropdown = null
             )
         }
 
@@ -122,12 +126,25 @@ class RegionalGuideViewModel @Inject constructor(
     fun onEupmyeondongSelected(eupmyeondong: String) {
         _regionSelectorUiState.update { state ->
             state.copy(
-                selectedEupmyeondong = eupmyeondong
+                selectedEupmyeondong = eupmyeondong,
+                expandedDropdown = null
             )
         }
     }
 
+    fun onRegionSelectorDropdownExpanded(dropdown: RegionSelectorDropdown) {
+        _regionSelectorUiState.update { state ->
+            state.copy(expandedDropdown = dropdown)
+        }
+    }
+
+    fun onRegionSelectorDropdownDismissed() {
+        collapseRegionSelectorDropdowns()
+    }
+
     fun onRegionSelectionSearchClick() {
+        collapseRegionSelectorDropdowns()
+
         val state = regionSelectorUiState.value
         val selectedSido = state.selectedSido
         val selectedSigungu = state.selectedSigungu
@@ -172,8 +189,9 @@ class RegionalGuideViewModel @Inject constructor(
     fun onRegionCandidateSelected(candidate: RegionSearchCandidateUiModel) {
         if (!candidate.isValid) return
 
+        _searchKeyword.value = candidate.displayText
+
         val region = candidate.toRegion()
-        applyRegionSelection(region)
         searchBySelectedRegion(
             query = candidate.displayText,
             region = region
@@ -198,8 +216,10 @@ class RegionalGuideViewModel @Inject constructor(
     fun searchByKeyword(keyword: String) {
         val trimmedKeyword = keyword.trim()
 
+        _searchKeyword.value = keyword
         keywordSuggestionJob?.cancel()
         guideLookupJob?.cancel()
+        collapseRegionSelectorDropdowns()
 
         if (trimmedKeyword.isBlank()) {
             _uiState.value = RegionalGuideUiState.Empty(
@@ -212,6 +232,7 @@ class RegionalGuideViewModel @Inject constructor(
         lastRequest = RegionalGuideRequest.Keyword(trimmedKeyword)
 
         guideLookupJob = viewModelScope.launch {
+            clearSelectedRegion()
             _uiState.value = RegionalGuideUiState.Loading(query = trimmedKeyword)
 
             try {
@@ -233,10 +254,10 @@ class RegionalGuideViewModel @Inject constructor(
                     }
 
                     is ResolveRegionFromKeywordResult.Resolved -> {
-                        applyRegionSelection(result.region)
+                        val regionalGuideRegion = normalizeAndApplyRegionSelection(result.region)
                         loadRegionalGuide(
                             query = trimmedKeyword,
-                            region = result.region
+                            region = regionalGuideRegion
                         )
                     }
                 }
@@ -281,10 +302,10 @@ class RegionalGuideViewModel @Inject constructor(
                     return@launch
                 }
 
-                applyRegionSelection(region)
+                val regionalGuideRegion = normalizeAndApplyRegionSelection(region)
                 loadRegionalGuide(
                     query = trimmedAddress,
-                    region = region
+                    region = regionalGuideRegion
                 )
             } catch (e: CancellationException) {
                 throw e
@@ -372,19 +393,22 @@ class RegionalGuideViewModel @Inject constructor(
     ) {
         keywordSuggestionJob?.cancel()
         guideLookupJob?.cancel()
-
-        lastRequest = RegionalGuideRequest.SelectedRegion(
-            query = query,
-            region = region
-        )
+        collapseRegionSelectorDropdowns()
 
         guideLookupJob = viewModelScope.launch {
-            _uiState.value = RegionalGuideUiState.Loading(query = query)
-
             try {
+                val regionalGuideRegion = normalizeAndApplyRegionSelection(region)
+
+                lastRequest = RegionalGuideRequest.SelectedRegion(
+                    query = query,
+                    region = regionalGuideRegion
+                )
+
+                _uiState.value = RegionalGuideUiState.Loading(query = query)
+
                 loadRegionalGuide(
                     query = query,
-                    region = region
+                    region = regionalGuideRegion
                 )
             } catch (e: CancellationException) {
                 throw e
@@ -394,6 +418,30 @@ class RegionalGuideViewModel @Inject constructor(
                     message = e.message ?: "선택한 지역의 배출 가이드를 조회하는 중 오류가 발생했습니다."
                 )
             }
+        }
+    }
+
+    private suspend fun normalizeAndApplyRegionSelection(region: Region): Region {
+        val regionalGuideRegion = normalizeRegionForRegionalGuideUseCase(region)
+
+        applyRegionSelection(regionalGuideRegion)
+
+        return regionalGuideRegion
+    }
+
+    private fun clearSelectedRegion() {
+        sigunguOptionsJob?.cancel()
+        eupmyeondongOptionsJob?.cancel()
+
+        _regionSelectorUiState.update { state ->
+            state.copy(
+                selectedSido = null,
+                selectedSigungu = null,
+                selectedEupmyeondong = null,
+                sigunguOptions = emptyList(),
+                eupmyeondongOptions = emptyList(),
+                expandedDropdown = null
+            )
         }
     }
 
@@ -410,7 +458,8 @@ class RegionalGuideViewModel @Inject constructor(
                 selectedSigungu = selectedSigungu,
                 selectedEupmyeondong = region.eupmyeondong,
                 sigunguOptions = emptyList(),
-                eupmyeondongOptions = emptyList()
+                eupmyeondongOptions = emptyList(),
+                expandedDropdown = null
             )
         }
 
@@ -527,6 +576,16 @@ class RegionalGuideViewModel @Inject constructor(
             sigungu = sigungu,
             eupmyeondong = eupmyeondong
         )
+
+    private fun collapseRegionSelectorDropdowns() {
+        _regionSelectorUiState.update { state ->
+            if (state.expandedDropdown == null) {
+                state
+            } else {
+                state.copy(expandedDropdown = null)
+            }
+        }
+    }
 
     private sealed interface RegionalGuideRequest {
         data class Keyword(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionSelectorSection.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionSelectorSection.kt
@@ -20,10 +20,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import com.team.yeogibeoryeo.presentation.regionalguide.RegionSelectorDropdown
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -39,6 +36,8 @@ fun RegionSelectorSection(
     onSidoSelected: (String) -> Unit,
     onSigunguSelected: (String) -> Unit,
     onEupmyeondongSelected: (String) -> Unit,
+    onDropdownExpanded: (RegionSelectorDropdown) -> Unit = {},
+    onDropdownDismissed: () -> Unit = {},
     onSearchClick: () -> Unit,
     onChangeClick: () -> Unit = {},
     modifier: Modifier = Modifier,
@@ -73,6 +72,9 @@ fun RegionSelectorSection(
                 RegionDropdownChip(
                     label = uiState.selectedSido ?: "시도 선택",
                     options = uiState.sidoOptions,
+                    expanded = uiState.expandedDropdown == RegionSelectorDropdown.SIDO,
+                    onExpanded = { onDropdownExpanded(RegionSelectorDropdown.SIDO) },
+                    onDismissed = onDropdownDismissed,
                     onOptionSelected = onSidoSelected,
                     modifier = Modifier.weight(1f),
                 )
@@ -81,6 +83,9 @@ fun RegionSelectorSection(
                     label = uiState.selectedSigungu ?: "시군구 선택",
                     options = uiState.sigunguOptions,
                     enabled = uiState.isSigunguSelectionEnabled,
+                    expanded = uiState.expandedDropdown == RegionSelectorDropdown.SIGUNGU,
+                    onExpanded = { onDropdownExpanded(RegionSelectorDropdown.SIGUNGU) },
+                    onDismissed = onDropdownDismissed,
                     onOptionSelected = onSigunguSelected,
                     modifier = Modifier.weight(1f),
                 )
@@ -90,6 +95,9 @@ fun RegionSelectorSection(
                 label = uiState.selectedEupmyeondong ?: "읍면동 선택",
                 options = uiState.eupmyeondongOptions,
                 enabled = uiState.isEupmyeondongSelectionEnabled,
+                expanded = uiState.expandedDropdown == RegionSelectorDropdown.EUPMYEONDONG,
+                onExpanded = { onDropdownExpanded(RegionSelectorDropdown.EUPMYEONDONG) },
+                onDismissed = onDropdownDismissed,
                 onOptionSelected = onEupmyeondongSelected,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -181,12 +189,13 @@ private fun RegionSelectorCompactCard(
 private fun RegionDropdownChip(
     label: String,
     options: List<String>,
+    expanded: Boolean,
+    onExpanded: () -> Unit,
+    onDismissed: () -> Unit,
     onOptionSelected: (String) -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
 ) {
-    var expanded by remember { mutableStateOf(false) }
-
     Column(
         modifier = modifier,
     ) {
@@ -196,7 +205,7 @@ private fun RegionDropdownChip(
             enabled = enabled,
             onClick = {
                 if (options.isNotEmpty()) {
-                    expanded = true
+                    onExpanded()
                 }
             },
             label = {
@@ -219,9 +228,7 @@ private fun RegionDropdownChip(
 
         DropdownMenu(
             expanded = expanded,
-            onDismissRequest = {
-                expanded = false
-            },
+            onDismissRequest = onDismissed,
         ) {
             options.forEach { option ->
                 DropdownMenuItem(
@@ -230,7 +237,6 @@ private fun RegionDropdownChip(
                     },
                     onClick = {
                         onOptionSelected(option)
-                        expanded = false
                     },
                 )
             }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionSelectorSection.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionSelectorSection.kt
@@ -1,11 +1,14 @@
 package com.team.yeogibeoryeo.presentation.regionalguide.components
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -23,6 +26,7 @@ import androidx.compose.runtime.Composable
 import com.team.yeogibeoryeo.presentation.regionalguide.RegionSelectorDropdown
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -196,49 +200,61 @@ private fun RegionDropdownChip(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
 ) {
-    Column(
+    BoxWithConstraints(
         modifier = modifier,
     ) {
-        FilterChip(
-            modifier = Modifier.fillMaxWidth(),
-            selected = enabled && label in options,
-            enabled = enabled,
-            onClick = {
-                if (options.isNotEmpty()) {
-                    onExpanded()
-                }
-            },
-            label = {
-                Text(
-                    text = label,
-                    maxLines = 1,
-                    fontWeight = FontWeight.SemiBold,
-                )
-            },
-            shape = RoundedCornerShape(14.dp),
-            colors = FilterChipDefaults.filterChipColors(
-                containerColor = MaterialTheme.colorScheme.surface,
-                labelColor = MaterialTheme.colorScheme.onSurface,
-                selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                disabledLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            ),
-        )
+        val dropdownWidth = maxWidth
 
-        DropdownMenu(
-            expanded = expanded,
-            onDismissRequest = onDismissed,
-        ) {
-            options.forEach { option ->
-                DropdownMenuItem(
-                    text = {
-                        Text(text = option)
-                    },
-                    onClick = {
-                        onOptionSelected(option)
-                    },
-                )
+        Column {
+            FilterChip(
+                modifier = Modifier.fillMaxWidth(),
+                selected = enabled && label in options,
+                enabled = enabled,
+                onClick = {
+                    if (options.isNotEmpty()) {
+                        onExpanded()
+                    }
+                },
+                label = {
+                    Text(
+                        text = label,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                },
+                shape = RoundedCornerShape(14.dp),
+                colors = FilterChipDefaults.filterChipColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    labelColor = MaterialTheme.colorScheme.onSurface,
+                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                    selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    disabledLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                ),
+            )
+
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = onDismissed,
+                modifier = Modifier
+                    .width(dropdownWidth)
+                    .heightIn(max = 280.dp),
+            ) {
+                options.forEach { option ->
+                    DropdownMenuItem(
+                        text = {
+                            Text(
+                                text = option,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        },
+                        onClick = {
+                            onOptionSelected(option)
+                        },
+                    )
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
@@ -1,4 +1,4 @@
-package com.team.yeogibeoryeo.presentation.regionalguide.components
+﻿package com.team.yeogibeoryeo.presentation.regionalguide.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -86,8 +86,7 @@ fun RegionalGuideSearchBar(
                 capitalization = KeyboardCapitalization.None,
                 autoCorrectEnabled = false,
                 // 지역명은 고유명사가 많아 IME 자동 보정이 오탐을 만들 수 있습니다.
-                // visualTransformation을 지정하지 않으므로 입력값은 검색창에 그대로 표시됩니다.
-                keyboardType = KeyboardType.Password,
+                keyboardType = KeyboardType.Text,
                 imeAction = ImeAction.Search
             ),
             keyboardActions = KeyboardActions(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
@@ -17,33 +17,32 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun RegionalGuideSearchBar(
     keyword: String,
     onKeywordChange: (String) -> Unit,
-    onSearchClick: () -> Unit,
+    onSearchClick: (String) -> Unit,
     modifier: Modifier = Modifier,
     candidateContent: (@Composable ColumnScope.() -> Unit)? = null,
 ) {
-    val focusManager = LocalFocusManager.current
-    val keyboardController = LocalSoftwareKeyboardController.current
     val hasCandidates = candidateContent != null
 
     fun submitSearch() {
         if (keyword.isBlank()) return
 
-        focusManager.clearFocus()
-        keyboardController?.hide()
-        onSearchClick()
+        onSearchClick(keyword)
     }
 
     Column(
@@ -52,7 +51,15 @@ fun RegionalGuideSearchBar(
         OutlinedTextField(
             modifier = Modifier
                 .fillMaxWidth()
-                .heightIn(min = SEARCH_FIELD_MIN_HEIGHT),
+                .heightIn(min = SEARCH_FIELD_MIN_HEIGHT)
+                .onPreviewKeyEvent { event ->
+                    if (event.type == KeyEventType.KeyUp && event.key == Key.Enter) {
+                        submitSearch()
+                        true
+                    } else {
+                        false
+                    }
+                },
             value = keyword,
             onValueChange = onKeywordChange,
             singleLine = true,
@@ -76,6 +83,11 @@ fun RegionalGuideSearchBar(
                 SEARCH_FIELD_DEFAULT_SHAPE
             },
             keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.None,
+                autoCorrectEnabled = false,
+                // 지역명은 고유명사가 많아 IME 자동 보정이 오탐을 만들 수 있습니다.
+                // visualTransformation을 지정하지 않으므로 입력값은 검색창에 그대로 표시됩니다.
+                keyboardType = KeyboardType.Password,
                 imeAction = ImeAction.Search
             ),
             keyboardActions = KeyboardActions(

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModelTest.kt
@@ -7,6 +7,7 @@ import com.team.yeogibeoryeo.domain.region.usecase.ExtractRegionFromAddressUseCa
 import com.team.yeogibeoryeo.domain.region.usecase.GetEupmyeondongOptionsUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.GetSidoOptionsUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.GetSigunguOptionsUseCase
+import com.team.yeogibeoryeo.domain.region.usecase.NormalizeRegionForRegionalGuideUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.ResolveRegionFromKeywordUseCase
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideQuery
@@ -14,6 +15,7 @@ import com.team.yeogibeoryeo.domain.regionalguide.repository.RegionalDisposalGui
 import com.team.yeogibeoryeo.domain.regionalguide.usecase.GetRegionalDisposalGuideUseCase
 import com.team.yeogibeoryeo.domain.regionalguide.usecase.NormalizeRegionalGuideQueryUseCase
 import com.team.yeogibeoryeo.domain.regionalguide.usecase.SelectRegionalGuideCandidateUseCase
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionSearchCandidateUiModel
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -163,6 +165,59 @@ class RegionalGuideViewModelTest {
     }
 
     @Test
+    fun `keyword search collapses expanded region selector dropdown`() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onRegionSelectorDropdownExpanded(RegionSelectorDropdown.SIDO)
+
+        assertEquals(
+            RegionSelectorDropdown.SIDO,
+            viewModel.regionSelectorUiState.value.expandedDropdown
+        )
+
+        viewModel.onSearchKeywordChanged("없는지역")
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        assertNull(viewModel.regionSelectorUiState.value.expandedDropdown)
+    }
+
+    @Test
+    fun `selected region search collapses expanded region selector dropdown`() = runTest {
+        val regionalGuideRepository = FakeRegionalDisposalGuideRepository(
+            candidates = listOf(
+                sampleGuide(
+                    sido = "경기도",
+                    sigungu = "수원시",
+                    targetRegionName = "없음"
+                )
+            )
+        )
+        val viewModel = createViewModel(
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                sigunguOptionsBySido = mapOf(
+                    "경기도" to listOf("수원시")
+                )
+            ),
+            regionalGuideRepository = regionalGuideRepository
+        )
+        advanceUntilIdle()
+
+        viewModel.onSidoSelected("경기도")
+        advanceUntilIdle()
+        viewModel.onSigunguSelected("수원시")
+        advanceUntilIdle()
+        viewModel.onRegionSelectorDropdownExpanded(RegionSelectorDropdown.SIGUNGU)
+
+        viewModel.onRegionSelectionSearchClick()
+        advanceUntilIdle()
+
+        assertNull(viewModel.regionSelectorUiState.value.expandedDropdown)
+        assertTrue(viewModel.uiState.value is RegionalGuideUiState.Success)
+    }
+
+    @Test
     fun `retry last request repeats selected region lookup`() = runTest {
         val regionalGuideRepository = FakeRegionalDisposalGuideRepository(
             candidates = listOf(
@@ -258,8 +313,71 @@ class RegionalGuideViewModelTest {
 
         val state = viewModel.uiState.value as RegionalGuideUiState.Ambiguous
 
+        assertEquals("on", viewModel.searchKeyword.value)
         assertEquals("on", state.query)
         assertEquals(2, state.candidates.size)
+
+        with(viewModel.regionSelectorUiState.value) {
+            assertNull(selectedSido)
+            assertNull(selectedSigungu)
+            assertNull(selectedEupmyeondong)
+        }
+    }
+
+    @Test
+    fun `keyword suggestion keeps typed typo keyword without replacing it`() = runTest {
+        val viewModel = createViewModel(
+            regionRepository = FakeRegionRepository(
+                resolvedRegion = Region(sigungu = "중안구")
+            ),
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                keywordRegions = listOf(
+                    Region(
+                        sido = "경기도",
+                        sigungu = "수원시 장안구"
+                    )
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("중안구")
+        advanceTimeBy(400)
+        advanceUntilIdle()
+
+        assertEquals("중안구", viewModel.searchKeyword.value)
+        assertEquals(RegionalGuideUiState.Idle, viewModel.uiState.value)
+
+        with(viewModel.regionSelectorUiState.value) {
+            assertNull(selectedSido)
+            assertNull(selectedSigungu)
+            assertNull(selectedEupmyeondong)
+        }
+    }
+
+    @Test
+    fun `keyword search restores submitted keyword when current input was corrected by ime`() = runTest {
+        val viewModel = createViewModel(
+            regionRepository = FakeRegionRepository(
+                resolvedRegion = Region(sigungu = "중안구")
+            ),
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                keywordRegions = listOf(
+                    Region(
+                        sido = "경기도",
+                        sigungu = "수원시 장안구"
+                    )
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("장안구")
+        viewModel.searchByKeyword("중안구")
+        advanceUntilIdle()
+
+        assertEquals("중안구", viewModel.searchKeyword.value)
+        assertTrue(viewModel.uiState.value is RegionalGuideUiState.Empty)
     }
 
     @Test
@@ -343,6 +461,7 @@ class RegionalGuideViewModelTest {
         viewModel.onRegionCandidateSelected(candidate)
         advanceUntilIdle()
 
+        assertEquals(candidate.displayText, viewModel.searchKeyword.value)
         assertTrue(viewModel.uiState.value is RegionalGuideUiState.Success)
         assertEquals("울주군", regionalGuideRepository.queries.single().sigunguQuery)
 
@@ -350,6 +469,137 @@ class RegionalGuideViewModelTest {
             assertEquals("울산광역시", selectedSido)
             assertEquals("울주군", selectedSigungu)
             assertEquals("온양읍", selectedEupmyeondong)
+        }
+    }
+
+    @Test
+    fun `candidate selection normalizes administrative district for selector state`() = runTest {
+        val regionalGuideRepository = FakeRegionalDisposalGuideRepository(
+            candidates = listOf(
+                sampleGuide(
+                    sido = "경기도",
+                    sigungu = "수원시",
+                    targetRegionName = "없음"
+                )
+            )
+        )
+        val viewModel = createViewModel(
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                sigunguOptionsBySido = mapOf(
+                    "경기도" to listOf("수원시")
+                ),
+                eupmyeondongOptionsByRegion = mapOf(
+                    "경기도" to mapOf(
+                        "수원시" to listOf("파장동")
+                    )
+                )
+            ),
+            regionalGuideRepository = regionalGuideRepository
+        )
+        advanceUntilIdle()
+
+        viewModel.onRegionCandidateSelected(
+            RegionSearchCandidateUiModel(
+                sido = "경기도",
+                sigungu = "수원시 장안구",
+                eupmyeondong = "파장동"
+            )
+        )
+        advanceUntilIdle()
+
+        assertEquals("수원시", regionalGuideRepository.queries.single().sigunguQuery)
+
+        with(viewModel.regionSelectorUiState.value) {
+            assertEquals("경기도", selectedSido)
+            assertEquals("수원시", selectedSigungu)
+            assertEquals("파장동", selectedEupmyeondong)
+        }
+    }
+
+    @Test
+    fun `address lookup normalizes administrative district before selector and guide lookup`() = runTest {
+        val regionalGuideRepository = FakeRegionalDisposalGuideRepository(
+            candidates = listOf(
+                sampleGuide(
+                    sido = "경기도",
+                    sigungu = "성남시",
+                    targetRegionName = "없음"
+                )
+            )
+        )
+        val viewModel = createViewModel(
+            regionRepository = FakeRegionRepository(
+                extractedRegion = Region(
+                    sido = "경기도",
+                    sigungu = "성남시 중원구",
+                    eupmyeondong = "중앙동"
+                )
+            ),
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                sigunguOptionsBySido = mapOf(
+                    "경기도" to listOf("성남시")
+                ),
+                eupmyeondongOptionsByRegion = mapOf(
+                    "경기도" to mapOf(
+                        "성남시" to listOf("중앙동")
+                    )
+                )
+            ),
+            regionalGuideRepository = regionalGuideRepository
+        )
+        advanceUntilIdle()
+
+        viewModel.loadByAddress("경기도 성남시 중원구 중앙동")
+        advanceUntilIdle()
+
+        assertEquals("성남시", regionalGuideRepository.queries.single().sigunguQuery)
+
+        with(viewModel.regionSelectorUiState.value) {
+            assertEquals("경기도", selectedSido)
+            assertEquals("성남시", selectedSigungu)
+            assertEquals("중앙동", selectedEupmyeondong)
+        }
+    }
+
+    @Test
+    fun `keyword not found clears previous selected region`() = runTest {
+        val viewModel = createViewModel(
+            regionRepository = FakeRegionRepository(
+                resolvedRegion = Region(sigungu = "중안구")
+            ),
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                keywordRegions = listOf(
+                    Region(
+                        sido = "경기도",
+                        sigungu = "수원시 장안구"
+                    )
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onRegionCandidateSelected(
+            RegionSearchCandidateUiModel(
+                sido = "경기도",
+                sigungu = "수원시 장안구",
+                eupmyeondong = null
+            )
+        )
+        advanceUntilIdle()
+
+        assertEquals("수원시", viewModel.regionSelectorUiState.value.selectedSigungu)
+
+        viewModel.onSearchKeywordChanged("중안구")
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        assertEquals("중안구", viewModel.searchKeyword.value)
+        assertTrue(viewModel.uiState.value is RegionalGuideUiState.Empty)
+
+        with(viewModel.regionSelectorUiState.value) {
+            assertNull(selectedSido)
+            assertNull(selectedSigungu)
+            assertNull(selectedEupmyeondong)
         }
     }
 
@@ -491,7 +741,10 @@ class RegionalGuideViewModelTest {
             ),
             getSidoOptionsUseCase = GetSidoOptionsUseCase(regionOptionsRepository),
             getSigunguOptionsUseCase = GetSigunguOptionsUseCase(regionOptionsRepository),
-            getEupmyeondongOptionsUseCase = GetEupmyeondongOptionsUseCase(regionOptionsRepository)
+            getEupmyeondongOptionsUseCase = GetEupmyeondongOptionsUseCase(regionOptionsRepository),
+            normalizeRegionForRegionalGuideUseCase = NormalizeRegionForRegionalGuideUseCase(
+                regionOptionsRepository
+            )
         )
     }
 
@@ -511,9 +764,10 @@ class RegionalGuideViewModelTest {
     }
 
     private class FakeRegionRepository(
-        private val resolvedRegion: Region? = null
+        private val resolvedRegion: Region? = null,
+        private val extractedRegion: Region? = null
     ) : RegionRepository {
-        override fun extractRegionFromAddress(address: String): Region? = null
+        override fun extractRegionFromAddress(address: String): Region? = extractedRegion
 
         override suspend fun resolveRegionFromKeyword(keyword: String): Region? = resolvedRegion
 
@@ -577,6 +831,27 @@ class RegionalGuideViewModelTest {
                     region.sigungu?.contains(keyword) == true
                 }
             }
+        }
+
+        override suspend fun normalizeRegionForRegionalGuide(
+            region: Region
+        ): Region {
+            val selectedSido = region.sido
+            val selectedSigungu = region.sigungu
+                ?.takeIf { sigungu -> sigungu.isNotBlank() }
+                ?.substringBefore(" ")
+                ?.let { sigungu ->
+                    if (sigungu.contains("시") && sigungu.contains("구")) {
+                        sigungu.substringBefore("시") + "시"
+                    } else {
+                        sigungu
+                    }
+                }
+
+            return region.copy(
+                sido = selectedSido,
+                sigungu = selectedSigungu
+            )
         }
     }
 


### PR DESCRIPTION
## 작업 내용

- `/info` 제공 지역 목록을 `CTPV_NM + SGG_NM` 기준 asset으로 추가했습니다.
- 지역 가이드 선택형 UI의 시군구 옵션을 행정구역 JSON 기준이 아니라 `/info` 제공 지역 기준으로 변경했습니다.
- 행정구역 기반 `Region`을 지역 가이드 제공 단위로 변환하는 공통 흐름을 추가했습니다.
  - 예: `수원시 장안구 -> 수원시`
  - 예: `성남시 중원구 -> 성남시`
- 직접 검색, 선택형 UI, 주소 기반 진입이 같은 지역 변환 흐름을 재사용하도록 연결했습니다.
- `eupmyeondong`은 `/info` 조회 key가 아니라 후보 선택 보조값으로 유지했습니다.
- 검색 실행 시 선택형 UI 펼침 상태와 드롭다운 상태가 닫히도록 정리했습니다.
- 자동 후보 추천이나 IME 보정으로 검색어 원본이 임의 변경되지 않도록 보완했습니다.
- 선택형 지역 옵션 목록이 길어질 경우 드롭다운 높이를 제한하고 내부 스크롤로 표시되도록 개선했습니다.
- 관련 domain / data / presentation 테스트를 보강했습니다.

## 테스트

- [x] 관련 단위 테스트 통과 확인
  - `com.team.yeogibeoryeo.domain.region.*`
  - `com.team.yeogibeoryeo.domain.regionalguide.*`
  - `com.team.yeogibeoryeo.data.region.*`
  - `com.team.yeogibeoryeo.data.regionalguide.*`
  - `com.team.yeogibeoryeo.presentation.regionalguide.RegionalGuideViewModelTest`
- [x] 변경 모듈 컴파일 확인
  - `:presentation:compileDebugKotlin`
  - `:app:compileDebugKotlin`
- [x] GitHub Actions CI 통과 확인

## 확인한 주요 케이스

- `경기도 > 성남시` 선택 시 `/info` 기준 성남시 가이드가 조회되는 것 확인
- `경기도 > 수원시` 선택 시 `/info` 기준 수원시 가이드가 조회되는 것 확인
- 선택형 UI에서 `성남시 중원구 / 수정구 / 분당구`가 중복 선택지로 노출되지 않는 것 확인
- 선택형 UI에서 `수원시 장안구 / 권선구 / 영통구 / 팔달구`가 중복 선택지로 노출되지 않는 것 확인
- 직접 검색에서 행정구 / 읍면동 후보를 선택해도 `/info` 조회는 제공 지역 기준으로 보정되는 것 확인
- `/info` 응답이 복수 권역으로 내려오는 경우 #103의 후보 선택 UX가 유지되는 것 확인
- 검색 실행 시 선택형 UI 펼침 상태와 드롭다운 상태가 닫히는 것 확인
- `중안구` 같은 오타 검색어 입력 후 Enter 또는 검색 버튼을 눌러도 검색어 원본이 유지되는 것 확인
- 후보를 직접 선택한 경우에만 검색창 값과 선택 지역 상태가 후보 기준으로 갱신되는 것 확인
- 시군구 / 읍면동 옵션이 길어져도 선택 칩 아래 드롭다운 형태로 표시되고 내부 스크롤되는 것 확인

## 스크린샷

| 지역 가이드 제공 단위 조회 | 선택형 지역 옵션 드롭다운 |
|---|---|
| `경기도 > 성남시` 기준으로 조회된 결과 화면 | 시군구 목록을 높이 제한된 드롭다운으로 표시 |
| <img width="1344" height="2992" alt="Screenshot_20260608_011249" src="https://github.com/user-attachments/assets/3b72c390-21f9-409d-a6f9-4a24fc3f539e" /> | <img width="1344" height="2992" alt="Screenshot_20260608_011220" src="https://github.com/user-attachments/assets/706f81e3-7376-4eac-87f5-8e0e4572e833" /> |

## 후속 작업

- 지도 화면에서 선택한 장소 주소를 지역 가이드 화면으로 전달하는 Navigation 연결은 #61에서 진행합니다.
- 지도 연결 후 `/getSpot` 주소 기반 조회 흐름에서 추가 예외 케이스가 있으면 별도 보완합니다.

## 관련 이슈

- Related #105
- Follow-up of #60
- Follow-up of #103