### PR TITLE
feat: 즐겨찾기 타입별 탭 골격 추가

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesRoute.kt
@@ -16,7 +16,10 @@ fun FavoritesRoute(
 
     FavoritesScreen(
         uiState = uiState,
+        onTabClick = viewModel::selectTab,
         onItemGuideClick = onItemGuideClick,
+        onCollectionSpotClick = {},
+        onRegionalGuideClick = {},
         modifier = modifier,
     )
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreen.kt
@@ -10,19 +10,26 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
 import com.team.yeogibeoryeo.presentation.favorites.components.EmptyFavoritesCard
 import com.team.yeogibeoryeo.presentation.favorites.components.FavoriteCard
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteTab
 
 @Composable
 fun FavoritesScreen(
     uiState: FavoritesUiState,
+    onTabClick: (FavoriteTab) -> Unit,
     onItemGuideClick: (String) -> Unit,
+    onCollectionSpotClick: (String) -> Unit,
+    onRegionalGuideClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(
@@ -42,6 +49,13 @@ fun FavoritesScreen(
             )
         }
 
+        item {
+            FavoriteTabRow(
+                selectedTab = uiState.selectedTab,
+                onTabClick = onTabClick,
+            )
+        }
+
         when {
             uiState.isLoading -> {
                 item {
@@ -56,23 +70,58 @@ fun FavoritesScreen(
                 }
             }
 
-            uiState.favorites.isEmpty() -> {
+            uiState.selectedFavorites.isEmpty() -> {
                 item {
-                    EmptyFavoritesCard()
+                    EmptyFavoritesCard(
+                        title = uiState.selectedTab.emptyTitle,
+                        description = uiState.selectedTab.emptyDescription,
+                    )
                 }
             }
 
             else -> {
                 items(
-                    items = uiState.favorites,
-                    key = { it.targetId },
+                    items = uiState.selectedFavorites,
+                    key = { "${it.type.name}:${it.targetId}" },
                 ) { favorite ->
                     FavoriteCard(
                         favorite = favorite,
-                        onClick = { onItemGuideClick(favorite.targetId) },
+                        onClick = {
+                            when (favorite.type) {
+                                FavoriteTargetType.ITEM_GUIDE -> onItemGuideClick(favorite.targetId)
+                                FavoriteTargetType.COLLECTION_SPOT -> onCollectionSpotClick(favorite.targetId)
+                                FavoriteTargetType.REGIONAL_GUIDE -> onRegionalGuideClick(favorite.targetId)
+                            }
+                        },
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun FavoriteTabRow(
+    selectedTab: FavoriteTab,
+    onTabClick: (FavoriteTab) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    PrimaryTabRow(
+        selectedTabIndex = FavoriteTab.entries.indexOf(selectedTab),
+        modifier = modifier,
+    ) {
+        FavoriteTab.entries.forEach { tab ->
+            Tab(
+                selected = selectedTab == tab,
+                onClick = { onTabClick(tab) },
+                text = {
+                    Text(
+                        text = tab.label,
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                },
+            )
         }
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreenPreview.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreenPreview.kt
@@ -3,8 +3,10 @@ package com.team.yeogibeoryeo.presentation.favorites
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
 import com.team.yeogibeoryeo.common.design.theme.YeogiBeoryeoTheme
-import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteItemUiModel
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteTab
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteUiModel
 
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
 @Composable
@@ -12,7 +14,10 @@ private fun FavoritesScreenLoadingPreview() {
     FavoriteScreenPreviewContainer {
         FavoritesScreen(
             uiState = FavoritesUiState(isLoading = true),
+            onTabClick = {},
             onItemGuideClick = {},
+            onCollectionSpotClick = {},
+            onRegionalGuideClick = {},
         )
     }
 }
@@ -23,7 +28,24 @@ private fun FavoritesScreenEmptyPreview() {
     FavoriteScreenPreviewContainer {
         FavoritesScreen(
             uiState = FavoritesUiState(),
+            onTabClick = {},
             onItemGuideClick = {},
+            onCollectionSpotClick = {},
+            onRegionalGuideClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+private fun FavoritesScreenSpotEmptyPreview() {
+    FavoriteScreenPreviewContainer {
+        FavoritesScreen(
+            uiState = FavoritesUiState(selectedTab = FavoriteTab.COLLECTION_SPOT),
+            onTabClick = {},
+            onItemGuideClick = {},
+            onCollectionSpotClick = {},
+            onRegionalGuideClick = {},
         )
     }
 }
@@ -35,26 +57,32 @@ private fun FavoritesScreenListPreview() {
         FavoritesScreen(
             uiState =
                 FavoritesUiState(
-                    favorites =
+                    itemGuideFavorites =
                         listOf(
-                            FavoriteItemUiModel(
+                            FavoriteUiModel(
+                                type = FavoriteTargetType.ITEM_GUIDE,
                                 targetId = "paper-pack",
                                 title = "종이팩",
                                 subtitle = "종이팩",
                             ),
-                            FavoriteItemUiModel(
+                            FavoriteUiModel(
+                                type = FavoriteTargetType.ITEM_GUIDE,
                                 targetId = "large-waste",
                                 title = "대형폐기물",
                                 subtitle = "대형폐기물",
                             ),
-                            FavoriteItemUiModel(
+                            FavoriteUiModel(
+                                type = FavoriteTargetType.ITEM_GUIDE,
                                 targetId = "very-long-title",
                                 title = "아주 긴 이름의 즐겨찾기 품목 가이드",
                                 subtitle = "생활계 유해폐기물",
                             ),
                         ),
                 ),
+            onTabClick = {},
             onItemGuideClick = {},
+            onCollectionSpotClick = {},
+            onRegionalGuideClick = {},
         )
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesUiState.kt
@@ -1,8 +1,20 @@
 package com.team.yeogibeoryeo.presentation.favorites
 
-import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteItemUiModel
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteTab
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteUiModel
 
 data class FavoritesUiState(
     val isLoading: Boolean = false,
-    val favorites: List<FavoriteItemUiModel> = emptyList(),
-)
+    val selectedTab: FavoriteTab = FavoriteTab.ITEM_GUIDE,
+    val itemGuideFavorites: List<FavoriteUiModel> = emptyList(),
+    val collectionSpotFavorites: List<FavoriteUiModel> = emptyList(),
+    val regionalGuideFavorites: List<FavoriteUiModel> = emptyList(),
+) {
+    val selectedFavorites: List<FavoriteUiModel>
+        get() =
+            when (selectedTab) {
+                FavoriteTab.ITEM_GUIDE -> itemGuideFavorites
+                FavoriteTab.COLLECTION_SPOT -> collectionSpotFavorites
+                FavoriteTab.REGIONAL_GUIDE -> regionalGuideFavorites
+            }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModel.kt
@@ -4,13 +4,16 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
-import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalItemGuideUseCase
-import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteItemUiModel
+import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteCollectionSpotUiMapper
+import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteItemGuideUiMapper
+import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteRegionalGuideUiMapper
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteTab
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 
 @HiltViewModel
@@ -18,23 +21,35 @@ class FavoritesViewModel
     @Inject
     constructor(
         observeFavoritesUseCase: ObserveFavoritesUseCase,
-        private val getDisposalItemGuideUseCase: GetDisposalItemGuideUseCase,
+        private val itemGuideUiMapper: FavoriteItemGuideUiMapper,
+        private val collectionSpotUiMapper: FavoriteCollectionSpotUiMapper,
+        private val regionalGuideUiMapper: FavoriteRegionalGuideUiMapper,
     ) : ViewModel() {
+        private val selectedTab = MutableStateFlow(FavoriteTab.ITEM_GUIDE)
+
         val uiState: StateFlow<FavoritesUiState> =
-            observeFavoritesUseCase(FavoriteTargetType.ITEM_GUIDE)
-                .map { favorites ->
+            combine(
+                selectedTab,
+                observeFavoritesUseCase(),
+            ) { selectedTab, favorites ->
+                val itemGuideFavorites =
+                    favorites
+                        .filter { it.type == FavoriteTargetType.ITEM_GUIDE }
+                        .mapNotNull { favorite -> itemGuideUiMapper.map(favorite) }
+                val collectionSpotFavorites =
+                    favorites
+                        .filter { it.type == FavoriteTargetType.COLLECTION_SPOT }
+                        .mapNotNull { favorite -> collectionSpotUiMapper.map(favorite) }
+                val regionalGuideFavorites =
+                    favorites
+                        .filter { it.type == FavoriteTargetType.REGIONAL_GUIDE }
+                        .mapNotNull { favorite -> regionalGuideUiMapper.map(favorite) }
+
                     FavoritesUiState(
-                        favorites =
-                            favorites.mapNotNull { favorite ->
-                                val guide = getDisposalItemGuideUseCase(favorite.targetId)
-                                guide?.let {
-                                    FavoriteItemUiModel(
-                                        targetId = favorite.targetId,
-                                        title = it.name,
-                                        subtitle = it.subCategory?.displayName ?: it.category.displayName,
-                                    )
-                                }
-                            },
+                        selectedTab = selectedTab,
+                        itemGuideFavorites = itemGuideFavorites,
+                        collectionSpotFavorites = collectionSpotFavorites,
+                        regionalGuideFavorites = regionalGuideFavorites,
                     )
                 }
                 .stateIn(
@@ -42,4 +57,8 @@ class FavoritesViewModel
                     started = SharingStarted.WhileSubscribed(5_000),
                     initialValue = FavoritesUiState(isLoading = true),
                 )
+
+        fun selectTab(tab: FavoriteTab) {
+            selectedTab.value = tab
+        }
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/components/EmptyFavoritesCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/components/EmptyFavoritesCard.kt
@@ -19,7 +19,11 @@ import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.common.R as CommonR
 
 @Composable
-fun EmptyFavoritesCard(modifier: Modifier = Modifier) {
+fun EmptyFavoritesCard(
+    title: String,
+    description: String,
+    modifier: Modifier = Modifier,
+) {
     Card(
         modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(20.dp),
@@ -39,12 +43,12 @@ fun EmptyFavoritesCard(modifier: Modifier = Modifier) {
                 tint = MaterialTheme.colorScheme.tertiary,
             )
             Text(
-                text = "아직 즐겨찾기한 품목이 없어요",
+                text = title,
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
             )
             Text(
-                text = "품목 가이드 상세 화면에서 별을 누르면 여기에 모아볼 수 있어요.",
+                text = description,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/components/FavoriteCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/components/FavoriteCard.kt
@@ -23,12 +23,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteItemUiModel
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteUiModel
 import com.team.yeogibeoryeo.common.R as CommonR
 
 @Composable
 fun FavoriteCard(
-    favorite: FavoriteItemUiModel,
+    favorite: FavoriteUiModel,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/mapper/FavoriteCollectionSpotUiMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/mapper/FavoriteCollectionSpotUiMapper.kt
@@ -1,0 +1,14 @@
+package com.team.yeogibeoryeo.presentation.favorites.mapper
+
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteUiModel
+import javax.inject.Inject
+
+class FavoriteCollectionSpotUiMapper
+    @Inject
+    constructor() {
+    suspend fun map(favorite: Favorite): FavoriteUiModel? {
+        // TODO: Resolve collection spot source data when COLLECTION_SPOT favorites are connected.
+        return null
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/mapper/FavoriteItemGuideUiMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/mapper/FavoriteItemGuideUiMapper.kt
@@ -1,0 +1,24 @@
+package com.team.yeogibeoryeo.presentation.favorites.mapper
+
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalItemGuideUseCase
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteUiModel
+import javax.inject.Inject
+
+class FavoriteItemGuideUiMapper
+    @Inject
+    constructor(
+        private val getDisposalItemGuideUseCase: GetDisposalItemGuideUseCase,
+    ) {
+        suspend fun map(favorite: Favorite): FavoriteUiModel? {
+            val guide = getDisposalItemGuideUseCase(favorite.targetId) ?: return null
+
+            return FavoriteUiModel(
+                type = FavoriteTargetType.ITEM_GUIDE,
+                targetId = favorite.targetId,
+                title = guide.name,
+                subtitle = guide.subCategory?.displayName ?: guide.category.displayName,
+            )
+        }
+    }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/mapper/FavoriteRegionalGuideUiMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/mapper/FavoriteRegionalGuideUiMapper.kt
@@ -1,0 +1,14 @@
+package com.team.yeogibeoryeo.presentation.favorites.mapper
+
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteUiModel
+import javax.inject.Inject
+
+class FavoriteRegionalGuideUiMapper
+    @Inject
+    constructor() {
+    suspend fun map(favorite: Favorite): FavoriteUiModel? {
+        // TODO: Resolve regional guide source data when REGIONAL_GUIDE favorites are connected.
+        return null
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/model/FavoriteTab.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/model/FavoriteTab.kt
@@ -1,0 +1,29 @@
+package com.team.yeogibeoryeo.presentation.favorites.model
+
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+
+enum class FavoriteTab(
+    val targetType: FavoriteTargetType,
+    val label: String,
+    val emptyTitle: String,
+    val emptyDescription: String,
+) {
+    ITEM_GUIDE(
+        targetType = FavoriteTargetType.ITEM_GUIDE,
+        label = "품목",
+        emptyTitle = "아직 즐겨찾기한 품목이 없어요",
+        emptyDescription = "품목 가이드 상세 화면에서 별을 누르면 여기에 모아볼 수 있어요.",
+    ),
+    COLLECTION_SPOT(
+        targetType = FavoriteTargetType.COLLECTION_SPOT,
+        label = "장소",
+        emptyTitle = "아직 즐겨찾기한 장소가 없어요",
+        emptyDescription = "수거 장소 즐겨찾기 연결 후 이곳에서 모아볼 수 있어요.",
+    ),
+    REGIONAL_GUIDE(
+        targetType = FavoriteTargetType.REGIONAL_GUIDE,
+        label = "지역",
+        emptyTitle = "아직 즐겨찾기한 지역 가이드가 없어요",
+        emptyDescription = "지역 가이드 즐겨찾기 연결 후 이곳에서 모아볼 수 있어요.",
+    ),
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/model/FavoriteUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/model/FavoriteUiModel.kt
@@ -1,6 +1,9 @@
 package com.team.yeogibeoryeo.presentation.favorites.model
 
-data class FavoriteItemUiModel(
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+
+data class FavoriteUiModel(
+    val type: FavoriteTargetType,
     val targetId: String,
     val title: String,
     val subtitle: String?,

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModelTest.kt
@@ -10,7 +10,11 @@ import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.domain.item.model.DisposalSubCategory
 import com.team.yeogibeoryeo.domain.item.repository.DisposalItemGuideRepository
 import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalItemGuideUseCase
-import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteItemUiModel
+import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteCollectionSpotUiMapper
+import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteItemGuideUiMapper
+import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteRegionalGuideUiMapper
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteTab
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteUiModel
 import com.team.yeogibeoryeo.presentation.search.MainDispatcherRule
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -61,13 +65,14 @@ class FavoritesViewModelTest {
 
             assertEquals(
                 listOf(
-                    FavoriteItemUiModel(
+                    FavoriteUiModel(
+                        type = FavoriteTargetType.ITEM_GUIDE,
                         targetId = "paper-pack",
                         title = "종이팩",
                         subtitle = "우유팩",
                     ),
                 ),
-                viewModel.uiState.value.favorites,
+                viewModel.uiState.value.itemGuideFavorites,
             )
         }
 
@@ -94,7 +99,25 @@ class FavoritesViewModelTest {
             }
             advanceUntilIdle()
 
-            assertEquals(emptyList<FavoriteItemUiModel>(), viewModel.uiState.value.favorites)
+            assertEquals(emptyList<FavoriteUiModel>(), viewModel.uiState.value.itemGuideFavorites)
+        }
+
+    @Test
+    fun `탭을 변경하면 선택된 탭 상태를 반영한다`() =
+        runTest {
+            val viewModel =
+                createViewModel(
+                    favoriteRepository = FakeFavoriteRepository(),
+                    itemRepository = FakeItemRepository(guides = emptyList()),
+                )
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.uiState.collect()
+            }
+
+            viewModel.selectTab(FavoriteTab.COLLECTION_SPOT)
+            advanceUntilIdle()
+
+            assertEquals(FavoriteTab.COLLECTION_SPOT, viewModel.uiState.value.selectedTab)
         }
 
     private fun createViewModel(
@@ -103,7 +126,9 @@ class FavoritesViewModelTest {
     ): FavoritesViewModel =
         FavoritesViewModel(
             observeFavoritesUseCase = ObserveFavoritesUseCase(favoriteRepository),
-            getDisposalItemGuideUseCase = GetDisposalItemGuideUseCase(itemRepository),
+            itemGuideUiMapper = FavoriteItemGuideUiMapper(GetDisposalItemGuideUseCase(itemRepository)),
+            collectionSpotUiMapper = FavoriteCollectionSpotUiMapper(),
+            regionalGuideUiMapper = FavoriteRegionalGuideUiMapper(),
         )
 
     private fun sampleGuide(


### PR DESCRIPTION
## 작업 내용

- 즐겨찾기 화면에 품목 / 장소 / 지역 탭 UI를 추가했습니다.
- 즐겨찾기 UI 모델을 `FavoriteUiModel`로 공통화했습니다.
- 품목 즐겨찾기 매핑 로직을 `FavoriteItemGuideUiMapper`로 분리했습니다.
- 장소 / 지역 즐겨찾기 확장을 위한 mapper 파일을 추가했습니다.
- 아직 연결되지 않은 장소 / 지역 탭은 안전한 빈 상태로 표시되도록 처리했습니다.
- `FavoritesViewModel` 테스트를 변경된 타입별 상태 구조에 맞게 수정했습니다.

## 화면 캡처

<img width="320" alt="즐겨찾기 타입별 탭 화면" src="https://github.com/user-attachments/assets/ef5702cf-ea1d-4f65-b89b-556e8917d54f" />

## 검증

- [x] `./gradlew.bat :presentation:testDebugUnitTest :presentation:compileDebugKotlin`

Related #107
