### PR TITLE
[Refactor] 안내 탭 검색바 공통 컴포넌트화

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/components/SearchBarField.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/components/SearchBarField.kt
@@ -13,12 +13,16 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.ImeAction
@@ -33,12 +37,14 @@ fun SearchBarField(
     modifier: Modifier = Modifier,
     placeholder: String,
     leadingContent: (@Composable () -> Unit)? = null,
-    trailingContent: (@Composable () -> Unit)? = null,
+    trailingContent: (@Composable (Boolean) -> Unit)? = null,
     candidateContent: (@Composable ColumnScope.() -> Unit)? = null,
     minHeight: Dp = 56.dp,
     searchEnabled: (String) -> Boolean = { it.isNotBlank() },
 ) {
     val hasCandidates = candidateContent != null
+    val searchFieldInteractionSource = remember { MutableInteractionSource() }
+    val isSearchFieldFocused by searchFieldInteractionSource.collectIsFocusedAsState()
     val isSearchEnabled = searchEnabled(keyword)
     val collapsedShape = RoundedCornerShape(12.dp)
     val expandedShape = RoundedCornerShape(
@@ -85,17 +91,18 @@ fun SearchBarField(
                 { it() }
             },
             trailingIcon = trailingContent?.let {
-                { it() }
+                { it(isSearchFieldFocused) }
             },
+            interactionSource = searchFieldInteractionSource,
             shape = if (hasCandidates) {
                 expandedShape
             } else {
                 collapsedShape
             },
             colors = OutlinedTextFieldDefaults.colors(
-                focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                focusedBorderColor = MaterialTheme.colorScheme.outline,
+                focusedContainerColor = MaterialTheme.colorScheme.background,
+                unfocusedContainerColor = MaterialTheme.colorScheme.background,
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
                 unfocusedBorderColor = MaterialTheme.colorScheme.outline,
             ),
             keyboardOptions = KeyboardOptions(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/components/SearchBarField.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/components/SearchBarField.kt
@@ -1,0 +1,129 @@
+package com.team.yeogibeoryeo.presentation.common.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SearchBarField(
+    keyword: String,
+    onKeywordChange: (String) -> Unit,
+    onSearch: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String,
+    leadingContent: (@Composable () -> Unit)? = null,
+    trailingContent: (@Composable () -> Unit)? = null,
+    candidateContent: (@Composable ColumnScope.() -> Unit)? = null,
+    minHeight: Dp = 56.dp,
+    searchEnabled: (String) -> Boolean = { it.isNotBlank() },
+) {
+    val hasCandidates = candidateContent != null
+    val isSearchEnabled = searchEnabled(keyword)
+    val collapsedShape = RoundedCornerShape(12.dp)
+    val expandedShape = RoundedCornerShape(
+        topStart = 12.dp,
+        topEnd = 12.dp,
+        bottomStart = 0.dp,
+        bottomEnd = 0.dp,
+    )
+    val candidateShape = RoundedCornerShape(
+        topStart = 0.dp,
+        topEnd = 0.dp,
+        bottomStart = 12.dp,
+        bottomEnd = 12.dp,
+    )
+
+    fun submitSearch() {
+        if (!isSearchEnabled) return
+
+        onSearch(keyword)
+    }
+
+    Column(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        OutlinedTextField(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = minHeight)
+                .onPreviewKeyEvent { event ->
+                    if (event.type == KeyEventType.KeyUp && event.key == Key.Enter) {
+                        submitSearch()
+                        true
+                    } else {
+                        false
+                    }
+                },
+            value = keyword,
+            onValueChange = onKeywordChange,
+            singleLine = true,
+            placeholder = {
+                Text(text = placeholder)
+            },
+            leadingIcon = leadingContent?.let {
+                { it() }
+            },
+            trailingIcon = trailingContent?.let {
+                { it() }
+            },
+            shape = if (hasCandidates) {
+                expandedShape
+            } else {
+                collapsedShape
+            },
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                focusedBorderColor = MaterialTheme.colorScheme.outline,
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+            ),
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.None,
+                autoCorrectEnabled = false,
+                keyboardType = KeyboardType.Text,
+                imeAction = ImeAction.Search,
+            ),
+            keyboardActions = KeyboardActions(
+                onSearch = {
+                    submitSearch()
+                },
+            ),
+        )
+
+        if (candidateContent != null) {
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = candidateShape,
+                color = MaterialTheme.colorScheme.surface,
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    candidateContent()
+                }
+            }
+        }
+    }
+
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapOverlayControls.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapOverlayControls.kt
@@ -60,21 +60,14 @@ private fun MapOverlaySearchArea(
     onSearchClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Surface(
+    MapSearchBar(
+        keyword = keyword,
+        onKeywordChanged = onKeywordChanged,
+        onSearchClick = onSearchClick,
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 12.dp),
-        shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.surface,
-        tonalElevation = 3.dp,
-        shadowElevation = 2.dp,
-    ) {
-        MapSearchBar(
-            keyword = keyword,
-            onKeywordChanged = onKeywordChanged,
-            onSearchClick = onSearchClick,
-        )
-    }
+    )
 }
 
 @Composable

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
@@ -2,26 +2,27 @@ package com.team.yeogibeoryeo.presentation.map.components
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.Preview
 import com.team.yeogibeoryeo.common.R as CommonR
+import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.common.components.SearchBarField
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -45,34 +46,56 @@ fun MapSearchBar(
             .fillMaxWidth()
             .padding(horizontal = 14.dp, vertical = 8.dp),
     ) {
-        OutlinedTextField(
-            value = keyword,
-            onValueChange = onKeywordChanged,
-            modifier = Modifier
-                .fillMaxWidth()
-                .heightIn(min = 56.dp),
-            placeholder = {
-                Text(text = "동네 또는 주소를 검색해주세요.")
+        SearchBarField(
+            modifier = Modifier.fillMaxWidth(),
+            keyword = keyword,
+            onKeywordChange = onKeywordChanged,
+            onSearch = {
+                submitSearch()
             },
-            singleLine = true,
-            trailingIcon = {
+            placeholder = "동네 또는 주소를 검색해주세요.",
+            leadingContent = {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = if (keyword.isBlank()) {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    } else {
+                        MaterialTheme.colorScheme.primary
+                    }
+                )
+            },
+            trailingContent = {
+                if (keyword.isNotBlank()) {
+                    IconButton(onClick = { onKeywordChanged("") }) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = "검색어 지우기",
+                            modifier = Modifier.size(20.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
                 IconButton(
-                    onClick = ::submitSearch,
+                    onClick = {
+                        if (keyword.isNotBlank()) {
+                            submitSearch()
+                        }
+                    },
+                    enabled = keyword.isNotBlank(),
                 ) {
                     Icon(
                         painter = painterResource(id = CommonR.drawable.ic_action_search),
-                        contentDescription = "검색",
+                        contentDescription = stringResource(R.string.search_action),
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.primary,
                     )
                 }
             },
-            keyboardOptions = KeyboardOptions(
-                imeAction = ImeAction.Search,
-            ),
-            keyboardActions = KeyboardActions(
-                onSearch = {
-                    submitSearch()
-                },
-            ),
+            minHeight = 56.dp,
+            searchEnabled = { it.isNotBlank() },
         )
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
@@ -1,9 +1,7 @@
 package com.team.yeogibeoryeo.presentation.map.components
 
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
@@ -40,51 +38,45 @@ fun MapSearchBar(
         onSearchClick()
     }
 
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 14.dp, vertical = 8.dp),
-    ) {
-        SearchBarField(
-            modifier = Modifier.fillMaxWidth(),
-            keyword = keyword,
-            onKeywordChange = onKeywordChanged,
-            onSearch = {
-                submitSearch()
-            },
-            placeholder = "동네 또는 주소를 검색해주세요.",
-            trailingContent = {
-                if (keyword.isNotBlank()) {
-                    IconButton(onClick = { onKeywordChanged("") }) {
-                        Icon(
-                            imageVector = Icons.Default.Close,
-                            contentDescription = "검색어 지우기",
-                            modifier = Modifier.size(20.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-
-                IconButton(
-                    onClick = {
-                        if (keyword.isNotBlank()) {
-                            submitSearch()
-                        }
-                    },
-                    enabled = keyword.isNotBlank(),
-                ) {
+    SearchBarField(
+        modifier = modifier.fillMaxWidth(),
+        keyword = keyword,
+        onKeywordChange = onKeywordChanged,
+        onSearch = {
+            submitSearch()
+        },
+        placeholder = "동네 또는 주소를 검색해주세요.",
+        trailingContent = {
+            if (keyword.isNotBlank()) {
+                IconButton(onClick = { onKeywordChanged("") }) {
                     Icon(
-                        painter = painterResource(id = CommonR.drawable.ic_action_search),
-                        contentDescription = stringResource(R.string.search_action),
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "검색어 지우기",
                         modifier = Modifier.size(20.dp),
-                        tint = MaterialTheme.colorScheme.primary,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-            },
-            minHeight = 56.dp,
-            searchEnabled = { it.isNotBlank() },
-        )
-    }
+            }
+
+            IconButton(
+                onClick = {
+                    if (keyword.isNotBlank()) {
+                        submitSearch()
+                    }
+                },
+                enabled = keyword.isNotBlank(),
+            ) {
+                Icon(
+                    painter = painterResource(id = CommonR.drawable.ic_action_search),
+                    contentDescription = stringResource(R.string.search_action),
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+        },
+        minHeight = 56.dp,
+        searchEnabled = { it.isNotBlank() },
+    )
 }
 
 @Preview(showBackground = true)

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -54,18 +53,6 @@ fun MapSearchBar(
                 submitSearch()
             },
             placeholder = "동네 또는 주소를 검색해주세요.",
-            leadingContent = {
-                Icon(
-                    imageVector = Icons.Default.Search,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp),
-                    tint = if (keyword.isBlank()) {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    } else {
-                        MaterialTheme.colorScheme.primary
-                    }
-                )
-            },
             trailingContent = {
                 if (keyword.isNotBlank()) {
                     IconButton(onClick = { onKeywordChanged("") }) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
@@ -46,7 +46,12 @@ fun MapSearchBar(
             submitSearch()
         },
         placeholder = "동네 또는 주소를 검색해주세요.",
-        trailingContent = {
+        trailingContent = { isFocused ->
+            val searchIconColor = when {
+                keyword.isNotBlank() || isFocused -> MaterialTheme.colorScheme.primary
+                else -> MaterialTheme.colorScheme.onSurfaceVariant
+            }
+
             if (keyword.isNotBlank()) {
                 IconButton(onClick = { onKeywordChanged("") }) {
                     Icon(
@@ -64,13 +69,13 @@ fun MapSearchBar(
                         submitSearch()
                     }
                 },
-                enabled = keyword.isNotBlank(),
+                enabled = isFocused || keyword.isNotBlank(),
             ) {
                 Icon(
                     painter = painterResource(id = CommonR.drawable.ic_action_search),
                     contentDescription = stringResource(R.string.search_action),
                     modifier = Modifier.size(20.dp),
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = searchIconColor,
                 )
             }
         },

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
@@ -33,7 +33,12 @@ fun RegionalGuideSearchBar(
         onKeywordChange = onKeywordChange,
         onSearch = { onSearchClick(it) },
         placeholder = "지역명 또는 주소를 검색해주세요.",
-        trailingContent = {
+        trailingContent = { isFocused ->
+            val searchIconColor = when {
+                keyword.isNotBlank() || isFocused -> MaterialTheme.colorScheme.primary
+                else -> MaterialTheme.colorScheme.onSurfaceVariant
+            }
+
             if (keyword.isNotBlank()) {
                 IconButton(onClick = { onKeywordChange("") }) {
                     Icon(
@@ -51,12 +56,12 @@ fun RegionalGuideSearchBar(
                         onSearchClick(keyword)
                     }
                 },
-                enabled = keyword.isNotBlank(),
+                enabled = isFocused || keyword.isNotBlank(),
             ) {
                 Icon(
                     painter = painterResource(id = CommonR.drawable.ic_action_search),
                     contentDescription = stringResource(R.string.search_action),
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = searchIconColor,
                     modifier = Modifier.size(20.dp),
                 )
             }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -34,18 +33,6 @@ fun RegionalGuideSearchBar(
         onKeywordChange = onKeywordChange,
         onSearch = { onSearchClick(it) },
         placeholder = "지역명 또는 주소를 검색해주세요.",
-        leadingContent = {
-            Icon(
-                imageVector = Icons.Default.Search,
-                contentDescription = null,
-                modifier = Modifier.size(18.dp),
-                tint = if (keyword.isBlank()) {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                } else {
-                    MaterialTheme.colorScheme.primary
-                },
-            )
-        },
         trailingContent = {
             if (keyword.isNotBlank()) {
                 IconButton(onClick = { onKeywordChange("") }) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
@@ -1,33 +1,24 @@
-﻿package com.team.yeogibeoryeo.presentation.regionalguide.components
+package com.team.yeogibeoryeo.presentation.regionalguide.components
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.input.key.type
-import androidx.compose.ui.text.input.KeyboardCapitalization
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.common.R as CommonR
+import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.common.components.SearchBarField
 
 @Composable
 fun RegionalGuideSearchBar(
@@ -37,97 +28,56 @@ fun RegionalGuideSearchBar(
     modifier: Modifier = Modifier,
     candidateContent: (@Composable ColumnScope.() -> Unit)? = null,
 ) {
-    val hasCandidates = candidateContent != null
-
-    fun submitSearch() {
-        if (keyword.isBlank()) return
-
-        onSearchClick(keyword)
-    }
-
-    Column(
-        modifier = modifier.fillMaxWidth()
-    ) {
-        OutlinedTextField(
-            modifier = Modifier
-                .fillMaxWidth()
-                .heightIn(min = SEARCH_FIELD_MIN_HEIGHT)
-                .onPreviewKeyEvent { event ->
-                    if (event.type == KeyEventType.KeyUp && event.key == Key.Enter) {
-                        submitSearch()
-                        true
-                    } else {
-                        false
-                    }
+    SearchBarField(
+        modifier = modifier.fillMaxWidth(),
+        keyword = keyword,
+        onKeywordChange = onKeywordChange,
+        onSearch = { onSearchClick(it) },
+        placeholder = "지역명 또는 주소를 검색해주세요.",
+        leadingContent = {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = if (keyword.isBlank()) {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                } else {
+                    MaterialTheme.colorScheme.primary
                 },
-            value = keyword,
-            onValueChange = onKeywordChange,
-            singleLine = true,
-            placeholder = {
-                Text(text = "지역명 또는 주소를 검색해주세요.")
-            },
-            trailingIcon = {
-                IconButton(
-                    onClick = ::submitSearch,
-                    enabled = keyword.isNotBlank()
-                ) {
+            )
+        },
+        trailingContent = {
+            if (keyword.isNotBlank()) {
+                IconButton(onClick = { onKeywordChange("") }) {
                     Icon(
-                        imageVector = Icons.Default.Search,
-                        contentDescription = "검색"
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "검색어 지우기",
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-            },
-            shape = if (hasCandidates) {
-                SEARCH_FIELD_EXPANDED_SHAPE
-            } else {
-                SEARCH_FIELD_DEFAULT_SHAPE
-            },
-            keyboardOptions = KeyboardOptions(
-                capitalization = KeyboardCapitalization.None,
-                autoCorrectEnabled = false,
-                // 지역명은 고유명사가 많아 IME 자동 보정이 오탐을 만들 수 있습니다.
-                keyboardType = KeyboardType.Text,
-                imeAction = ImeAction.Search
-            ),
-            keyboardActions = KeyboardActions(
-                onSearch = {
-                    submitSearch()
-                }
-            )
-        )
-
-        if (candidateContent != null) {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                shape = SEARCH_CANDIDATE_CONTAINER_SHAPE,
-                color = MaterialTheme.colorScheme.surface,
-                shadowElevation = SEARCH_CANDIDATE_ELEVATION,
-            ) {
-                Column(
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    candidateContent()
-                }
             }
-        }
-    }
-}
 
-private val SEARCH_FIELD_MIN_HEIGHT = 56.dp
-private val SEARCH_FIELD_DEFAULT_SHAPE = RoundedCornerShape(12.dp)
-private val SEARCH_FIELD_EXPANDED_SHAPE = RoundedCornerShape(
-    topStart = 12.dp,
-    topEnd = 12.dp,
-    bottomStart = 0.dp,
-    bottomEnd = 0.dp,
-)
-private val SEARCH_CANDIDATE_CONTAINER_SHAPE = RoundedCornerShape(
-    topStart = 0.dp,
-    topEnd = 0.dp,
-    bottomStart = 12.dp,
-    bottomEnd = 12.dp,
-)
-private val SEARCH_CANDIDATE_ELEVATION = 3.dp
+            IconButton(
+                onClick = {
+                    if (keyword.isNotBlank()) {
+                        onSearchClick(keyword)
+                    }
+                },
+                enabled = keyword.isNotBlank(),
+            ) {
+                Icon(
+                    painter = painterResource(id = CommonR.drawable.ic_action_search),
+                    contentDescription = stringResource(R.string.search_action),
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        },
+        candidateContent = candidateContent,
+        minHeight = 56.dp,
+    )
+}
 
 @Preview(showBackground = true)
 @Composable

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -6,24 +6,15 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -34,22 +25,19 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
-import com.team.yeogibeoryeo.common.R as CommonR
 import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.search.components.DisposalItemCard
 import com.team.yeogibeoryeo.presentation.search.components.EmptySearchResult
+import com.team.yeogibeoryeo.presentation.search.components.ItemSearchBar
 import com.team.yeogibeoryeo.presentation.search.components.QuickCategoryGrid
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
 
@@ -139,74 +127,14 @@ fun ItemSearchScreen(
             )
         }
 
-        // 검색창 (더욱 강조된 검색바 디자인)
-        val searchActionDescription = stringResource(R.string.search_action)
-        OutlinedTextField(
-            value = uiState.query,
-            onValueChange = onQueryChange,
+        ItemSearchBar(
+            keyword = uiState.query,
+            onKeywordChange = onQueryChange,
+            onSearchClick = {
+                onSearchClick()
+            },
+            placeholder = stringResource(R.string.item_search_query_label),
             modifier = Modifier.fillMaxWidth(),
-            placeholder = {
-                Text(
-                    text = stringResource(R.string.item_search_query_label),
-                    style = MaterialTheme.typography.bodyLarge.copy(
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        fontSize = 16.sp
-                    )
-                )
-            },
-            leadingIcon = {
-                Icon(
-                    painter = painterResource(id = CommonR.drawable.ic_symbol_recycle),
-                    contentDescription = null,
-                    modifier = Modifier.size(22.dp),
-                    tint =
-                        if (uiState.query.isEmpty()) {
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        } else {
-                            MaterialTheme.colorScheme.primary
-                        }
-                )
-            },
-            trailingIcon = {
-                Row(
-                    modifier = Modifier.padding(end = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    if (uiState.query.isNotEmpty()) {
-                        IconButton(onClick = { onQueryChange("") }) {
-                            Icon(
-                                painter = painterResource(id = CommonR.drawable.ic_action_close),
-                                contentDescription = null,
-                                modifier = Modifier.size(20.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
-                    IconButton(onClick = onSearchClick) {
-                        Icon(
-                            painter = painterResource(id = CommonR.drawable.ic_action_search),
-                            contentDescription = searchActionDescription,
-                            modifier = Modifier
-                                .size(24.dp)
-                                .semantics {
-                                    contentDescription = searchActionDescription
-                                },
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                }
-            },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-            keyboardActions = KeyboardActions(onSearch = { onSearchClick() }),
-            shape = RoundedCornerShape(28.dp),
-            colors = OutlinedTextFieldDefaults.colors(
-                focusedBorderColor = MaterialTheme.colorScheme.primary,
-                unfocusedBorderColor = Color.Transparent,
-                focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                cursorColor = MaterialTheme.colorScheme.primary,
-            )
         )
 
         // 검색 결과 또는 제안 섹션

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchBar.kt
@@ -35,7 +35,12 @@ fun ItemSearchBar(
             }
         },
         placeholder = placeholder,
-        trailingContent = {
+        trailingContent = { isFocused ->
+            val searchIconColor = when {
+                keyword.isNotBlank() || isFocused -> MaterialTheme.colorScheme.primary
+                else -> MaterialTheme.colorScheme.onSurfaceVariant
+            }
+
             if (keyword.isNotBlank()) {
                 IconButton(onClick = { onKeywordChange("") }) {
                     Icon(
@@ -53,13 +58,13 @@ fun ItemSearchBar(
                         onSearchClick()
                     }
                 },
-                enabled = keyword.isNotBlank(),
+                enabled = isFocused || keyword.isNotBlank(),
             ) {
                 Icon(
                     painter = painterResource(id = CommonR.drawable.ic_action_search),
                     contentDescription = stringResource(R.string.search_action),
                     modifier = Modifier.size(20.dp),
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = searchIconColor,
                 )
             }
         },

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchBar.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -36,18 +35,6 @@ fun ItemSearchBar(
             }
         },
         placeholder = placeholder,
-        leadingContent = {
-            Icon(
-                imageVector = Icons.Default.Search,
-                contentDescription = null,
-                modifier = Modifier.size(18.dp),
-                tint = if (keyword.isBlank()) {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                } else {
-                    MaterialTheme.colorScheme.primary
-                },
-            )
-        },
         trailingContent = {
             if (keyword.isNotBlank()) {
                 IconButton(onClick = { onKeywordChange("") }) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchBar.kt
@@ -1,0 +1,94 @@
+package com.team.yeogibeoryeo.presentation.search.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.common.R as CommonR
+import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.common.components.SearchBarField
+
+@Composable
+fun ItemSearchBar(
+    keyword: String,
+    onKeywordChange: (String) -> Unit,
+    onSearchClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String,
+) {
+    SearchBarField(
+        modifier = modifier.fillMaxWidth(),
+        keyword = keyword,
+        onKeywordChange = onKeywordChange,
+        onSearch = {
+            if (keyword.isNotBlank()) {
+                onSearchClick()
+            }
+        },
+        placeholder = placeholder,
+        leadingContent = {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = if (keyword.isBlank()) {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                } else {
+                    MaterialTheme.colorScheme.primary
+                },
+            )
+        },
+        trailingContent = {
+            if (keyword.isNotBlank()) {
+                IconButton(onClick = { onKeywordChange("") }) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "검색어 지우기",
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            IconButton(
+                onClick = {
+                    if (keyword.isNotBlank()) {
+                        onSearchClick()
+                    }
+                },
+                enabled = keyword.isNotBlank(),
+            ) {
+                Icon(
+                    painter = painterResource(id = CommonR.drawable.ic_action_search),
+                    contentDescription = stringResource(R.string.search_action),
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+        },
+        minHeight = 56.dp,
+        searchEnabled = { it.isNotBlank() },
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ItemSearchBarPreview() {
+    ItemSearchBar(
+        keyword = "비닐",
+        onKeywordChange = {},
+        onSearchClick = {},
+        placeholder = "품목 검색",
+        modifier = Modifier.fillMaxWidth(),
+    )
+}


### PR DESCRIPTION
## 작업 내용
- `안내` 탭 공통 검색바와 내부 렌더링이 동일하지 않게 보이던 지점(지도 검색바)에서, 불필요한 레이아웃 래핑(`Row`)을 제거해 SearchBarField 본문만 그대로 사용하도록 정렬했습니다.
- 좌측 아이콘 제거는 유지한 상태에서, 검색바의 배경/모서리/테두리 룩은 `안내` 탭과 동일 경로를 사용하도록 했습니다.

## 확인 사항
- 지도 탭 검색바 내부 배경/테두리/캔버스가 안내 탭 검색바와 같은 스타일로 보이는지
- 검색어 입력/클리어/검색(아이콘/IME) 동작 유지

## 테스트
- `./gradlew.bat :presentation:compileDebugKotlin`

## 관련 이슈
- Related #110