### PR TITLE
feat: 수거 장소 즐겨찾기 저장 및 Favorites 장소 탭 연동

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/di/FavoriteDataModule.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/di/FavoriteDataModule.kt
@@ -2,9 +2,14 @@ package com.team.yeogibeoryeo.data.favorite.di
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.team.yeogibeoryeo.data.favorite.local.CollectionSpotFavoriteSnapshotDao
 import com.team.yeogibeoryeo.data.favorite.local.FavoriteDao
 import com.team.yeogibeoryeo.data.favorite.local.FavoriteDatabase
+import com.team.yeogibeoryeo.data.favorite.repository.CollectionSpotFavoriteSnapshotRepositoryImpl
 import com.team.yeogibeoryeo.data.favorite.repository.FavoriteRepositoryImpl
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
 import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
 import dagger.Binds
 import dagger.Module
@@ -26,11 +31,39 @@ object FavoriteDatabaseModule {
             context,
             FavoriteDatabase::class.java,
             "yeogi_beoryeo_favorites.db",
-        ).build()
+        )
+            .addMigrations(FAVORITE_DATABASE_MIGRATION_1_2)
+            .build()
 
     @Provides
     @Singleton
     fun provideFavoriteDao(database: FavoriteDatabase): FavoriteDao = database.favoriteDao()
+
+    @Provides
+    @Singleton
+    fun provideCollectionSpotFavoriteSnapshotDao(
+        database: FavoriteDatabase,
+    ): CollectionSpotFavoriteSnapshotDao = database.collectionSpotFavoriteSnapshotDao()
+
+    private val FAVORITE_DATABASE_MIGRATION_1_2 =
+        object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS collection_spot_favorite_snapshots (
+                        targetId TEXT NOT NULL,
+                        name TEXT NOT NULL,
+                        spotType TEXT NOT NULL,
+                        address TEXT NOT NULL,
+                        detailLocation TEXT,
+                        latitude REAL,
+                        longitude REAL,
+                        PRIMARY KEY(targetId)
+                    )
+                    """.trimIndent(),
+                )
+            }
+        }
 }
 
 @Module
@@ -39,4 +72,10 @@ abstract class FavoriteBindModule {
     @Binds
     @Singleton
     abstract fun bindFavoriteRepository(repository: FavoriteRepositoryImpl): FavoriteRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindCollectionSpotFavoriteSnapshotRepository(
+        repository: CollectionSpotFavoriteSnapshotRepositoryImpl,
+    ): CollectionSpotFavoriteSnapshotRepository
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/di/FavoriteDataModule.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/di/FavoriteDataModule.kt
@@ -8,7 +8,9 @@ import com.team.yeogibeoryeo.data.favorite.local.CollectionSpotFavoriteSnapshotD
 import com.team.yeogibeoryeo.data.favorite.local.FavoriteDao
 import com.team.yeogibeoryeo.data.favorite.local.FavoriteDatabase
 import com.team.yeogibeoryeo.data.favorite.repository.CollectionSpotFavoriteSnapshotRepositoryImpl
+import com.team.yeogibeoryeo.data.favorite.repository.CollectionSpotFavoriteRepositoryImpl
 import com.team.yeogibeoryeo.data.favorite.repository.FavoriteRepositoryImpl
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteRepository
 import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
 import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
 import dagger.Binds
@@ -78,4 +80,10 @@ abstract class FavoriteBindModule {
     abstract fun bindCollectionSpotFavoriteSnapshotRepository(
         repository: CollectionSpotFavoriteSnapshotRepositoryImpl,
     ): CollectionSpotFavoriteSnapshotRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindCollectionSpotFavoriteRepository(
+        repository: CollectionSpotFavoriteRepositoryImpl,
+    ): CollectionSpotFavoriteRepository
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/CollectionSpotFavoriteSnapshotDao.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/CollectionSpotFavoriteSnapshotDao.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface CollectionSpotFavoriteSnapshotDao {
-    @Query("SELECT * FROM collection_spot_favorite_snapshots ORDER BY targetId ASC")
+    @Query("SELECT * FROM collection_spot_favorite_snapshots")
     fun observeSnapshots(): Flow<List<CollectionSpotFavoriteSnapshotEntity>>
 
     @Query("SELECT * FROM collection_spot_favorite_snapshots WHERE targetId = :targetId")

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/CollectionSpotFavoriteSnapshotDao.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/CollectionSpotFavoriteSnapshotDao.kt
@@ -1,0 +1,21 @@
+package com.team.yeogibeoryeo.data.favorite.local
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CollectionSpotFavoriteSnapshotDao {
+    @Query("SELECT * FROM collection_spot_favorite_snapshots ORDER BY targetId ASC")
+    fun observeSnapshots(): Flow<List<CollectionSpotFavoriteSnapshotEntity>>
+
+    @Query("SELECT * FROM collection_spot_favorite_snapshots WHERE targetId = :targetId")
+    suspend fun getSnapshot(targetId: String): CollectionSpotFavoriteSnapshotEntity?
+
+    @Upsert
+    suspend fun upsertSnapshot(entity: CollectionSpotFavoriteSnapshotEntity)
+
+    @Query("DELETE FROM collection_spot_favorite_snapshots WHERE targetId = :targetId")
+    suspend fun deleteSnapshot(targetId: String)
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/CollectionSpotFavoriteSnapshotEntity.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/CollectionSpotFavoriteSnapshotEntity.kt
@@ -1,0 +1,15 @@
+package com.team.yeogibeoryeo.data.favorite.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "collection_spot_favorite_snapshots")
+data class CollectionSpotFavoriteSnapshotEntity(
+    @PrimaryKey val targetId: String,
+    val name: String,
+    val spotType: String,
+    val address: String,
+    val detailLocation: String?,
+    val latitude: Double?,
+    val longitude: Double?,
+)

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/FavoriteDatabase.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/FavoriteDatabase.kt
@@ -4,10 +4,15 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 
 @Database(
-    entities = [FavoriteEntity::class],
-    version = 1,
+    entities = [
+        FavoriteEntity::class,
+        CollectionSpotFavoriteSnapshotEntity::class,
+    ],
+    version = 2,
     exportSchema = false,
 )
 abstract class FavoriteDatabase : RoomDatabase() {
     abstract fun favoriteDao(): FavoriteDao
+
+    abstract fun collectionSpotFavoriteSnapshotDao(): CollectionSpotFavoriteSnapshotDao
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/mapper/CollectionSpotFavoriteSnapshotMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/mapper/CollectionSpotFavoriteSnapshotMapper.kt
@@ -1,0 +1,39 @@
+package com.team.yeogibeoryeo.data.favorite.mapper
+
+import com.team.yeogibeoryeo.data.favorite.local.CollectionSpotFavoriteSnapshotEntity
+import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+
+fun CollectionSpotFavoriteSnapshot.toEntity(): CollectionSpotFavoriteSnapshotEntity =
+    CollectionSpotFavoriteSnapshotEntity(
+        targetId = targetId,
+        name = name,
+        spotType = type.name,
+        address = address,
+        detailLocation = detailLocation,
+        latitude = coordinate?.latitude,
+        longitude = coordinate?.longitude,
+    )
+
+fun CollectionSpotFavoriteSnapshotEntity.toDomain(): CollectionSpotFavoriteSnapshot? {
+    val type = runCatching {
+        CollectionSpotType.valueOf(spotType)
+    }.getOrNull() ?: return null
+
+    return CollectionSpotFavoriteSnapshot(
+        targetId = targetId,
+        name = name,
+        type = type,
+        address = address,
+        detailLocation = detailLocation,
+        coordinate = latitude?.let { latitude ->
+            longitude?.let { longitude ->
+                Coordinate(
+                    latitude = latitude,
+                    longitude = longitude,
+                )
+            }
+        },
+    )
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/repository/CollectionSpotFavoriteRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/repository/CollectionSpotFavoriteRepositoryImpl.kt
@@ -1,0 +1,49 @@
+package com.team.yeogibeoryeo.data.favorite.repository
+
+import androidx.room.withTransaction
+import com.team.yeogibeoryeo.data.favorite.local.FavoriteDatabase
+import com.team.yeogibeoryeo.data.favorite.mapper.toEntity
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.model.toFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteRepository
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import javax.inject.Inject
+
+class CollectionSpotFavoriteRepositoryImpl
+    @Inject
+    constructor(
+        private val database: FavoriteDatabase,
+    ) : CollectionSpotFavoriteRepository {
+        override suspend fun toggleFavorite(spot: CollectionSpot): Boolean =
+            database.withTransaction {
+                val favoriteDao = database.favoriteDao()
+                val snapshotDao = database.collectionSpotFavoriteSnapshotDao()
+                val favorite =
+                    Favorite(
+                        type = FavoriteTargetType.COLLECTION_SPOT,
+                        targetId = spot.id,
+                        savedAtMillis = System.currentTimeMillis(),
+                    )
+
+                if (favoriteDao.isFavorite(favorite.type.name, favorite.targetId)) {
+                    favoriteDao.deleteFavorite(favorite.type.name, favorite.targetId)
+                    snapshotDao.deleteSnapshot(spot.id)
+                    false
+                } else {
+                    favoriteDao.upsertFavorite(favorite.toEntity())
+                    snapshotDao.upsertSnapshot(spot.toFavoriteSnapshot().toEntity())
+                    true
+                }
+            }
+
+        override suspend fun removeFavorite(targetId: String) {
+            database.withTransaction {
+                database.favoriteDao().deleteFavorite(
+                    type = FavoriteTargetType.COLLECTION_SPOT.name,
+                    targetId = targetId,
+                )
+                database.collectionSpotFavoriteSnapshotDao().deleteSnapshot(targetId)
+            }
+        }
+    }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/repository/CollectionSpotFavoriteSnapshotRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/repository/CollectionSpotFavoriteSnapshotRepositoryImpl.kt
@@ -1,0 +1,31 @@
+package com.team.yeogibeoryeo.data.favorite.repository
+
+import com.team.yeogibeoryeo.data.favorite.local.CollectionSpotFavoriteSnapshotDao
+import com.team.yeogibeoryeo.data.favorite.mapper.toDomain
+import com.team.yeogibeoryeo.data.favorite.mapper.toEntity
+import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class CollectionSpotFavoriteSnapshotRepositoryImpl
+    @Inject
+    constructor(
+        private val snapshotDao: CollectionSpotFavoriteSnapshotDao,
+    ) : CollectionSpotFavoriteSnapshotRepository {
+        override fun observeSnapshots(): Flow<List<CollectionSpotFavoriteSnapshot>> =
+            snapshotDao.observeSnapshots()
+                .map { entities -> entities.mapNotNull { entity -> entity.toDomain() } }
+
+        override suspend fun getSnapshot(targetId: String): CollectionSpotFavoriteSnapshot? =
+            snapshotDao.getSnapshot(targetId)?.toDomain()
+
+        override suspend fun upsertSnapshot(snapshot: CollectionSpotFavoriteSnapshot) {
+            snapshotDao.upsertSnapshot(snapshot.toEntity())
+        }
+
+        override suspend fun deleteSnapshot(targetId: String) {
+            snapshotDao.deleteSnapshot(targetId)
+        }
+    }

--- a/data/src/test/java/com/team/yeogibeoryeo/data/favorite/mapper/CollectionSpotFavoriteSnapshotMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/favorite/mapper/CollectionSpotFavoriteSnapshotMapperTest.kt
@@ -1,0 +1,78 @@
+package com.team.yeogibeoryeo.data.favorite.mapper
+
+import com.team.yeogibeoryeo.data.favorite.local.CollectionSpotFavoriteSnapshotEntity
+import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CollectionSpotFavoriteSnapshotMapperTest {
+    @Test
+    fun `수거 장소 즐겨찾기 스냅샷을 Entity로 변환한다`() {
+        val snapshot =
+            CollectionSpotFavoriteSnapshot(
+                targetId = "spot-1",
+                name = "폐건전지 수거함",
+                type = CollectionSpotType.BATTERY_BIN,
+                address = "서울특별시 영등포구 문래동",
+                detailLocation = "주민센터 앞",
+                coordinate = Coordinate(latitude = 37.5, longitude = 126.9),
+            )
+
+        val entity = snapshot.toEntity()
+
+        assertEquals("spot-1", entity.targetId)
+        assertEquals("폐건전지 수거함", entity.name)
+        assertEquals("BATTERY_BIN", entity.spotType)
+        assertEquals("서울특별시 영등포구 문래동", entity.address)
+        assertEquals("주민센터 앞", entity.detailLocation)
+        assertEquals(37.5, entity.latitude)
+        assertEquals(126.9, entity.longitude)
+    }
+
+    @Test
+    fun `Entity를 수거 장소 즐겨찾기 스냅샷으로 변환한다`() {
+        val entity =
+            CollectionSpotFavoriteSnapshotEntity(
+                targetId = "spot-1",
+                name = "폐건전지 수거함",
+                spotType = "BATTERY_BIN",
+                address = "서울특별시 영등포구 문래동",
+                detailLocation = "주민센터 앞",
+                latitude = 37.5,
+                longitude = 126.9,
+            )
+
+        val snapshot = entity.toDomain()
+
+        assertEquals(
+            CollectionSpotFavoriteSnapshot(
+                targetId = "spot-1",
+                name = "폐건전지 수거함",
+                type = CollectionSpotType.BATTERY_BIN,
+                address = "서울특별시 영등포구 문래동",
+                detailLocation = "주민센터 앞",
+                coordinate = Coordinate(latitude = 37.5, longitude = 126.9),
+            ),
+            snapshot,
+        )
+    }
+
+    @Test
+    fun `알 수 없는 수거 장소 타입은 null로 변환한다`() {
+        val entity =
+            CollectionSpotFavoriteSnapshotEntity(
+                targetId = "spot-1",
+                name = "수거함",
+                spotType = "UNKNOWN_TYPE",
+                address = "주소",
+                detailLocation = null,
+                latitude = null,
+                longitude = null,
+            )
+
+        assertNull(entity.toDomain())
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/CollectionSpotFavoriteSnapshot.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/CollectionSpotFavoriteSnapshot.kt
@@ -1,0 +1,24 @@
+package com.team.yeogibeoryeo.domain.favorite.model
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+
+data class CollectionSpotFavoriteSnapshot(
+    val targetId: String,
+    val name: String,
+    val type: CollectionSpotType,
+    val address: String,
+    val detailLocation: String?,
+    val coordinate: Coordinate?,
+)
+
+fun CollectionSpot.toFavoriteSnapshot(): CollectionSpotFavoriteSnapshot =
+    CollectionSpotFavoriteSnapshot(
+        targetId = id,
+        name = name,
+        type = type,
+        address = address,
+        detailLocation = detailLocation,
+        coordinate = coordinate,
+    )

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/repository/CollectionSpotFavoriteRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/repository/CollectionSpotFavoriteRepository.kt
@@ -1,0 +1,9 @@
+package com.team.yeogibeoryeo.domain.favorite.repository
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+
+interface CollectionSpotFavoriteRepository {
+    suspend fun toggleFavorite(spot: CollectionSpot): Boolean
+
+    suspend fun removeFavorite(targetId: String)
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/repository/CollectionSpotFavoriteSnapshotRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/repository/CollectionSpotFavoriteSnapshotRepository.kt
@@ -1,0 +1,14 @@
+package com.team.yeogibeoryeo.domain.favorite.repository
+
+import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
+import kotlinx.coroutines.flow.Flow
+
+interface CollectionSpotFavoriteSnapshotRepository {
+    fun observeSnapshots(): Flow<List<CollectionSpotFavoriteSnapshot>>
+
+    suspend fun getSnapshot(targetId: String): CollectionSpotFavoriteSnapshot?
+
+    suspend fun upsertSnapshot(snapshot: CollectionSpotFavoriteSnapshot)
+
+    suspend fun deleteSnapshot(targetId: String)
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/GetCollectionSpotFavoriteSnapshotUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/GetCollectionSpotFavoriteSnapshotUseCase.kt
@@ -1,0 +1,12 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
+import javax.inject.Inject
+
+class GetCollectionSpotFavoriteSnapshotUseCase
+    @Inject
+    constructor(
+        private val repository: CollectionSpotFavoriteSnapshotRepository,
+    ) {
+        suspend operator fun invoke(targetId: String) = repository.getSnapshot(targetId)
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ObserveCollectionSpotFavoriteSnapshotsUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ObserveCollectionSpotFavoriteSnapshotsUseCase.kt
@@ -1,0 +1,12 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
+import javax.inject.Inject
+
+class ObserveCollectionSpotFavoriteSnapshotsUseCase
+    @Inject
+    constructor(
+        private val repository: CollectionSpotFavoriteSnapshotRepository,
+    ) {
+        operator fun invoke() = repository.observeSnapshots()
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/RemoveCollectionSpotFavoriteSnapshotUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/RemoveCollectionSpotFavoriteSnapshotUseCase.kt
@@ -1,0 +1,14 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
+import javax.inject.Inject
+
+class RemoveCollectionSpotFavoriteSnapshotUseCase
+    @Inject
+    constructor(
+        private val repository: CollectionSpotFavoriteSnapshotRepository,
+    ) {
+        suspend operator fun invoke(targetId: String) {
+            repository.deleteSnapshot(targetId)
+        }
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/RemoveCollectionSpotFavoriteUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/RemoveCollectionSpotFavoriteUseCase.kt
@@ -1,0 +1,21 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import javax.inject.Inject
+
+class RemoveCollectionSpotFavoriteUseCase
+    @Inject
+    constructor(
+        private val favoriteRepository: FavoriteRepository,
+        private val snapshotRepository: CollectionSpotFavoriteSnapshotRepository,
+    ) {
+        suspend operator fun invoke(targetId: String) {
+            favoriteRepository.removeFavorite(
+                type = FavoriteTargetType.COLLECTION_SPOT,
+                targetId = targetId,
+            )
+            snapshotRepository.deleteSnapshot(targetId)
+        }
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/RemoveCollectionSpotFavoriteUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/RemoveCollectionSpotFavoriteUseCase.kt
@@ -1,21 +1,13 @@
 package com.team.yeogibeoryeo.domain.favorite.usecase
 
-import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
-import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
-import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteRepository
 import javax.inject.Inject
 
 class RemoveCollectionSpotFavoriteUseCase
     @Inject
     constructor(
-        private val favoriteRepository: FavoriteRepository,
-        private val snapshotRepository: CollectionSpotFavoriteSnapshotRepository,
+        private val collectionSpotFavoriteRepository: CollectionSpotFavoriteRepository,
     ) {
-        suspend operator fun invoke(targetId: String) {
-            favoriteRepository.removeFavorite(
-                type = FavoriteTargetType.COLLECTION_SPOT,
-                targetId = targetId,
-            )
-            snapshotRepository.deleteSnapshot(targetId)
-        }
+        suspend operator fun invoke(targetId: String) =
+            collectionSpotFavoriteRepository.removeFavorite(targetId)
     }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/SaveCollectionSpotFavoriteSnapshotUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/SaveCollectionSpotFavoriteSnapshotUseCase.kt
@@ -1,0 +1,15 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
+import javax.inject.Inject
+
+class SaveCollectionSpotFavoriteSnapshotUseCase
+    @Inject
+    constructor(
+        private val repository: CollectionSpotFavoriteSnapshotRepository,
+    ) {
+        suspend operator fun invoke(snapshot: CollectionSpotFavoriteSnapshot) {
+            repository.upsertSnapshot(snapshot)
+        }
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ToggleCollectionSpotFavoriteUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ToggleCollectionSpotFavoriteUseCase.kt
@@ -1,0 +1,35 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.model.toFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import javax.inject.Inject
+
+class ToggleCollectionSpotFavoriteUseCase
+    @Inject
+    constructor(
+        private val favoriteRepository: FavoriteRepository,
+        private val snapshotRepository: CollectionSpotFavoriteSnapshotRepository,
+    ) {
+        suspend operator fun invoke(spot: CollectionSpot): Boolean {
+            val isFavorite =
+                favoriteRepository.toggleFavorite(
+                    Favorite(
+                        type = FavoriteTargetType.COLLECTION_SPOT,
+                        targetId = spot.id,
+                        savedAtMillis = System.currentTimeMillis(),
+                    ),
+                )
+
+            if (isFavorite) {
+                snapshotRepository.upsertSnapshot(spot.toFavoriteSnapshot())
+            } else {
+                snapshotRepository.deleteSnapshot(spot.id)
+            }
+
+            return isFavorite
+        }
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ToggleCollectionSpotFavoriteUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ToggleCollectionSpotFavoriteUseCase.kt
@@ -1,35 +1,14 @@
 package com.team.yeogibeoryeo.domain.favorite.usecase
 
-import com.team.yeogibeoryeo.domain.favorite.model.Favorite
-import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
-import com.team.yeogibeoryeo.domain.favorite.model.toFavoriteSnapshot
-import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
-import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteRepository
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import javax.inject.Inject
 
 class ToggleCollectionSpotFavoriteUseCase
     @Inject
     constructor(
-        private val favoriteRepository: FavoriteRepository,
-        private val snapshotRepository: CollectionSpotFavoriteSnapshotRepository,
+        private val collectionSpotFavoriteRepository: CollectionSpotFavoriteRepository,
     ) {
-        suspend operator fun invoke(spot: CollectionSpot): Boolean {
-            val isFavorite =
-                favoriteRepository.toggleFavorite(
-                    Favorite(
-                        type = FavoriteTargetType.COLLECTION_SPOT,
-                        targetId = spot.id,
-                        savedAtMillis = System.currentTimeMillis(),
-                    ),
-                )
-
-            if (isFavorite) {
-                snapshotRepository.upsertSnapshot(spot.toFavoriteSnapshot())
-            } else {
-                snapshotRepository.deleteSnapshot(spot.id)
-            }
-
-            return isFavorite
-        }
+        suspend operator fun invoke(spot: CollectionSpot): Boolean =
+            collectionSpotFavoriteRepository.toggleFavorite(spot)
     }

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/model/CollectionSpotFavoriteSnapshotTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/model/CollectionSpotFavoriteSnapshotTest.kt
@@ -1,0 +1,33 @@
+package com.team.yeogibeoryeo.domain.favorite.model
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CollectionSpotFavoriteSnapshotTest {
+    @Test
+    fun `CollectionSpot id를 수거 장소 즐겨찾기 targetId로 사용한다`() {
+        val spot =
+            CollectionSpot(
+                id = "폐건전지 수거함_서울특별시 영등포구 문래동_주민센터 앞",
+                name = "폐건전지 수거함",
+                type = CollectionSpotType.BATTERY_BIN,
+                address = "서울특별시 영등포구 문래동",
+                detailLocation = "주민센터 앞",
+                coordinate = Coordinate(latitude = 37.5, longitude = 126.9),
+                distanceMeter = 120,
+                isBookmarked = true,
+            )
+
+        val snapshot = spot.toFavoriteSnapshot()
+
+        assertEquals(spot.id, snapshot.targetId)
+        assertEquals(spot.name, snapshot.name)
+        assertEquals(spot.type, snapshot.type)
+        assertEquals(spot.address, snapshot.address)
+        assertEquals(spot.detailLocation, snapshot.detailLocation)
+        assertEquals(spot.coordinate, snapshot.coordinate)
+    }
+}

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/usecase/RemoveCollectionSpotFavoriteUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/usecase/RemoveCollectionSpotFavoriteUseCaseTest.kt
@@ -1,15 +1,12 @@
 package com.team.yeogibeoryeo.domain.favorite.usecase
 
 import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
-import com.team.yeogibeoryeo.domain.favorite.model.Favorite
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
-import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
-import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteRepository
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -20,19 +17,9 @@ class RemoveCollectionSpotFavoriteUseCaseTest {
     fun `targetId로 공통 Favorite와 수거 장소 스냅샷을 함께 삭제한다`() =
         runBlocking {
             val targetId = "spot-1"
-            val favoriteRepository =
-                FakeFavoriteRepository(
-                    initialFavorites =
-                        listOf(
-                            Favorite(
-                                type = FavoriteTargetType.COLLECTION_SPOT,
-                                targetId = targetId,
-                                savedAtMillis = 1L,
-                            ),
-                        ),
-                )
-            val snapshotRepository =
-                FakeCollectionSpotFavoriteSnapshotRepository(
+            val collectionSpotFavoriteRepository =
+                FakeCollectionSpotFavoriteRepository(
+                    favoriteTargetIds = setOf(targetId),
                     initialSnapshots =
                         listOf(
                             CollectionSpotFavoriteSnapshot(
@@ -47,79 +34,32 @@ class RemoveCollectionSpotFavoriteUseCaseTest {
                 )
             val useCase =
                 RemoveCollectionSpotFavoriteUseCase(
-                    favoriteRepository = favoriteRepository,
-                    snapshotRepository = snapshotRepository,
+                    collectionSpotFavoriteRepository = collectionSpotFavoriteRepository,
                 )
 
             useCase(targetId)
 
-            assertFalse(favoriteRepository.isFavorite(FavoriteTargetType.COLLECTION_SPOT, targetId))
-            assertEquals(emptyList<CollectionSpotFavoriteSnapshot>(), snapshotRepository.snapshots.value)
+            assertFalse(collectionSpotFavoriteRepository.isFavorite(FavoriteTargetType.COLLECTION_SPOT, targetId))
+            assertEquals(emptyList<CollectionSpotFavoriteSnapshot>(), collectionSpotFavoriteRepository.snapshots.value)
         }
 
-    private class FakeFavoriteRepository(
-        initialFavorites: List<Favorite> = emptyList(),
-    ) : FavoriteRepository {
-        private val favorites = MutableStateFlow(initialFavorites)
-
-        override fun observeFavorites(): Flow<List<Favorite>> = favorites
-
-        override fun observeFavorite(
-            type: FavoriteTargetType,
-            targetId: String,
-        ): Flow<Boolean> =
-            favorites.map { items ->
-                items.any { favorite -> favorite.type == type && favorite.targetId == targetId }
-            }
-
-        override suspend fun isFavorite(
-            type: FavoriteTargetType,
-            targetId: String,
-        ): Boolean =
-            favorites.value.any { favorite -> favorite.type == type && favorite.targetId == targetId }
-
-        override suspend fun toggleFavorite(favorite: Favorite): Boolean {
-            return if (isFavorite(favorite.type, favorite.targetId)) {
-                removeFavorite(favorite.type, favorite.targetId)
-                false
-            } else {
-                addFavorite(favorite)
-                true
-            }
-        }
-
-        override suspend fun addFavorite(favorite: Favorite) {
-            favorites.value =
-                favorites.value
-                    .filterNot { it.type == favorite.type && it.targetId == favorite.targetId } + favorite
-        }
-
-        override suspend fun removeFavorite(
-            type: FavoriteTargetType,
-            targetId: String,
-        ) {
-            favorites.value = favorites.value.filterNot { it.type == type && it.targetId == targetId }
-        }
-    }
-
-    private class FakeCollectionSpotFavoriteSnapshotRepository(
+    private class FakeCollectionSpotFavoriteRepository(
+        favoriteTargetIds: Set<String> = emptySet(),
         initialSnapshots: List<CollectionSpotFavoriteSnapshot> = emptyList(),
-    ) : CollectionSpotFavoriteSnapshotRepository {
+    ) : CollectionSpotFavoriteRepository {
+        private val favoriteIds = MutableStateFlow(favoriteTargetIds)
         val snapshots = MutableStateFlow(initialSnapshots)
 
-        override fun observeSnapshots(): Flow<List<CollectionSpotFavoriteSnapshot>> = snapshots
+        override suspend fun toggleFavorite(spot: CollectionSpot): Boolean = false
 
-        override suspend fun getSnapshot(targetId: String): CollectionSpotFavoriteSnapshot? =
-            snapshots.value.firstOrNull { snapshot -> snapshot.targetId == targetId }
-
-        override suspend fun upsertSnapshot(snapshot: CollectionSpotFavoriteSnapshot) {
-            snapshots.value =
-                snapshots.value
-                    .filterNot { it.targetId == snapshot.targetId } + snapshot
-        }
-
-        override suspend fun deleteSnapshot(targetId: String) {
+        override suspend fun removeFavorite(targetId: String) {
+            favoriteIds.value = favoriteIds.value - targetId
             snapshots.value = snapshots.value.filterNot { it.targetId == targetId }
         }
+
+        fun isFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Boolean = type == FavoriteTargetType.COLLECTION_SPOT && targetId in favoriteIds.value
     }
 }

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/usecase/RemoveCollectionSpotFavoriteUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/usecase/RemoveCollectionSpotFavoriteUseCaseTest.kt
@@ -1,0 +1,125 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class RemoveCollectionSpotFavoriteUseCaseTest {
+    @Test
+    fun `targetId로 공통 Favorite와 수거 장소 스냅샷을 함께 삭제한다`() =
+        runBlocking {
+            val targetId = "spot-1"
+            val favoriteRepository =
+                FakeFavoriteRepository(
+                    initialFavorites =
+                        listOf(
+                            Favorite(
+                                type = FavoriteTargetType.COLLECTION_SPOT,
+                                targetId = targetId,
+                                savedAtMillis = 1L,
+                            ),
+                        ),
+                )
+            val snapshotRepository =
+                FakeCollectionSpotFavoriteSnapshotRepository(
+                    initialSnapshots =
+                        listOf(
+                            CollectionSpotFavoriteSnapshot(
+                                targetId = targetId,
+                                name = "폐건전지 수거함",
+                                type = CollectionSpotType.BATTERY_BIN,
+                                address = "서울특별시 영등포구 문래동",
+                                detailLocation = "주민센터 앞",
+                                coordinate = Coordinate(latitude = 37.5, longitude = 126.9),
+                            ),
+                        ),
+                )
+            val useCase =
+                RemoveCollectionSpotFavoriteUseCase(
+                    favoriteRepository = favoriteRepository,
+                    snapshotRepository = snapshotRepository,
+                )
+
+            useCase(targetId)
+
+            assertFalse(favoriteRepository.isFavorite(FavoriteTargetType.COLLECTION_SPOT, targetId))
+            assertEquals(emptyList<CollectionSpotFavoriteSnapshot>(), snapshotRepository.snapshots.value)
+        }
+
+    private class FakeFavoriteRepository(
+        initialFavorites: List<Favorite> = emptyList(),
+    ) : FavoriteRepository {
+        private val favorites = MutableStateFlow(initialFavorites)
+
+        override fun observeFavorites(): Flow<List<Favorite>> = favorites
+
+        override fun observeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Flow<Boolean> =
+            favorites.map { items ->
+                items.any { favorite -> favorite.type == type && favorite.targetId == targetId }
+            }
+
+        override suspend fun isFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Boolean =
+            favorites.value.any { favorite -> favorite.type == type && favorite.targetId == targetId }
+
+        override suspend fun toggleFavorite(favorite: Favorite): Boolean {
+            return if (isFavorite(favorite.type, favorite.targetId)) {
+                removeFavorite(favorite.type, favorite.targetId)
+                false
+            } else {
+                addFavorite(favorite)
+                true
+            }
+        }
+
+        override suspend fun addFavorite(favorite: Favorite) {
+            favorites.value =
+                favorites.value
+                    .filterNot { it.type == favorite.type && it.targetId == favorite.targetId } + favorite
+        }
+
+        override suspend fun removeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ) {
+            favorites.value = favorites.value.filterNot { it.type == type && it.targetId == targetId }
+        }
+    }
+
+    private class FakeCollectionSpotFavoriteSnapshotRepository(
+        initialSnapshots: List<CollectionSpotFavoriteSnapshot> = emptyList(),
+    ) : CollectionSpotFavoriteSnapshotRepository {
+        val snapshots = MutableStateFlow(initialSnapshots)
+
+        override fun observeSnapshots(): Flow<List<CollectionSpotFavoriteSnapshot>> = snapshots
+
+        override suspend fun getSnapshot(targetId: String): CollectionSpotFavoriteSnapshot? =
+            snapshots.value.firstOrNull { snapshot -> snapshot.targetId == targetId }
+
+        override suspend fun upsertSnapshot(snapshot: CollectionSpotFavoriteSnapshot) {
+            snapshots.value =
+                snapshots.value
+                    .filterNot { it.targetId == snapshot.targetId } + snapshot
+        }
+
+        override suspend fun deleteSnapshot(targetId: String) {
+            snapshots.value = snapshots.value.filterNot { it.targetId == targetId }
+        }
+    }
+}

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/usecase/ToggleCollectionSpotFavoriteUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/usecase/ToggleCollectionSpotFavoriteUseCaseTest.kt
@@ -1,0 +1,152 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ToggleCollectionSpotFavoriteUseCaseTest {
+    @Test
+    fun `즐겨찾기가 아니면 공통 Favorite와 수거 장소 스냅샷을 저장한다`() =
+        runBlocking {
+            val favoriteRepository = FakeFavoriteRepository()
+            val snapshotRepository = FakeCollectionSpotFavoriteSnapshotRepository()
+            val useCase = ToggleCollectionSpotFavoriteUseCase(
+                favoriteRepository = favoriteRepository,
+                snapshotRepository = snapshotRepository,
+            )
+            val spot = sampleSpot()
+
+            val isFavorite = useCase(spot)
+
+            assertTrue(isFavorite)
+            assertTrue(favoriteRepository.isFavorite(FavoriteTargetType.COLLECTION_SPOT, spot.id))
+            assertEquals(spot.id, snapshotRepository.snapshots.value.single().targetId)
+            assertEquals(spot.coordinate, snapshotRepository.snapshots.value.single().coordinate)
+        }
+
+    @Test
+    fun `이미 즐겨찾기면 공통 Favorite와 수거 장소 스냅샷을 삭제한다`() =
+        runBlocking {
+            val spot = sampleSpot()
+            val favoriteRepository = FakeFavoriteRepository(
+                initialFavorites = listOf(
+                    Favorite(
+                        type = FavoriteTargetType.COLLECTION_SPOT,
+                        targetId = spot.id,
+                        savedAtMillis = 1L,
+                    ),
+                ),
+            )
+            val snapshotRepository = FakeCollectionSpotFavoriteSnapshotRepository(
+                initialSnapshots = listOf(
+                    CollectionSpotFavoriteSnapshot(
+                        targetId = spot.id,
+                        name = spot.name,
+                        type = spot.type,
+                        address = spot.address,
+                        detailLocation = spot.detailLocation,
+                        coordinate = spot.coordinate,
+                    ),
+                ),
+            )
+            val useCase = ToggleCollectionSpotFavoriteUseCase(
+                favoriteRepository = favoriteRepository,
+                snapshotRepository = snapshotRepository,
+            )
+
+            val isFavorite = useCase(spot)
+
+            assertFalse(isFavorite)
+            assertFalse(favoriteRepository.isFavorite(FavoriteTargetType.COLLECTION_SPOT, spot.id))
+            assertEquals(emptyList<CollectionSpotFavoriteSnapshot>(), snapshotRepository.snapshots.value)
+        }
+
+    private fun sampleSpot(): CollectionSpot =
+        CollectionSpot(
+            id = "spot-1",
+            name = "폐건전지 수거함",
+            type = CollectionSpotType.BATTERY_BIN,
+            address = "서울특별시 영등포구 문래동",
+            detailLocation = "주민센터 앞",
+            coordinate = Coordinate(latitude = 37.5, longitude = 126.9),
+        )
+
+    private class FakeFavoriteRepository(
+        initialFavorites: List<Favorite> = emptyList(),
+    ) : FavoriteRepository {
+        private val favorites = MutableStateFlow(initialFavorites)
+
+        override fun observeFavorites(): Flow<List<Favorite>> = favorites
+
+        override fun observeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Flow<Boolean> =
+            favorites.map { items ->
+                items.any { favorite -> favorite.type == type && favorite.targetId == targetId }
+            }
+
+        override suspend fun isFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Boolean =
+            favorites.value.any { favorite -> favorite.type == type && favorite.targetId == targetId }
+
+        override suspend fun toggleFavorite(favorite: Favorite): Boolean {
+            return if (isFavorite(favorite.type, favorite.targetId)) {
+                removeFavorite(favorite.type, favorite.targetId)
+                false
+            } else {
+                addFavorite(favorite)
+                true
+            }
+        }
+
+        override suspend fun addFavorite(favorite: Favorite) {
+            favorites.value =
+                favorites.value
+                    .filterNot { it.type == favorite.type && it.targetId == favorite.targetId } + favorite
+        }
+
+        override suspend fun removeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ) {
+            favorites.value = favorites.value.filterNot { it.type == type && it.targetId == targetId }
+        }
+    }
+
+    private class FakeCollectionSpotFavoriteSnapshotRepository(
+        initialSnapshots: List<CollectionSpotFavoriteSnapshot> = emptyList(),
+    ) : CollectionSpotFavoriteSnapshotRepository {
+        val snapshots = MutableStateFlow(initialSnapshots)
+
+        override fun observeSnapshots(): Flow<List<CollectionSpotFavoriteSnapshot>> = snapshots
+
+        override suspend fun getSnapshot(targetId: String): CollectionSpotFavoriteSnapshot? =
+            snapshots.value.firstOrNull { snapshot -> snapshot.targetId == targetId }
+
+        override suspend fun upsertSnapshot(snapshot: CollectionSpotFavoriteSnapshot) {
+            snapshots.value =
+                snapshots.value
+                    .filterNot { it.targetId == snapshot.targetId } + snapshot
+        }
+
+        override suspend fun deleteSnapshot(targetId: String) {
+            snapshots.value = snapshots.value.filterNot { it.targetId == targetId }
+        }
+    }
+}

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/usecase/ToggleCollectionSpotFavoriteUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/usecase/ToggleCollectionSpotFavoriteUseCaseTest.kt
@@ -1,16 +1,13 @@
 package com.team.yeogibeoryeo.domain.favorite.usecase
 
 import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
-import com.team.yeogibeoryeo.domain.favorite.model.Favorite
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
-import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
-import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.model.toFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteRepository
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -21,36 +18,26 @@ class ToggleCollectionSpotFavoriteUseCaseTest {
     @Test
     fun `즐겨찾기가 아니면 공통 Favorite와 수거 장소 스냅샷을 저장한다`() =
         runBlocking {
-            val favoriteRepository = FakeFavoriteRepository()
-            val snapshotRepository = FakeCollectionSpotFavoriteSnapshotRepository()
+            val collectionSpotFavoriteRepository = FakeCollectionSpotFavoriteRepository()
             val useCase = ToggleCollectionSpotFavoriteUseCase(
-                favoriteRepository = favoriteRepository,
-                snapshotRepository = snapshotRepository,
+                collectionSpotFavoriteRepository = collectionSpotFavoriteRepository,
             )
             val spot = sampleSpot()
 
             val isFavorite = useCase(spot)
 
             assertTrue(isFavorite)
-            assertTrue(favoriteRepository.isFavorite(FavoriteTargetType.COLLECTION_SPOT, spot.id))
-            assertEquals(spot.id, snapshotRepository.snapshots.value.single().targetId)
-            assertEquals(spot.coordinate, snapshotRepository.snapshots.value.single().coordinate)
+            assertTrue(collectionSpotFavoriteRepository.isFavorite(FavoriteTargetType.COLLECTION_SPOT, spot.id))
+            assertEquals(spot.id, collectionSpotFavoriteRepository.snapshots.value.single().targetId)
+            assertEquals(spot.coordinate, collectionSpotFavoriteRepository.snapshots.value.single().coordinate)
         }
 
     @Test
     fun `이미 즐겨찾기면 공통 Favorite와 수거 장소 스냅샷을 삭제한다`() =
         runBlocking {
             val spot = sampleSpot()
-            val favoriteRepository = FakeFavoriteRepository(
-                initialFavorites = listOf(
-                    Favorite(
-                        type = FavoriteTargetType.COLLECTION_SPOT,
-                        targetId = spot.id,
-                        savedAtMillis = 1L,
-                    ),
-                ),
-            )
-            val snapshotRepository = FakeCollectionSpotFavoriteSnapshotRepository(
+            val collectionSpotFavoriteRepository = FakeCollectionSpotFavoriteRepository(
+                favoriteTargetIds = setOf(spot.id),
                 initialSnapshots = listOf(
                     CollectionSpotFavoriteSnapshot(
                         targetId = spot.id,
@@ -63,15 +50,14 @@ class ToggleCollectionSpotFavoriteUseCaseTest {
                 ),
             )
             val useCase = ToggleCollectionSpotFavoriteUseCase(
-                favoriteRepository = favoriteRepository,
-                snapshotRepository = snapshotRepository,
+                collectionSpotFavoriteRepository = collectionSpotFavoriteRepository,
             )
 
             val isFavorite = useCase(spot)
 
             assertFalse(isFavorite)
-            assertFalse(favoriteRepository.isFavorite(FavoriteTargetType.COLLECTION_SPOT, spot.id))
-            assertEquals(emptyList<CollectionSpotFavoriteSnapshot>(), snapshotRepository.snapshots.value)
+            assertFalse(collectionSpotFavoriteRepository.isFavorite(FavoriteTargetType.COLLECTION_SPOT, spot.id))
+            assertEquals(emptyList<CollectionSpotFavoriteSnapshot>(), collectionSpotFavoriteRepository.snapshots.value)
         }
 
     private fun sampleSpot(): CollectionSpot =
@@ -84,69 +70,34 @@ class ToggleCollectionSpotFavoriteUseCaseTest {
             coordinate = Coordinate(latitude = 37.5, longitude = 126.9),
         )
 
-    private class FakeFavoriteRepository(
-        initialFavorites: List<Favorite> = emptyList(),
-    ) : FavoriteRepository {
-        private val favorites = MutableStateFlow(initialFavorites)
+    private class FakeCollectionSpotFavoriteRepository(
+        favoriteTargetIds: Set<String> = emptySet(),
+        initialSnapshots: List<CollectionSpotFavoriteSnapshot> = emptyList(),
+    ) : CollectionSpotFavoriteRepository {
+        private val favoriteIds = MutableStateFlow(favoriteTargetIds)
+        val snapshots = MutableStateFlow(initialSnapshots)
 
-        override fun observeFavorites(): Flow<List<Favorite>> = favorites
-
-        override fun observeFavorite(
-            type: FavoriteTargetType,
-            targetId: String,
-        ): Flow<Boolean> =
-            favorites.map { items ->
-                items.any { favorite -> favorite.type == type && favorite.targetId == targetId }
-            }
-
-        override suspend fun isFavorite(
-            type: FavoriteTargetType,
-            targetId: String,
-        ): Boolean =
-            favorites.value.any { favorite -> favorite.type == type && favorite.targetId == targetId }
-
-        override suspend fun toggleFavorite(favorite: Favorite): Boolean {
-            return if (isFavorite(favorite.type, favorite.targetId)) {
-                removeFavorite(favorite.type, favorite.targetId)
+        override suspend fun toggleFavorite(spot: CollectionSpot): Boolean {
+            return if (isFavorite(FavoriteTargetType.COLLECTION_SPOT, spot.id)) {
+                removeFavorite(spot.id)
                 false
             } else {
-                addFavorite(favorite)
+                favoriteIds.value = favoriteIds.value + spot.id
+                snapshots.value =
+                    snapshots.value
+                        .filterNot { it.targetId == spot.id } + spot.toFavoriteSnapshot()
                 true
             }
         }
 
-        override suspend fun addFavorite(favorite: Favorite) {
-            favorites.value =
-                favorites.value
-                    .filterNot { it.type == favorite.type && it.targetId == favorite.targetId } + favorite
-        }
-
-        override suspend fun removeFavorite(
-            type: FavoriteTargetType,
-            targetId: String,
-        ) {
-            favorites.value = favorites.value.filterNot { it.type == type && it.targetId == targetId }
-        }
-    }
-
-    private class FakeCollectionSpotFavoriteSnapshotRepository(
-        initialSnapshots: List<CollectionSpotFavoriteSnapshot> = emptyList(),
-    ) : CollectionSpotFavoriteSnapshotRepository {
-        val snapshots = MutableStateFlow(initialSnapshots)
-
-        override fun observeSnapshots(): Flow<List<CollectionSpotFavoriteSnapshot>> = snapshots
-
-        override suspend fun getSnapshot(targetId: String): CollectionSpotFavoriteSnapshot? =
-            snapshots.value.firstOrNull { snapshot -> snapshot.targetId == targetId }
-
-        override suspend fun upsertSnapshot(snapshot: CollectionSpotFavoriteSnapshot) {
-            snapshots.value =
-                snapshots.value
-                    .filterNot { it.targetId == snapshot.targetId } + snapshot
-        }
-
-        override suspend fun deleteSnapshot(targetId: String) {
+        override suspend fun removeFavorite(targetId: String) {
+            favoriteIds.value = favoriteIds.value - targetId
             snapshots.value = snapshots.value.filterNot { it.targetId == targetId }
         }
+
+        fun isFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Boolean = type == FavoriteTargetType.COLLECTION_SPOT && targetId in favoriteIds.value
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesRoute.kt
@@ -20,6 +20,7 @@ fun FavoritesRoute(
         onItemGuideClick = onItemGuideClick,
         onCollectionSpotClick = {},
         onRegionalGuideClick = {},
+        onCollectionSpotFavoriteRemoveClick = viewModel::removeCollectionSpotFavorite,
         modifier = modifier,
     )
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreen.kt
@@ -30,6 +30,7 @@ fun FavoritesScreen(
     onItemGuideClick: (String) -> Unit,
     onCollectionSpotClick: (String) -> Unit,
     onRegionalGuideClick: (String) -> Unit,
+    onCollectionSpotFavoriteRemoveClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(
@@ -92,6 +93,14 @@ fun FavoritesScreen(
                                 FavoriteTargetType.COLLECTION_SPOT -> onCollectionSpotClick(favorite.targetId)
                                 FavoriteTargetType.REGIONAL_GUIDE -> onRegionalGuideClick(favorite.targetId)
                             }
+                        },
+                        onRemoveClick = when (favorite.type) {
+                            FavoriteTargetType.COLLECTION_SPOT -> {
+                                { onCollectionSpotFavoriteRemoveClick(favorite.targetId) }
+                            }
+
+                            FavoriteTargetType.ITEM_GUIDE,
+                            FavoriteTargetType.REGIONAL_GUIDE -> null
                         },
                     )
                 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreenPreview.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreenPreview.kt
@@ -18,6 +18,7 @@ private fun FavoritesScreenLoadingPreview() {
             onItemGuideClick = {},
             onCollectionSpotClick = {},
             onRegionalGuideClick = {},
+            onCollectionSpotFavoriteRemoveClick = {},
         )
     }
 }
@@ -32,6 +33,7 @@ private fun FavoritesScreenEmptyPreview() {
             onItemGuideClick = {},
             onCollectionSpotClick = {},
             onRegionalGuideClick = {},
+            onCollectionSpotFavoriteRemoveClick = {},
         )
     }
 }
@@ -46,6 +48,7 @@ private fun FavoritesScreenSpotEmptyPreview() {
             onItemGuideClick = {},
             onCollectionSpotClick = {},
             onRegionalGuideClick = {},
+            onCollectionSpotFavoriteRemoveClick = {},
         )
     }
 }
@@ -83,6 +86,7 @@ private fun FavoritesScreenListPreview() {
             onItemGuideClick = {},
             onCollectionSpotClick = {},
             onRegionalGuideClick = {},
+            onCollectionSpotFavoriteRemoveClick = {},
         )
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModel.kt
@@ -45,12 +45,14 @@ class FavoritesViewModel
                 val collectionSpotFavoriteIds =
                     favorites
                         .filter { it.type == FavoriteTargetType.COLLECTION_SPOT }
-                        .map { favorite -> favorite.targetId }
-                        .toSet()
+                val collectionSpotSnapshotsById =
+                    collectionSpotSnapshots.associateBy { snapshot -> snapshot.targetId }
                 val collectionSpotFavorites =
-                    collectionSpotSnapshots
-                        .filter { snapshot -> snapshot.targetId in collectionSpotFavoriteIds }
-                        .map { snapshot -> collectionSpotUiMapper.map(snapshot) }
+                    collectionSpotFavoriteIds
+                        .mapNotNull { favorite ->
+                            collectionSpotSnapshotsById[favorite.targetId]
+                                ?.let { snapshot -> collectionSpotUiMapper.map(snapshot) }
+                        }
                 val regionalGuideFavorites =
                     favorites
                         .filter { it.type == FavoriteTargetType.REGIONAL_GUIDE }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModel.kt
@@ -3,7 +3,9 @@ package com.team.yeogibeoryeo.presentation.favorites
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveCollectionSpotFavoriteSnapshotsUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.RemoveCollectionSpotFavoriteUseCase
 import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteCollectionSpotUiMapper
 import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteItemGuideUiMapper
 import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteRegionalGuideUiMapper
@@ -15,12 +17,15 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class FavoritesViewModel
     @Inject
     constructor(
         observeFavoritesUseCase: ObserveFavoritesUseCase,
+        observeCollectionSpotFavoriteSnapshotsUseCase: ObserveCollectionSpotFavoriteSnapshotsUseCase,
+        private val removeCollectionSpotFavoriteUseCase: RemoveCollectionSpotFavoriteUseCase,
         private val itemGuideUiMapper: FavoriteItemGuideUiMapper,
         private val collectionSpotUiMapper: FavoriteCollectionSpotUiMapper,
         private val regionalGuideUiMapper: FavoriteRegionalGuideUiMapper,
@@ -31,15 +36,21 @@ class FavoritesViewModel
             combine(
                 selectedTab,
                 observeFavoritesUseCase(),
-            ) { selectedTab, favorites ->
+                observeCollectionSpotFavoriteSnapshotsUseCase(),
+            ) { selectedTab, favorites, collectionSpotSnapshots ->
                 val itemGuideFavorites =
                     favorites
                         .filter { it.type == FavoriteTargetType.ITEM_GUIDE }
                         .mapNotNull { favorite -> itemGuideUiMapper.map(favorite) }
-                val collectionSpotFavorites =
+                val collectionSpotFavoriteIds =
                     favorites
                         .filter { it.type == FavoriteTargetType.COLLECTION_SPOT }
-                        .mapNotNull { favorite -> collectionSpotUiMapper.map(favorite) }
+                        .map { favorite -> favorite.targetId }
+                        .toSet()
+                val collectionSpotFavorites =
+                    collectionSpotSnapshots
+                        .filter { snapshot -> snapshot.targetId in collectionSpotFavoriteIds }
+                        .map { snapshot -> collectionSpotUiMapper.map(snapshot) }
                 val regionalGuideFavorites =
                     favorites
                         .filter { it.type == FavoriteTargetType.REGIONAL_GUIDE }
@@ -60,5 +71,11 @@ class FavoritesViewModel
 
         fun selectTab(tab: FavoriteTab) {
             selectedTab.value = tab
+        }
+
+        fun removeCollectionSpotFavorite(targetId: String) {
+            viewModelScope.launch {
+                removeCollectionSpotFavoriteUseCase(targetId)
+            }
         }
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/components/FavoriteCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/components/FavoriteCard.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -31,6 +32,7 @@ fun FavoriteCard(
     favorite: FavoriteUiModel,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onRemoveClick: (() -> Unit)? = null,
 ) {
     Card(
         modifier = modifier
@@ -69,12 +71,23 @@ fun FavoriteCard(
                 }
             }
 
-            Icon(
-                painter = painterResource(id = CommonR.drawable.ic_action_chevron_right),
-                contentDescription = null,
-                modifier = Modifier.size(20.dp),
-                tint = MaterialTheme.colorScheme.outlineVariant,
-            )
+            if (onRemoveClick != null) {
+                IconButton(onClick = onRemoveClick) {
+                    Icon(
+                        painter = painterResource(id = CommonR.drawable.ic_favorite_filled),
+                        contentDescription = "즐겨찾기 해제",
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.tertiary,
+                    )
+                }
+            } else {
+                Icon(
+                    painter = painterResource(id = CommonR.drawable.ic_action_chevron_right),
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.outlineVariant,
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/mapper/FavoriteCollectionSpotUiMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/mapper/FavoriteCollectionSpotUiMapper.kt
@@ -1,14 +1,45 @@
 package com.team.yeogibeoryeo.presentation.favorites.mapper
 
 import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.usecase.GetCollectionSpotFavoriteSnapshotUseCase
 import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteUiModel
+import com.team.yeogibeoryeo.presentation.map.mapper.toDisplayName
 import javax.inject.Inject
 
 class FavoriteCollectionSpotUiMapper
     @Inject
-    constructor() {
-    suspend fun map(favorite: Favorite): FavoriteUiModel? {
-        // TODO: Resolve collection spot source data when COLLECTION_SPOT favorites are connected.
-        return null
+    constructor(
+        private val getCollectionSpotFavoriteSnapshotUseCase: GetCollectionSpotFavoriteSnapshotUseCase,
+    ) {
+        suspend fun map(favorite: Favorite): FavoriteUiModel? {
+            if (favorite.type != FavoriteTargetType.COLLECTION_SPOT) return null
+
+            val snapshot = getCollectionSpotFavoriteSnapshotUseCase(favorite.targetId) ?: return null
+
+            return FavoriteUiModel(
+                type = FavoriteTargetType.COLLECTION_SPOT,
+                targetId = favorite.targetId,
+                title = snapshot.name,
+                subtitle = snapshot.toSubtitle(),
+            )
+        }
+
+        fun map(snapshot: CollectionSpotFavoriteSnapshot): FavoriteUiModel =
+            FavoriteUiModel(
+                type = FavoriteTargetType.COLLECTION_SPOT,
+                targetId = snapshot.targetId,
+                title = snapshot.name,
+                subtitle = snapshot.toSubtitle(),
+            )
+
+        private fun CollectionSpotFavoriteSnapshot.toSubtitle(): String =
+            listOf(
+                type.toDisplayName(),
+                address,
+                detailLocation,
+            )
+                .filterNot { it.isNullOrBlank() }
+                .joinToString(" · ")
     }
-}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/model/FavoriteTab.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/model/FavoriteTab.kt
@@ -17,8 +17,8 @@ enum class FavoriteTab(
     COLLECTION_SPOT(
         targetType = FavoriteTargetType.COLLECTION_SPOT,
         label = "장소",
-        emptyTitle = "아직 즐겨찾기한 장소가 없어요",
-        emptyDescription = "수거 장소 즐겨찾기 연결 후 이곳에서 모아볼 수 있어요.",
+        emptyTitle = "즐겨찾기한 수거 장소가 없어요",
+        emptyDescription = "지도에서 자주 확인하는 수거 장소를 즐겨찾기에 추가해 보세요.",
     ),
     REGIONAL_GUIDE(
         targetType = FavoriteTargetType.REGIONAL_GUIDE,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -101,6 +101,7 @@ fun CollectionSpotMapScreen(
         },
         onTypeClick = viewModel::onSpotTypeClick,
         onSpotClick = viewModel::onSpotClick,
+        onSpotFavoriteClick = viewModel::onSpotFavoriteClick,
         modifier = modifier,
     )
 }
@@ -118,6 +119,7 @@ private fun CollectionSpotMapContent(
     onLocationNoticeActionClick: (MapLocationNoticeAction) -> Unit,
     onTypeClick: (CollectionSpotType) -> Unit,
     onSpotClick: (CollectionSpot) -> Unit,
+    onSpotFavoriteClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val isCurrentLocationSearching = uiState.isLoading &&
@@ -277,6 +279,7 @@ private fun CollectionSpotMapContent(
                     mapUiMode == MapUiMode.SpotDetail && selectedSpot != null -> {
                         SpotDetailBottomSheetContent(
                             spot = selectedSpot,
+                            onFavoriteClick = onSpotFavoriteClick,
                             onCloseClick = {
                                 mapUiMode = MapUiMode.ResultList
                                 sheetLevel = MapSheetLevel.Peek
@@ -296,6 +299,7 @@ private fun CollectionSpotMapContent(
                             errorMessage = uiState.errorMessage,
                             onTypeClick = onTypeClick,
                             onLocationNoticeActionClick = onLocationNoticeActionClick,
+                            onSpotFavoriteClick = onSpotFavoriteClick,
                             onSpotClick = { spot ->
                                 onLocationTrackingModeChange(LocationTrackingMode.NoFollow)
                                 mapUiMode = MapUiMode.SpotDetail
@@ -359,6 +363,7 @@ private fun CollectionSpotMapContentPreview() {
                 onLocationNoticeActionClick = {},
                 onTypeClick = {},
                 onSpotClick = {},
+                onSpotFavoriteClick = {},
             )
         }
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -2,6 +2,9 @@ package com.team.yeogibeoryeo.presentation.map
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ToggleCollectionSpotFavoriteUseCase
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
@@ -32,6 +35,8 @@ class CollectionSpotMapViewModel @Inject constructor(
     private val locationPermissionChecker: LocationPermissionChecker,
     private val getFreshRecentCurrentLocationSpotsUseCase: GetFreshRecentCurrentLocationSpotsUseCase,
     private val saveRecentCurrentLocationSpotsUseCase: SaveRecentCurrentLocationSpotsUseCase,
+    private val observeFavoritesUseCase: ObserveFavoritesUseCase,
+    private val toggleCollectionSpotFavoriteUseCase: ToggleCollectionSpotFavoriteUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CollectionSpotMapUiState())
@@ -41,6 +46,11 @@ class CollectionSpotMapViewModel @Inject constructor(
     private var spotSearchJob: Job? = null
     private var currentLocationRefreshJob: Job? = null
     private var hasRequestedInitialCurrentLocationSearch = false
+    private var favoriteSpotIds: Set<String> = emptySet()
+
+    init {
+        observeCollectionSpotFavorites()
+    }
 
     fun onSearchKeywordChanged(keyword: String) {
         currentLocationRefreshJob?.cancel()
@@ -208,6 +218,12 @@ class CollectionSpotMapViewModel @Inject constructor(
         }
     }
 
+    fun onSpotFavoriteClick(spot: CollectionSpot) {
+        viewModelScope.launch {
+            toggleCollectionSpotFavoriteUseCase(spot)
+        }
+    }
+
     fun onLocationPermissionDenied() {
         originalSpots = emptyList()
 
@@ -298,7 +314,7 @@ class CollectionSpotMapViewModel @Inject constructor(
     }
 
     private fun updateSpotResult(spots: List<CollectionSpot>) {
-        originalSpots = spots
+        originalSpots = spots.withFavoriteState()
 
         val filteredSpots = filterCollectionSpotsUseCase(
             spots = originalSpots,
@@ -382,7 +398,7 @@ class CollectionSpotMapViewModel @Inject constructor(
     }
 
     private fun showCachedCurrentLocationSpots(spots: List<CollectionSpot>) {
-        originalSpots = spots
+        originalSpots = spots.withFavoriteState()
 
         val filteredSpots = filterCollectionSpotsUseCase(
             spots = originalSpots,
@@ -427,6 +443,43 @@ class CollectionSpotMapViewModel @Inject constructor(
         return currentState.searchKeyword.isBlank() &&
             currentState.searchMode == MapSearchMode.CURRENT_LOCATION
     }
+
+    private fun observeCollectionSpotFavorites() {
+        viewModelScope.launch {
+            observeFavoritesUseCase(FavoriteTargetType.COLLECTION_SPOT)
+                .collect { favorites ->
+                    favoriteSpotIds = favorites.map { favorite -> favorite.targetId }.toSet()
+                    applyFavoriteStateToCurrentResults()
+                }
+        }
+    }
+
+    private fun applyFavoriteStateToCurrentResults() {
+        if (originalSpots.isEmpty() && uiState.value.selectedSpot == null) return
+
+        originalSpots = originalSpots.withFavoriteState()
+
+        val filteredSpots = filterCollectionSpotsUseCase(
+            spots = originalSpots,
+            selectedTypes = uiState.value.selectedTypes,
+        )
+        val updatedSelectedSpot = uiState.value.selectedSpot?.let { selectedSpot ->
+            originalSpots.firstOrNull { spot -> spot.id == selectedSpot.id }
+                ?: selectedSpot.copy(isBookmarked = selectedSpot.id in favoriteSpotIds)
+        }
+
+        _uiState.update {
+            it.copy(
+                spots = filteredSpots,
+                selectedSpot = updatedSelectedSpot,
+            )
+        }
+    }
+
+    private fun List<CollectionSpot>.withFavoriteState(): List<CollectionSpot> =
+        map { spot ->
+            spot.copy(isBookmarked = spot.id in favoriteSpotIds)
+        }
 
     private companion object {
         const val DEFAULT_RADIUS_METER = 500

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomCard.kt
@@ -7,26 +7,32 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.presentation.map.mapper.toDisplayName
+import com.team.yeogibeoryeo.common.R as CommonR
 
 @Composable
 fun SpotBottomCard(
     spot: CollectionSpot,
     isSelected: Boolean,
     onClick: ((CollectionSpot) -> Unit)?,
+    onFavoriteClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val containerColor = if (isSelected) {
@@ -74,34 +80,69 @@ fun SpotBottomCard(
                 .fillMaxWidth()
                 .padding(16.dp),
         ) {
-            Row {
-                Text(
-                    text = spot.type.toDisplayName(),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = if (isSelected) {
-                        MaterialTheme.colorScheme.tertiary
-                    } else {
-                        MaterialTheme.colorScheme.primary
-                    },
-                )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Row {
+                        Text(
+                            text = spot.type.toDisplayName(),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = if (isSelected) {
+                                MaterialTheme.colorScheme.tertiary
+                            } else {
+                                MaterialTheme.colorScheme.primary
+                            },
+                        )
 
-                spot.distanceMeter?.let { distanceMeter ->
-                    Spacer(modifier = Modifier.width(8.dp))
+                        spot.distanceMeter?.let { distanceMeter ->
+                            Spacer(modifier = Modifier.width(8.dp))
+
+                            Text(
+                                text = "${distanceMeter}m",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = supportingContentColor,
+                            )
+                        }
+                    }
 
                     Text(
-                        text = "${distanceMeter}m",
-                        style = MaterialTheme.typography.labelMedium,
-                        color = supportingContentColor,
+                        text = spot.name,
+                        modifier = Modifier.padding(top = 6.dp),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+
+                IconButton(
+                    onClick = {
+                        onFavoriteClick(spot)
+                    },
+                    modifier = Modifier.size(40.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(
+                            id = if (spot.isBookmarked) {
+                                CommonR.drawable.ic_favorite_filled
+                            } else {
+                                CommonR.drawable.ic_favorite
+                            },
+                        ),
+                        contentDescription = if (spot.isBookmarked) {
+                            "즐겨찾기 해제"
+                        } else {
+                            "즐겨찾기 추가"
+                        },
+                        tint = if (spot.isBookmarked) {
+                            MaterialTheme.colorScheme.tertiary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
                     )
                 }
             }
-
-            Text(
-                text = spot.name,
-                modifier = Modifier.padding(top = 6.dp),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-            )
 
             Text(
                 text = spot.address,
@@ -142,6 +183,7 @@ private fun SpotBottomCardPreview() {
                 ),
                 isSelected = false,
                 onClick = {},
+                onFavoriteClick = {},
             )
         }
     }
@@ -167,6 +209,7 @@ private fun SpotBottomCardSelectedPreview() {
                 ),
                 isSelected = true,
                 onClick = {},
+                onFavoriteClick = {},
             )
         }
     }
@@ -192,6 +235,7 @@ private fun SpotBottomCardWithoutDetailPreview() {
                 ),
                 isSelected = false,
                 onClick = {},
+                onFavoriteClick = {},
             )
         }
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomList.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomList.kt
@@ -21,6 +21,7 @@ fun SpotBottomList(
     spots: List<CollectionSpot>,
     selectedSpot: CollectionSpot?,
     onSpotClick: (CollectionSpot) -> Unit,
+    onSpotFavoriteClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(
         start = 16.dp,
@@ -61,6 +62,7 @@ fun SpotBottomList(
                 onClick = {
                     onSpotClick(spot)
                 },
+                onFavoriteClick = onSpotFavoriteClick,
                 modifier = Modifier.fillMaxWidth(),
             )
         }
@@ -116,6 +118,7 @@ private fun SpotBottomListPreview() {
                     isBookmarked = false,
                 ),
                 onSpotClick = {},
+                onSpotFavoriteClick = {},
             )
         }
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
@@ -34,6 +34,7 @@ fun SpotBottomSheetContent(
     onTypeClick: (CollectionSpotType) -> Unit,
     onLocationNoticeActionClick: (MapLocationNoticeAction) -> Unit,
     onSpotClick: (CollectionSpot) -> Unit,
+    onSpotFavoriteClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val hasNoticeOrError = locationNotice != null ||
@@ -95,6 +96,7 @@ fun SpotBottomSheetContent(
                     spots = spots,
                     selectedSpot = selectedSpot,
                     onSpotClick = onSpotClick,
+                    onSpotFavoriteClick = onSpotFavoriteClick,
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(max = SpotBottomSheetListMaxHeight),
@@ -147,6 +149,7 @@ private fun SpotBottomSheetLoading(
 @Composable
 fun SpotDetailBottomSheetContent(
     spot: CollectionSpot,
+    onFavoriteClick: (CollectionSpot) -> Unit,
     onCloseClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -160,6 +163,7 @@ fun SpotDetailBottomSheetContent(
             spot = spot,
             isSelected = true,
             onClick = null,
+            onFavoriteClick = onFavoriteClick,
             modifier = Modifier.fillMaxWidth(),
         )
 
@@ -192,6 +196,7 @@ private fun SpotBottomSheetContentPreview() {
                 onTypeClick = {},
                 onLocationNoticeActionClick = {},
                 onSpotClick = {},
+                onSpotFavoriteClick = {},
             )
         }
     }
@@ -214,6 +219,7 @@ private fun SpotBottomSheetContentLoadingPreview() {
                 onTypeClick = {},
                 onLocationNoticeActionClick = {},
                 onSpotClick = {},
+                onSpotFavoriteClick = {},
             )
         }
     }
@@ -236,6 +242,7 @@ private fun SpotBottomSheetContentEmptyPreview() {
                 onTypeClick = {},
                 onLocationNoticeActionClick = {},
                 onSpotClick = {},
+                onSpotFavoriteClick = {},
             )
         }
     }
@@ -248,6 +255,7 @@ private fun SpotDetailBottomSheetContentPreview() {
         Surface {
             SpotDetailBottomSheetContent(
                 spot = sampleSpotBottomSheetSpots()[0],
+                onFavoriteClick = {},
                 onCloseClick = {},
             )
         }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModelTest.kt
@@ -1,15 +1,22 @@
 package com.team.yeogibeoryeo.presentation.favorites
 
 import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
 import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.usecase.GetCollectionSpotFavoriteSnapshotUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveCollectionSpotFavoriteSnapshotsUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.RemoveCollectionSpotFavoriteUseCase
 import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
 import com.team.yeogibeoryeo.domain.item.model.DisposalInstruction
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.domain.item.model.DisposalSubCategory
 import com.team.yeogibeoryeo.domain.item.repository.DisposalItemGuideRepository
 import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalItemGuideUseCase
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteCollectionSpotUiMapper
 import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteItemGuideUiMapper
 import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteRegionalGuideUiMapper
@@ -103,6 +110,135 @@ class FavoritesViewModelTest {
         }
 
     @Test
+    fun `수거 장소 스냅샷을 조회해 장소 즐겨찾기 UI 모델로 변환한다`() =
+        runTest {
+            val snapshot =
+                CollectionSpotFavoriteSnapshot(
+                    targetId = "spot-1",
+                    name = "폐건전지 수거함",
+                    type = CollectionSpotType.BATTERY_BIN,
+                    address = "서울특별시 영등포구 문래동",
+                    detailLocation = "주민센터 앞",
+                    coordinate = Coordinate(latitude = 37.5, longitude = 126.9),
+                )
+            val viewModel =
+                createViewModel(
+                    favoriteRepository =
+                        FakeFavoriteRepository(
+                            initialFavorites =
+                                listOf(
+                                    Favorite(
+                                        type = FavoriteTargetType.COLLECTION_SPOT,
+                                        targetId = snapshot.targetId,
+                                        savedAtMillis = 1L,
+                                    ),
+                                ),
+                        ),
+                    itemRepository = FakeItemRepository(guides = emptyList()),
+                    collectionSpotSnapshotRepository =
+                        FakeCollectionSpotFavoriteSnapshotRepository(
+                            snapshots = listOf(snapshot),
+                        ),
+                )
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.uiState.collect()
+            }
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(
+                    FavoriteUiModel(
+                        type = FavoriteTargetType.COLLECTION_SPOT,
+                        targetId = "spot-1",
+                        title = "폐건전지 수거함",
+                        subtitle = "폐건전지 · 서울특별시 영등포구 문래동 · 주민센터 앞",
+                    ),
+                ),
+                viewModel.uiState.value.collectionSpotFavorites,
+            )
+        }
+
+    @Test
+    fun `스냅샷이 없는 수거 장소 즐겨찾기는 장소 UI 목록에서 제외한다`() =
+        runTest {
+            val viewModel =
+                createViewModel(
+                    favoriteRepository =
+                        FakeFavoriteRepository(
+                            initialFavorites =
+                                listOf(
+                                    Favorite(
+                                        type = FavoriteTargetType.COLLECTION_SPOT,
+                                        targetId = "missing-snapshot",
+                                        savedAtMillis = 1L,
+                                    ),
+                                ),
+                        ),
+                    itemRepository = FakeItemRepository(guides = emptyList()),
+                    collectionSpotSnapshotRepository = FakeCollectionSpotFavoriteSnapshotRepository(),
+                )
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.uiState.collect()
+            }
+            advanceUntilIdle()
+
+            viewModel.selectTab(FavoriteTab.COLLECTION_SPOT)
+            advanceUntilIdle()
+
+            assertEquals(emptyList<FavoriteUiModel>(), viewModel.uiState.value.selectedFavorites)
+        }
+
+    @Test
+    fun `장소 즐겨찾기 해제 시 공통 Favorite와 스냅샷을 삭제하고 UI 목록을 갱신한다`() =
+        runTest {
+            val snapshot =
+                CollectionSpotFavoriteSnapshot(
+                    targetId = "spot-1",
+                    name = "폐건전지 수거함",
+                    type = CollectionSpotType.BATTERY_BIN,
+                    address = "서울특별시 영등포구 문래동",
+                    detailLocation = "주민센터 앞",
+                    coordinate = Coordinate(latitude = 37.5, longitude = 126.9),
+                )
+            val favoriteRepository =
+                FakeFavoriteRepository(
+                    initialFavorites =
+                        listOf(
+                            Favorite(
+                                type = FavoriteTargetType.COLLECTION_SPOT,
+                                targetId = snapshot.targetId,
+                                savedAtMillis = 1L,
+                            ),
+                        ),
+                )
+            val snapshotRepository =
+                FakeCollectionSpotFavoriteSnapshotRepository(
+                    snapshots = listOf(snapshot),
+                )
+            val viewModel =
+                createViewModel(
+                    favoriteRepository = favoriteRepository,
+                    itemRepository = FakeItemRepository(guides = emptyList()),
+                    collectionSpotSnapshotRepository = snapshotRepository,
+                )
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.uiState.collect()
+            }
+            advanceUntilIdle()
+
+            viewModel.selectTab(FavoriteTab.COLLECTION_SPOT)
+            advanceUntilIdle()
+            assertEquals(1, viewModel.uiState.value.selectedFavorites.size)
+
+            viewModel.removeCollectionSpotFavorite(snapshot.targetId)
+            advanceUntilIdle()
+
+            assertEquals(emptyList<FavoriteUiModel>(), viewModel.uiState.value.selectedFavorites)
+            assertEquals(false, favoriteRepository.isFavorite(FavoriteTargetType.COLLECTION_SPOT, snapshot.targetId))
+            assertEquals(emptyList<CollectionSpotFavoriteSnapshot>(), snapshotRepository.snapshots.value)
+        }
+
+    @Test
     fun `탭을 변경하면 선택된 탭 상태를 반영한다`() =
         runTest {
             val viewModel =
@@ -123,11 +259,23 @@ class FavoritesViewModelTest {
     private fun createViewModel(
         favoriteRepository: FakeFavoriteRepository,
         itemRepository: FakeItemRepository,
+        collectionSpotSnapshotRepository: FakeCollectionSpotFavoriteSnapshotRepository =
+            FakeCollectionSpotFavoriteSnapshotRepository(),
     ): FavoritesViewModel =
         FavoritesViewModel(
             observeFavoritesUseCase = ObserveFavoritesUseCase(favoriteRepository),
+            observeCollectionSpotFavoriteSnapshotsUseCase =
+                ObserveCollectionSpotFavoriteSnapshotsUseCase(collectionSpotSnapshotRepository),
+            removeCollectionSpotFavoriteUseCase =
+                RemoveCollectionSpotFavoriteUseCase(
+                    favoriteRepository = favoriteRepository,
+                    snapshotRepository = collectionSpotSnapshotRepository,
+                ),
             itemGuideUiMapper = FavoriteItemGuideUiMapper(GetDisposalItemGuideUseCase(itemRepository)),
-            collectionSpotUiMapper = FavoriteCollectionSpotUiMapper(),
+            collectionSpotUiMapper =
+                FavoriteCollectionSpotUiMapper(
+                    GetCollectionSpotFavoriteSnapshotUseCase(collectionSpotSnapshotRepository),
+                ),
             regionalGuideUiMapper = FavoriteRegionalGuideUiMapper(),
         )
 
@@ -206,6 +354,27 @@ class FavoritesViewModelTest {
         ) {
             favorites.value =
                 favorites.value.filterNot { it.type == type && it.targetId == targetId }
+        }
+    }
+
+    private class FakeCollectionSpotFavoriteSnapshotRepository(
+        snapshots: List<CollectionSpotFavoriteSnapshot> = emptyList(),
+    ) : CollectionSpotFavoriteSnapshotRepository {
+        val snapshots = MutableStateFlow(snapshots)
+
+        override fun observeSnapshots(): Flow<List<CollectionSpotFavoriteSnapshot>> = snapshots
+
+        override suspend fun getSnapshot(targetId: String): CollectionSpotFavoriteSnapshot? =
+            snapshots.value.firstOrNull { snapshot -> snapshot.targetId == targetId }
+
+        override suspend fun upsertSnapshot(snapshot: CollectionSpotFavoriteSnapshot) {
+            snapshots.value =
+                snapshots.value
+                    .filterNot { it.targetId == snapshot.targetId } + snapshot
+        }
+
+        override suspend fun deleteSnapshot(targetId: String) {
+            snapshots.value = snapshots.value.filterNot { it.targetId == targetId }
         }
     }
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModelTest.kt
@@ -3,8 +3,10 @@ package com.team.yeogibeoryeo.presentation.favorites
 import com.team.yeogibeoryeo.domain.favorite.model.Favorite
 import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteRepository
 import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
 import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.favorite.usecase.GetCollectionSpotFavoriteSnapshotUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveCollectionSpotFavoriteSnapshotsUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
@@ -189,6 +191,62 @@ class FavoritesViewModelTest {
         }
 
     @Test
+    fun `수거 장소 즐겨찾기는 Favorite 저장 순서를 기준으로 표시한다`() =
+        runTest {
+            val olderSnapshot =
+                CollectionSpotFavoriteSnapshot(
+                    targetId = "spot-older",
+                    name = "오래된 수거함",
+                    type = CollectionSpotType.BATTERY_BIN,
+                    address = "서울특별시 영등포구",
+                    detailLocation = null,
+                    coordinate = null,
+                )
+            val newerSnapshot =
+                CollectionSpotFavoriteSnapshot(
+                    targetId = "spot-newer",
+                    name = "최근 수거함",
+                    type = CollectionSpotType.PHONE_DROP_OFF,
+                    address = "서울특별시 마포구",
+                    detailLocation = null,
+                    coordinate = null,
+                )
+            val viewModel =
+                createViewModel(
+                    favoriteRepository =
+                        FakeFavoriteRepository(
+                            initialFavorites =
+                                listOf(
+                                    Favorite(
+                                        type = FavoriteTargetType.COLLECTION_SPOT,
+                                        targetId = newerSnapshot.targetId,
+                                        savedAtMillis = 2L,
+                                    ),
+                                    Favorite(
+                                        type = FavoriteTargetType.COLLECTION_SPOT,
+                                        targetId = olderSnapshot.targetId,
+                                        savedAtMillis = 1L,
+                                    ),
+                                ),
+                        ),
+                    itemRepository = FakeItemRepository(guides = emptyList()),
+                    collectionSpotSnapshotRepository =
+                        FakeCollectionSpotFavoriteSnapshotRepository(
+                            snapshots = listOf(olderSnapshot, newerSnapshot),
+                        ),
+                )
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.uiState.collect()
+            }
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf("spot-newer", "spot-older"),
+                viewModel.uiState.value.collectionSpotFavorites.map { it.targetId },
+            )
+        }
+
+    @Test
     fun `장소 즐겨찾기 해제 시 공통 Favorite와 스냅샷을 삭제하고 UI 목록을 갱신한다`() =
         runTest {
             val snapshot =
@@ -268,8 +326,11 @@ class FavoritesViewModelTest {
                 ObserveCollectionSpotFavoriteSnapshotsUseCase(collectionSpotSnapshotRepository),
             removeCollectionSpotFavoriteUseCase =
                 RemoveCollectionSpotFavoriteUseCase(
-                    favoriteRepository = favoriteRepository,
-                    snapshotRepository = collectionSpotSnapshotRepository,
+                    collectionSpotFavoriteRepository =
+                        FakeCollectionSpotFavoriteRepository(
+                            favoriteRepository = favoriteRepository,
+                            snapshotRepository = collectionSpotSnapshotRepository,
+                        ),
                 ),
             itemGuideUiMapper = FavoriteItemGuideUiMapper(GetDisposalItemGuideUseCase(itemRepository)),
             collectionSpotUiMapper =
@@ -375,6 +436,18 @@ class FavoritesViewModelTest {
 
         override suspend fun deleteSnapshot(targetId: String) {
             snapshots.value = snapshots.value.filterNot { it.targetId == targetId }
+        }
+    }
+
+    private class FakeCollectionSpotFavoriteRepository(
+        private val favoriteRepository: FakeFavoriteRepository,
+        private val snapshotRepository: FakeCollectionSpotFavoriteSnapshotRepository,
+    ) : CollectionSpotFavoriteRepository {
+        override suspend fun toggleFavorite(spot: CollectionSpot): Boolean = false
+
+        override suspend fun removeFavorite(targetId: String) {
+            favoriteRepository.removeFavorite(FavoriteTargetType.COLLECTION_SPOT, targetId)
+            snapshotRepository.deleteSnapshot(targetId)
         }
     }
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -1,5 +1,12 @@
 package com.team.yeogibeoryeo.presentation.map
 
+import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ToggleCollectionSpotFavoriteUseCase
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
@@ -18,6 +25,9 @@ import com.team.yeogibeoryeo.presentation.map.location.LocationPermissionChecker
 import com.team.yeogibeoryeo.presentation.search.MainDispatcherRule
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -782,6 +792,120 @@ class CollectionSpotMapViewModelTest {
             assertNull(cache.entry)
         }
 
+    @Test
+    fun `키워드 검색 결과에 즐겨찾기 저장소 기준 상태를 반영한다`() =
+        runTest {
+            val favoriteSpot = sampleSpot("favorite", CollectionSpotType.BATTERY_BIN)
+            val normalSpot = sampleSpot("normal", CollectionSpotType.RECYCLING_CENTER)
+            val favoriteRepository = FakeFavoriteRepository(
+                initialFavorites = listOf(collectionSpotFavorite(favoriteSpot.id)),
+            )
+            val viewModel = createViewModel(
+                repository = FakeCollectionSpotRepository(
+                    keywordSpots = listOf(favoriteSpot, normalSpot),
+                ),
+                currentLocationResult = CurrentLocationResult.NotFound,
+                favoriteRepository = favoriteRepository,
+            )
+            advanceUntilIdle()
+
+            viewModel.onSearchKeywordChanged("문래동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(true, false),
+                viewModel.uiState.value.spots.map { spot -> spot.isBookmarked },
+            )
+        }
+
+    @Test
+    fun `캐시 결과에 즐겨찾기 저장소 기준 상태를 반영한다`() =
+        runTest {
+            val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
+            val locationResult = CompletableDeferred<CurrentLocationResult>()
+            val viewModel = createViewModel(
+                repository = FakeCollectionSpotRepository(),
+                currentLocationProvider = FakeCurrentLocationProvider {
+                    locationResult.await()
+                },
+                hasFineLocationPermission = true,
+                recentCurrentLocationSpotCacheRepository = FakeRecentCurrentLocationSpotCacheRepository(
+                    entry = freshCacheEntry(listOf(cachedSpot.copy(isBookmarked = false))),
+                ),
+                favoriteRepository = FakeFavoriteRepository(
+                    initialFavorites = listOf(collectionSpotFavorite(cachedSpot.id)),
+                ),
+            )
+            advanceUntilIdle()
+
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+            advanceUntilIdle()
+
+            assertEquals(true, viewModel.uiState.value.spots.single().isBookmarked)
+        }
+
+    @Test
+    fun `즐겨찾기 토글 시 공통 Favorite와 스냅샷을 함께 저장한다`() =
+        runTest {
+            val spot = sampleSpot("spot", CollectionSpotType.BATTERY_BIN)
+            val favoriteRepository = FakeFavoriteRepository()
+            val snapshotRepository = FakeCollectionSpotFavoriteSnapshotRepository()
+            val viewModel = createViewModel(
+                repository = FakeCollectionSpotRepository(keywordSpots = listOf(spot)),
+                currentLocationResult = CurrentLocationResult.NotFound,
+                favoriteRepository = favoriteRepository,
+                snapshotRepository = snapshotRepository,
+            )
+
+            viewModel.onSearchKeywordChanged("문래동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+            viewModel.onSpotFavoriteClick(spot)
+            advanceUntilIdle()
+
+            assertEquals(true, favoriteRepository.isFavorite(FavoriteTargetType.COLLECTION_SPOT, spot.id))
+            assertEquals(spot.id, snapshotRepository.snapshots.value.single().targetId)
+            assertEquals(true, viewModel.uiState.value.spots.single().isBookmarked)
+        }
+
+    @Test
+    fun `즐겨찾기 해제 시 공통 Favorite와 스냅샷을 함께 삭제한다`() =
+        runTest {
+            val spot = sampleSpot("spot", CollectionSpotType.BATTERY_BIN)
+            val favoriteRepository = FakeFavoriteRepository(
+                initialFavorites = listOf(collectionSpotFavorite(spot.id)),
+            )
+            val snapshotRepository = FakeCollectionSpotFavoriteSnapshotRepository(
+                initialSnapshots = listOf(
+                    CollectionSpotFavoriteSnapshot(
+                        targetId = spot.id,
+                        name = spot.name,
+                        type = spot.type,
+                        address = spot.address,
+                        detailLocation = spot.detailLocation,
+                        coordinate = spot.coordinate,
+                    ),
+                ),
+            )
+            val viewModel = createViewModel(
+                repository = FakeCollectionSpotRepository(keywordSpots = listOf(spot)),
+                currentLocationResult = CurrentLocationResult.NotFound,
+                favoriteRepository = favoriteRepository,
+                snapshotRepository = snapshotRepository,
+            )
+
+            viewModel.onSearchKeywordChanged("문래동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+            viewModel.onSpotFavoriteClick(viewModel.uiState.value.spots.single())
+            advanceUntilIdle()
+
+            assertEquals(false, favoriteRepository.isFavorite(FavoriteTargetType.COLLECTION_SPOT, spot.id))
+            assertEquals(emptyList<CollectionSpotFavoriteSnapshot>(), snapshotRepository.snapshots.value)
+            assertEquals(false, viewModel.uiState.value.spots.single().isBookmarked)
+        }
+
     private fun createViewModel(
         repository: FakeCollectionSpotRepository,
         currentLocationResult: CurrentLocationResult,
@@ -789,6 +913,9 @@ class CollectionSpotMapViewModelTest {
         recentCurrentLocationSpotCacheRepository: RecentCurrentLocationSpotCacheRepository =
             FakeRecentCurrentLocationSpotCacheRepository(),
         timeProvider: TimeProvider = FakeTimeProvider(),
+        favoriteRepository: FakeFavoriteRepository = FakeFavoriteRepository(),
+        snapshotRepository: FakeCollectionSpotFavoriteSnapshotRepository =
+            FakeCollectionSpotFavoriteSnapshotRepository(),
     ): CollectionSpotMapViewModel {
         return createViewModel(
             repository = repository,
@@ -796,6 +923,8 @@ class CollectionSpotMapViewModelTest {
             hasFineLocationPermission = hasFineLocationPermission,
             recentCurrentLocationSpotCacheRepository = recentCurrentLocationSpotCacheRepository,
             timeProvider = timeProvider,
+            favoriteRepository = favoriteRepository,
+            snapshotRepository = snapshotRepository,
         )
     }
 
@@ -806,6 +935,9 @@ class CollectionSpotMapViewModelTest {
         recentCurrentLocationSpotCacheRepository: RecentCurrentLocationSpotCacheRepository =
             FakeRecentCurrentLocationSpotCacheRepository(),
         timeProvider: TimeProvider = FakeTimeProvider(),
+        favoriteRepository: FakeFavoriteRepository = FakeFavoriteRepository(),
+        snapshotRepository: FakeCollectionSpotFavoriteSnapshotRepository =
+            FakeCollectionSpotFavoriteSnapshotRepository(),
     ): CollectionSpotMapViewModel {
         return CollectionSpotMapViewModel(
             searchCollectionSpotsByKeywordUseCase = SearchCollectionSpotsByKeywordUseCase(repository),
@@ -820,6 +952,11 @@ class CollectionSpotMapViewModelTest {
             saveRecentCurrentLocationSpotsUseCase = SaveRecentCurrentLocationSpotsUseCase(
                 repository = recentCurrentLocationSpotCacheRepository,
                 timeProvider = timeProvider,
+            ),
+            observeFavoritesUseCase = ObserveFavoritesUseCase(favoriteRepository),
+            toggleCollectionSpotFavoriteUseCase = ToggleCollectionSpotFavoriteUseCase(
+                favoriteRepository = favoriteRepository,
+                snapshotRepository = snapshotRepository,
             ),
         )
     }
@@ -927,6 +1064,80 @@ class CollectionSpotMapViewModelTest {
         }
 
         override suspend fun geocodeSpot(spot: CollectionSpot): CollectionSpot = spot
+    }
+
+    private fun collectionSpotFavorite(targetId: String): Favorite =
+        Favorite(
+            type = FavoriteTargetType.COLLECTION_SPOT,
+            targetId = targetId,
+            savedAtMillis = 1L,
+        )
+
+    private class FakeFavoriteRepository(
+        initialFavorites: List<Favorite> = emptyList(),
+    ) : FavoriteRepository {
+        private val favorites = MutableStateFlow(initialFavorites)
+
+        override fun observeFavorites(): Flow<List<Favorite>> = favorites
+
+        override fun observeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Flow<Boolean> =
+            favorites.map { items ->
+                items.any { favorite -> favorite.type == type && favorite.targetId == targetId }
+            }
+
+        override suspend fun isFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Boolean =
+            favorites.value.any { favorite -> favorite.type == type && favorite.targetId == targetId }
+
+        override suspend fun toggleFavorite(favorite: Favorite): Boolean {
+            return if (isFavorite(favorite.type, favorite.targetId)) {
+                removeFavorite(favorite.type, favorite.targetId)
+                false
+            } else {
+                addFavorite(favorite)
+                true
+            }
+        }
+
+        override suspend fun addFavorite(favorite: Favorite) {
+            favorites.value =
+                favorites.value
+                    .filterNot { it.type == favorite.type && it.targetId == favorite.targetId } + favorite
+        }
+
+        override suspend fun removeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ) {
+            favorites.value =
+                favorites.value.filterNot { it.type == type && it.targetId == targetId }
+        }
+    }
+
+    private class FakeCollectionSpotFavoriteSnapshotRepository(
+        initialSnapshots: List<CollectionSpotFavoriteSnapshot> = emptyList(),
+    ) : CollectionSpotFavoriteSnapshotRepository {
+        val snapshots = MutableStateFlow(initialSnapshots)
+
+        override fun observeSnapshots(): Flow<List<CollectionSpotFavoriteSnapshot>> = snapshots
+
+        override suspend fun getSnapshot(targetId: String): CollectionSpotFavoriteSnapshot? =
+            snapshots.value.firstOrNull { snapshot -> snapshot.targetId == targetId }
+
+        override suspend fun upsertSnapshot(snapshot: CollectionSpotFavoriteSnapshot) {
+            snapshots.value =
+                snapshots.value
+                    .filterNot { it.targetId == snapshot.targetId } + snapshot
+        }
+
+        override suspend fun deleteSnapshot(targetId: String) {
+            snapshots.value = snapshots.value.filterNot { it.targetId == targetId }
+        }
     }
 
     private companion object {

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -3,6 +3,8 @@ package com.team.yeogibeoryeo.presentation.map
 import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
 import com.team.yeogibeoryeo.domain.favorite.model.Favorite
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.model.toFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteRepository
 import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
 import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
@@ -955,8 +957,11 @@ class CollectionSpotMapViewModelTest {
             ),
             observeFavoritesUseCase = ObserveFavoritesUseCase(favoriteRepository),
             toggleCollectionSpotFavoriteUseCase = ToggleCollectionSpotFavoriteUseCase(
-                favoriteRepository = favoriteRepository,
-                snapshotRepository = snapshotRepository,
+                collectionSpotFavoriteRepository =
+                    FakeCollectionSpotFavoriteRepository(
+                        favoriteRepository = favoriteRepository,
+                        snapshotRepository = snapshotRepository,
+                    ),
             ),
         )
     }
@@ -1137,6 +1142,35 @@ class CollectionSpotMapViewModelTest {
 
         override suspend fun deleteSnapshot(targetId: String) {
             snapshots.value = snapshots.value.filterNot { it.targetId == targetId }
+        }
+    }
+
+    private class FakeCollectionSpotFavoriteRepository(
+        private val favoriteRepository: FakeFavoriteRepository,
+        private val snapshotRepository: FakeCollectionSpotFavoriteSnapshotRepository,
+    ) : CollectionSpotFavoriteRepository {
+        override suspend fun toggleFavorite(spot: CollectionSpot): Boolean {
+            val isFavorite =
+                favoriteRepository.toggleFavorite(
+                    Favorite(
+                        type = FavoriteTargetType.COLLECTION_SPOT,
+                        targetId = spot.id,
+                        savedAtMillis = TEST_NOW_MILLIS,
+                    ),
+                )
+
+            if (isFavorite) {
+                snapshotRepository.upsertSnapshot(spot.toFavoriteSnapshot())
+            } else {
+                snapshotRepository.deleteSnapshot(spot.id)
+            }
+
+            return isFavorite
+        }
+
+        override suspend fun removeFavorite(targetId: String) {
+            favoriteRepository.removeFavorite(FavoriteTargetType.COLLECTION_SPOT, targetId)
+            snapshotRepository.deleteSnapshot(targetId)
         }
     }
 


### PR DESCRIPTION
## 작업 내용

수거 장소를 `FavoriteTargetType.COLLECTION_SPOT` 타입으로 즐겨찾기 저장하고, 지도 화면과 Favorites `장소` 탭에서 즐겨찾기 상태를 일관되게 확인할 수 있도록 연결했습니다.

## 주요 변경

- 수거 장소 즐겨찾기 스냅샷 저장 구조 추가
  - `collection_spot_favorite_snapshots` 테이블 추가
  - DB version `1 -> 2`
  - 장소명 / 타입 / 주소 / 상세 위치 / 좌표 저장
  - 거리 정보는 저장하지 않음
- `CollectionSpot.id`를 수거 장소 즐겨찾기 `targetId`로 사용하는 정책 적용
- 지도 BottomSheet 수거 장소 카드에 즐겨찾기 별 버튼 추가
- 수거 장소 즐겨찾기 추가 / 해제 토글 구현
  - 추가 시 공통 `favorites`와 수거 장소 스냅샷 함께 저장
  - 해제 시 공통 `favorites`와 수거 장소 스냅샷 함께 삭제
- 키워드 검색 / 현재 위치 검색 / 최근 현재 위치 캐시 결과에 Favorites 저장소 기준 즐겨찾기 상태 반영
- Favorites `장소` 탭에서 즐겨찾기한 수거 장소 목록 표시
- Favorites `장소` 탭에서 즐겨찾기 해제 연결
- 스냅샷이 없는 `COLLECTION_SPOT` 즐겨찾기는 목록에서 안전하게 제외
- 수거 장소 즐겨찾기 관련 domain / data / presentation 테스트 보강

## 유지한 정책

- 즐겨찾기 상태의 기준은 Room 기반 Favorites 저장소입니다.
- `CollectionSpot.isBookmarked`는 화면 표시용 결과 값으로만 사용합니다.
- 검색 결과 또는 캐시 결과의 `isBookmarked` 값을 SSOT로 사용하지 않습니다.
- 공통 `favorites` 테이블 구조는 변경하지 않았습니다.
- `/getSpot` 원격 검색 로직은 변경하지 않았습니다.
- 최근 현재 위치 검색 결과 캐시 TTL 정책은 변경하지 않았습니다.
- 위치 권한 처리, `CurrentLocationProvider`, NaverMap `locationSource` / `locationTrackingMode` 구조는 변경하지 않았습니다.
- 좌표는 저장하지만 지도 카드 / Favorites 장소 카드 UI에 직접 노출하지 않습니다.
- 품목 즐겨찾기 기존 흐름은 유지했습니다.
- 장소 카드 클릭 시 지도 이동 / 상세 표시 UX는 후속 이슈로 분리합니다.

## 검증

### 자동 테스트 / 빌드

- [x] `./gradlew.bat :domain:test`
- [x] `./gradlew.bat :data:testDebugUnitTest`
- [x] `./gradlew.bat :presentation:testDebugUnitTest`
- [x] `./gradlew.bat :presentation:compileDebugKotlin`
- [x] `./gradlew.bat :app:assembleDebug`

### 실제 기기 검증

- [x] 지도에서 수거 장소 즐겨찾기 추가 후 Favorites `장소` 탭에 표시되는지 확인
- [x] Favorites `장소` 탭에서 즐겨찾기 해제 시 목록이 즉시 갱신되는지 확인
- [x] 앱 재실행 후에도 수거 장소 즐겨찾기 상태가 유지되는지 확인
- [x] 지도 검색 결과에서 기존 즐겨찾기 상태가 유지되는지 확인
- [x] 별 버튼 터치 영역이 카드 클릭 / 마커 선택과 충돌하지 않는지 확인
- [x] Favorites 탭의 `품목 / 장소 / 지역` 탭 전환이 정상 동작하는지 확인
- [x] 기존 품목 즐겨찾기 흐름이 유지되는지 확인
- [x] 지도 필터칩, 마커 선택, BottomSheet 동작이 유지되는지 확인
- [x] 현재 위치 검색 / 위치 overlay / 실패 안내 UX가 유지되는지 확인

## 스크린샷

| 카드에 즐겨찾기 별 표시 | 별 버튼 선택 상태 | Favorites 장소 탭 표시 |
| --- | --- | --- |
| <img width="260" alt="지도 카드에 즐겨찾기 별 표시" src="https://github.com/user-attachments/assets/313802d8-d843-4cac-aace-63465395308a" /> | <img width="260" alt="수거 장소 즐겨찾기 선택 상태" src="https://github.com/user-attachments/assets/0d927313-2b52-4f5e-882e-074d276318d2" /> | <img width="260" alt="Favorites 장소 탭에 즐겨찾기한 수거 장소 표시" src="https://github.com/user-attachments/assets/75070669-7865-4273-b5db-9ff7c889dafd" /> |

## 후속 작업

- 즐겨찾기 장소 클릭 시 지도 탭 이동
- 저장된 좌표 기준 지도 카메라 이동
- 해당 장소 선택 상태 표시
- 가능하면 상세 BottomSheet 표시
- Navigation route / shared state / `savedStateHandle` 사용 방식 검토

Related #101