### PR TITLE
[Fix] 검색바 동작 정렬 누락 복구

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
@@ -2,8 +2,6 @@ package com.team.yeogibeoryeo.presentation.map.components
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -52,24 +50,13 @@ fun MapSearchBar(
                 else -> MaterialTheme.colorScheme.onSurfaceVariant
             }
 
-            if (keyword.isNotBlank()) {
-                IconButton(onClick = { onKeywordChanged("") }) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = "검색어 지우기",
-                        modifier = Modifier.size(20.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-
             IconButton(
                 onClick = {
                     if (keyword.isNotBlank()) {
                         submitSearch()
                     }
                 },
-                enabled = isFocused || keyword.isNotBlank(),
+                enabled = keyword.isNotBlank(),
             ) {
                 Icon(
                     painter = painterResource(id = CommonR.drawable.ic_action_search),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSearchBar.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -39,24 +37,13 @@ fun RegionalGuideSearchBar(
                 else -> MaterialTheme.colorScheme.onSurfaceVariant
             }
 
-            if (keyword.isNotBlank()) {
-                IconButton(onClick = { onKeywordChange("") }) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = "검색어 지우기",
-                        modifier = Modifier.size(20.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-
             IconButton(
                 onClick = {
                     if (keyword.isNotBlank()) {
                         onSearchClick(keyword)
                     }
                 },
-                enabled = isFocused || keyword.isNotBlank(),
+                enabled = keyword.isNotBlank(),
             ) {
                 Icon(
                     painter = painterResource(id = CommonR.drawable.ic_action_search),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchBar.kt
@@ -2,8 +2,6 @@ package com.team.yeogibeoryeo.presentation.search.components
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -41,24 +39,13 @@ fun ItemSearchBar(
                 else -> MaterialTheme.colorScheme.onSurfaceVariant
             }
 
-            if (keyword.isNotBlank()) {
-                IconButton(onClick = { onKeywordChange("") }) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = "검색어 지우기",
-                        modifier = Modifier.size(20.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-
             IconButton(
                 onClick = {
                     if (keyword.isNotBlank()) {
                         onSearchClick()
                     }
                 },
-                enabled = isFocused || keyword.isNotBlank(),
+                enabled = keyword.isNotBlank(),
             ) {
                 Icon(
                     painter = painterResource(id = CommonR.drawable.ic_action_search),


### PR DESCRIPTION
## 작업 내용
- 안내/지도/품목 검색바에서 `aed7240`에서 의도한 검색 아이콘 정렬 상태를 누락 없이 복원
- 검색어 입력 상태(`focused`, 입력 유/무)에 따라 검색 버튼 색상 동작 일관성 확보
- 기존 검색 동작 흐름(검색 IME/클릭/후속 후보 리스트)은 유지

## 변경 이유
- PR #111 병합 이후 `develop`에는 의도한 누락분이 반영되지 않아 화면별 검색바 동작이 어긋남
- 검색 UX 일관성은 사용자 혼동을 줄이고 리뷰/운영 리스크를 낮추기 위해 조기 정합성 반영이 필요

## 주요 변경 사항
- `presentation/map/components/MapSearchBar.kt`
- `presentation/regionalguide/components/RegionalGuideSearchBar.kt`
- `presentation/search/components/ItemSearchBar.kt`

## 확인 사항
- 네비게이션 동작 및 검색 플로우는 변경 없음
- 디자인/동작은 기존 정책(안내 탭 기준)과 정렬됨

## 테스트
- `./gradlew.bat :presentation:compileDebugKotlin`
- 로컬 UI 동작 점검(안내/지도/품목 검색 바: 입력 전/입력 후/포커스 변화 시 색상/활성 표시)

## 관련 이슈
Related #115