### PR TITLE
[Fix] 품목 상세 화면 하단바 스크롤 노출 정책 적용

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -1,8 +1,23 @@
 package com.team.yeogibeoryeo.navigation
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDestination.Companion.hasRoute
@@ -30,39 +45,64 @@ fun YeogiBeoryeoNavHost(
 ) {
     val currentBackStackEntry = navController.currentBackStackEntryAsState().value
     val currentDestination = currentBackStackEntry?.destination
+    val isItemDetailScreen = currentDestination?.hasRoute<ItemGuideDetailRoute>() == true
+    var isBottomBarVisible by remember { mutableStateOf(true) }
+
+    LaunchedEffect(currentBackStackEntry) {
+        isBottomBarVisible = true
+    }
 
     Scaffold(
         modifier = modifier,
         bottomBar = {
-            AppBottomNavigationBar(
-                items =
-                    listOf(
-                        BottomNavigationItem(
-                            label = "품목",
-                            iconResId = CommonR.drawable.ic_symbol_recycle,
-                            selected = currentBackStackEntry.isItemSearchSelected(),
-                            onClick = { navController.navigateBottomTab(ItemSearchRoute()) },
+            val enterTransition =
+                if (isItemDetailScreen) {
+                    fadeIn() + expandVertically(expandFrom = Alignment.Bottom) + slideInVertically { it }
+                } else {
+                    EnterTransition.None
+                }
+            val exitTransition =
+                if (isItemDetailScreen) {
+                    fadeOut() + shrinkVertically(shrinkTowards = Alignment.Bottom) + slideOutVertically { it }
+                } else {
+                    ExitTransition.None
+                }
+
+            AnimatedVisibility(
+                visible = !isItemDetailScreen || isBottomBarVisible,
+                enter = enterTransition,
+                exit = exitTransition,
+            ) {
+                AppBottomNavigationBar(
+                    items =
+                        listOf(
+                            BottomNavigationItem(
+                                label = "품목",
+                                iconResId = CommonR.drawable.ic_symbol_recycle,
+                                selected = currentBackStackEntry.isItemSearchSelected(),
+                                onClick = { navController.navigateBottomTab(ItemSearchRoute()) },
+                            ),
+                            BottomNavigationItem(
+                                label = "지도",
+                                iconResId = AppR.drawable.ic_navigation_map,
+                                selected = currentDestination?.hasRoute<MapRoute>() == true,
+                                onClick = { navController.navigateBottomTab(MapRoute) },
+                            ),
+                            BottomNavigationItem(
+                                label = "안내",
+                                iconResId = AppR.drawable.ic_navigation_guide,
+                                selected = currentDestination?.hasRoute<RegionalGuideRoute>() == true,
+                                onClick = { navController.navigateBottomTab(RegionalGuideRoute()) },
+                            ),
+                            BottomNavigationItem(
+                                label = "저장",
+                                iconResId = CommonR.drawable.ic_favorite,
+                                selected = currentBackStackEntry.isFavoritesSelected(),
+                                onClick = { navController.navigateBottomTab(FavoritesRoute) },
+                            ),
                         ),
-                        BottomNavigationItem(
-                            label = "지도",
-                            iconResId = AppR.drawable.ic_navigation_map,
-                            selected = currentDestination?.hasRoute<MapRoute>() == true,
-                            onClick = { navController.navigateBottomTab(MapRoute) },
-                        ),
-                        BottomNavigationItem(
-                            label = "안내",
-                            iconResId = AppR.drawable.ic_navigation_guide,
-                            selected = currentDestination?.hasRoute<RegionalGuideRoute>() == true,
-                            onClick = { navController.navigateBottomTab(RegionalGuideRoute()) },
-                        ),
-                        BottomNavigationItem(
-                            label = "저장",
-                            iconResId = CommonR.drawable.ic_favorite,
-                            selected = currentBackStackEntry.isFavoritesSelected(),
-                            onClick = { navController.navigateBottomTab(FavoritesRoute) },
-                        ),
-                    ),
-            )
+                )
+            }
         },
     ) { innerPadding ->
         NavHost(
@@ -115,6 +155,11 @@ fun YeogiBeoryeoNavHost(
                 ItemGuideDetailScreenRoute(
                     guideId = route.guideId,
                     onBackClick = navController::popBackStack,
+                    onBottomBarVisibilityChanged = { isVisible ->
+                        if (isItemDetailScreen) {
+                            isBottomBarVisible = isVisible
+                        }
+                    },
                 )
             }
         }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailRoute.kt
@@ -29,6 +29,7 @@ import com.team.yeogibeoryeo.presentation.favorites.components.FavoriteSnackbar
 fun ItemGuideDetailRoute(
     guideId: String,
     onBackClick: () -> Unit,
+    onBottomBarVisibilityChanged: (Boolean) -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: ItemGuideDetailViewModel = hiltViewModel(),
 ) {
@@ -73,6 +74,7 @@ fun ItemGuideDetailRoute(
                     isFavorite = state.isFavorite,
                     onBackClick = onBackClick,
                     onFavoriteClick = viewModel::toggleFavorite,
+                    onBottomBarVisibilityChanged = onBottomBarVisibilityChanged,
                     modifier = Modifier.padding(innerPadding),
                 )
             }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
@@ -17,6 +17,10 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -46,8 +50,35 @@ fun ItemGuideDetailScreen(
     isFavorite: Boolean,
     onBackClick: () -> Unit,
     onFavoriteClick: () -> Unit,
+    onBottomBarVisibilityChanged: (Boolean) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
+    val scrollState = rememberScrollState()
+    val onBottomBarVisibilityChangedState by rememberUpdatedState(onBottomBarVisibilityChanged)
+
+    LaunchedEffect(scrollState) {
+        var previousOffset = 0
+        onBottomBarVisibilityChangedState(true)
+
+        snapshotFlow { scrollState.value }
+            .collect { currentOffset ->
+                if (scrollState.maxValue > 0 && currentOffset >= scrollState.maxValue) {
+                    onBottomBarVisibilityChangedState(false)
+                    previousOffset = currentOffset
+                    return@collect
+                }
+
+                if (currentOffset == 0) {
+                    onBottomBarVisibilityChangedState(true)
+                } else if (currentOffset > previousOffset) {
+                    onBottomBarVisibilityChangedState(false)
+                } else if (currentOffset < previousOffset) {
+                    onBottomBarVisibilityChangedState(true)
+                }
+                previousOffset = currentOffset
+            }
+    }
+
     val backActionDescription = stringResource(R.string.back_action)
     val favoriteActionDescription = if (isFavorite) "즐겨찾기 해제" else "즐겨찾기 추가"
     val matchedRepresentativeCategory = RepresentativeGuideCategory.fromGuideName(guide.name)
@@ -60,7 +91,7 @@ fun ItemGuideDetailScreen(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(scrollState)
             .padding(
                 start = 24.dp,
                 top = 16.dp,


### PR DESCRIPTION
## 작업 내용
- 품목 상세 화면에서 스크롤 방향에 따라 BottomBar 표시를 전환합니다.
- 스크롤 DOWN: BottomBar 숨김
- 스크롤 UP: BottomBar 표시
- 품목 상세 화면 최하단 도달 시 BottomBar 무조건 숨김
- 품목 상세 화면에서만 BottomBar 애니메이션이 동작하고, 다른 화면은 기존 동작 유지

## 변경 이유
- 스크롤 피드백과 네비게이션 가시성을 개선하기 위해 동작 규칙을 명확히 고정했습니다.

## 주요 변경 사항
- ItemGuideDetailRoute에 하단바 표시 상태 콜백 추가
- ItemGuideDetailScreen에 스크롤 오프셋 기반 상태 변경 로직 추가(하향/상향 + 최하단 강제 숨김)
- YeogiBeoryeoNavHost에서 화면별 애니메이션 적용 분기 처리

## 확인 사항
- 품목 상세에서 스크롤 시 BottomBar show/hide 동작 안정성
- 최하단 도달 시 BottomBar 즉시 비노출 확인

## 테스트
- ./gradlew :app:installDebug
- 실제 기기에서 화면 이동/스크롤 동작 수동 검증

https://github.com/user-attachments/assets/69e5f0c3-5d3d-45d4-9ac5-dd2895084cac


## 관련 이슈
Related #114
