### PR TITLE
feat: 즐겨찾기 장소 클릭 시 지도 이동 연결

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
@@ -3,7 +3,15 @@ package com.team.yeogibeoryeo.navigation
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object MapRoute
+data class MapRoute(
+    val favoriteSpotTargetId: String? = null,
+    val favoriteSpotName: String? = null,
+    val favoriteSpotType: String? = null,
+    val favoriteSpotAddress: String? = null,
+    val favoriteSpotDetailLocation: String? = null,
+    val favoriteSpotLatitude: Double? = null,
+    val favoriteSpotLongitude: Double? = null,
+)
 
 @Serializable
 data class RegionalGuideRoute(

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class MapRoute(
+    val favoriteSpotRequestId: String? = null,
     val favoriteSpotTargetId: String? = null,
     val favoriteSpotName: String? = null,
     val favoriteSpotType: String? = null,

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -31,8 +32,12 @@ import com.team.yeogibeoryeo.common.navigation.AppBottomNavigationBar
 import com.team.yeogibeoryeo.common.navigation.BottomNavigationItem
 import com.team.yeogibeoryeo.common.navigation.navigateBottomTab
 import com.team.yeogibeoryeo.presentation.favorites.FavoritesRoute as FavoritesScreenRoute
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteCollectionSpotMapMoveRequest
 import com.team.yeogibeoryeo.presentation.map.CollectionSpotMapScreen
+import com.team.yeogibeoryeo.presentation.map.model.FavoriteSpotMapMoveRequest
 import com.team.yeogibeoryeo.presentation.regionalguide.RegionalGuideRoute as RegionalGuideScreenRoute
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.common.R as CommonR
 import com.team.yeogibeoryeo.R as AppR
 import com.team.yeogibeoryeo.presentation.search.ItemGuideDetailRoute as ItemGuideDetailScreenRoute
@@ -86,7 +91,7 @@ fun YeogiBeoryeoNavHost(
                                 label = "지도",
                                 iconResId = AppR.drawable.ic_navigation_map,
                                 selected = currentDestination?.hasRoute<MapRoute>() == true,
-                                onClick = { navController.navigateBottomTab(MapRoute) },
+                                onClick = { navController.navigateBottomTab(MapRoute()) },
                             ),
                             BottomNavigationItem(
                                 label = "안내",
@@ -110,8 +115,11 @@ fun YeogiBeoryeoNavHost(
             startDestination = ItemSearchRoute(),
             modifier = Modifier.padding(innerPadding),
         ) {
-            composable<MapRoute> {
-                CollectionSpotMapScreen()
+            composable<MapRoute> { backStackEntry ->
+                val route = backStackEntry.toRoute<MapRoute>()
+                CollectionSpotMapScreen(
+                    favoriteSpotMoveRequest = route.toFavoriteSpotMapMoveRequest(),
+                )
             }
 
             composable<RegionalGuideRoute> { backStackEntry ->
@@ -131,6 +139,15 @@ fun YeogiBeoryeoNavHost(
                                 source = ItemGuideDetailSource.FAVORITES,
                             ),
                         )
+                    },
+                    onCollectionSpotClick = { request ->
+                        navController.navigate(request.toMapRoute()) {
+                            popUpTo(navController.graph.findStartDestination().id) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = false
+                        }
                     },
                 )
             }
@@ -178,3 +195,39 @@ private fun NavBackStackEntry?.isItemGuideDetailSource(source: ItemGuideDetailSo
     this != null &&
         destination.hasRoute<ItemGuideDetailRoute>() &&
         toRoute<ItemGuideDetailRoute>().source == source
+
+private fun FavoriteCollectionSpotMapMoveRequest.toMapRoute(): MapRoute =
+    MapRoute(
+        favoriteSpotTargetId = targetId,
+        favoriteSpotName = name,
+        favoriteSpotType = type.name,
+        favoriteSpotAddress = address,
+        favoriteSpotDetailLocation = detailLocation,
+        favoriteSpotLatitude = latitude,
+        favoriteSpotLongitude = longitude,
+    )
+
+private fun MapRoute.toFavoriteSpotMapMoveRequest(): FavoriteSpotMapMoveRequest? {
+    val targetId = favoriteSpotTargetId ?: return null
+    val name = favoriteSpotName ?: return null
+    val typeName = favoriteSpotType ?: return null
+    val address = favoriteSpotAddress ?: return null
+    val latitude = favoriteSpotLatitude ?: return null
+    val longitude = favoriteSpotLongitude ?: return null
+    val type =
+        runCatching {
+            CollectionSpotType.valueOf(typeName)
+        }.getOrNull() ?: return null
+
+    return FavoriteSpotMapMoveRequest(
+        targetId = targetId,
+        name = name,
+        type = type,
+        address = address,
+        detailLocation = favoriteSpotDetailLocation,
+        coordinate = Coordinate(
+            latitude = latitude,
+            longitude = longitude,
+        ),
+    )
+}

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -28,6 +28,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
+import java.util.UUID
 import com.team.yeogibeoryeo.common.navigation.AppBottomNavigationBar
 import com.team.yeogibeoryeo.common.navigation.BottomNavigationItem
 import com.team.yeogibeoryeo.common.navigation.navigateBottomTab
@@ -198,6 +199,7 @@ private fun NavBackStackEntry?.isItemGuideDetailSource(source: ItemGuideDetailSo
 
 private fun FavoriteCollectionSpotMapMoveRequest.toMapRoute(): MapRoute =
     MapRoute(
+        favoriteSpotRequestId = UUID.randomUUID().toString(),
         favoriteSpotTargetId = targetId,
         favoriteSpotName = name,
         favoriteSpotType = type.name,
@@ -220,6 +222,7 @@ private fun MapRoute.toFavoriteSpotMapMoveRequest(): FavoriteSpotMapMoveRequest?
         }.getOrNull() ?: return null
 
     return FavoriteSpotMapMoveRequest(
+        requestId = favoriteSpotRequestId ?: targetId,
         targetId = targetId,
         name = name,
         type = type,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesRoute.kt
@@ -5,10 +5,12 @@ import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Modifier
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteCollectionSpotMapMoveRequest
 
 @Composable
 fun FavoritesRoute(
     onItemGuideClick: (String) -> Unit,
+    onCollectionSpotClick: (FavoriteCollectionSpotMapMoveRequest) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: FavoritesViewModel = hiltViewModel(),
 ) {
@@ -18,7 +20,7 @@ fun FavoritesRoute(
         uiState = uiState,
         onTabClick = viewModel::selectTab,
         onItemGuideClick = onItemGuideClick,
-        onCollectionSpotClick = {},
+        onCollectionSpotClick = onCollectionSpotClick,
         onRegionalGuideClick = {},
         onCollectionSpotFavoriteRemoveClick = viewModel::removeCollectionSpotFavorite,
         modifier = modifier,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreen.kt
@@ -86,8 +86,13 @@ fun FavoritesScreen(
                     items = uiState.selectedFavorites,
                     key = { "${it.type.name}:${it.targetId}" },
                 ) { favorite ->
+                    val isCardClickEnabled =
+                        favorite.type != FavoriteTargetType.COLLECTION_SPOT ||
+                            favorite.collectionSpotMapMoveRequest != null
+
                     FavoriteCard(
                         favorite = favorite,
+                        enabled = isCardClickEnabled,
                         onClick = {
                             when (favorite.type) {
                                 FavoriteTargetType.ITEM_GUIDE -> onItemGuideClick(favorite.targetId)

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
 import com.team.yeogibeoryeo.presentation.favorites.components.EmptyFavoritesCard
 import com.team.yeogibeoryeo.presentation.favorites.components.FavoriteCard
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteCollectionSpotMapMoveRequest
 import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteTab
 
 @Composable
@@ -28,7 +29,7 @@ fun FavoritesScreen(
     uiState: FavoritesUiState,
     onTabClick: (FavoriteTab) -> Unit,
     onItemGuideClick: (String) -> Unit,
-    onCollectionSpotClick: (String) -> Unit,
+    onCollectionSpotClick: (FavoriteCollectionSpotMapMoveRequest) -> Unit,
     onRegionalGuideClick: (String) -> Unit,
     onCollectionSpotFavoriteRemoveClick: (String) -> Unit,
     modifier: Modifier = Modifier,
@@ -90,7 +91,9 @@ fun FavoritesScreen(
                         onClick = {
                             when (favorite.type) {
                                 FavoriteTargetType.ITEM_GUIDE -> onItemGuideClick(favorite.targetId)
-                                FavoriteTargetType.COLLECTION_SPOT -> onCollectionSpotClick(favorite.targetId)
+                                FavoriteTargetType.COLLECTION_SPOT -> {
+                                    favorite.collectionSpotMapMoveRequest?.let(onCollectionSpotClick)
+                                }
                                 FavoriteTargetType.REGIONAL_GUIDE -> onRegionalGuideClick(favorite.targetId)
                             }
                         },

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/components/FavoriteCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/components/FavoriteCard.kt
@@ -32,12 +32,16 @@ fun FavoriteCard(
     favorite: FavoriteUiModel,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     onRemoveClick: (() -> Unit)? = null,
 ) {
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick),
+            .clickable(
+                enabled = enabled,
+                onClick = onClick,
+            ),
         shape = RoundedCornerShape(20.dp),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/mapper/FavoriteCollectionSpotUiMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/mapper/FavoriteCollectionSpotUiMapper.kt
@@ -4,6 +4,7 @@ import com.team.yeogibeoryeo.domain.favorite.model.Favorite
 import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
 import com.team.yeogibeoryeo.domain.favorite.usecase.GetCollectionSpotFavoriteSnapshotUseCase
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteCollectionSpotMapMoveRequest
 import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteUiModel
 import com.team.yeogibeoryeo.presentation.map.mapper.toDisplayName
 import javax.inject.Inject
@@ -23,6 +24,7 @@ class FavoriteCollectionSpotUiMapper
                 targetId = favorite.targetId,
                 title = snapshot.name,
                 subtitle = snapshot.toSubtitle(),
+                collectionSpotMapMoveRequest = snapshot.toMapMoveRequest(),
             )
         }
 
@@ -32,7 +34,22 @@ class FavoriteCollectionSpotUiMapper
                 targetId = snapshot.targetId,
                 title = snapshot.name,
                 subtitle = snapshot.toSubtitle(),
+                collectionSpotMapMoveRequest = snapshot.toMapMoveRequest(),
             )
+
+        private fun CollectionSpotFavoriteSnapshot.toMapMoveRequest(): FavoriteCollectionSpotMapMoveRequest? {
+            val coordinate = coordinate ?: return null
+
+            return FavoriteCollectionSpotMapMoveRequest(
+                targetId = targetId,
+                name = name,
+                type = type,
+                address = address,
+                detailLocation = detailLocation,
+                latitude = coordinate.latitude,
+                longitude = coordinate.longitude,
+            )
+        }
 
         private fun CollectionSpotFavoriteSnapshot.toSubtitle(): String =
             listOf(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/model/FavoriteCollectionSpotMapMoveRequest.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/model/FavoriteCollectionSpotMapMoveRequest.kt
@@ -1,0 +1,13 @@
+package com.team.yeogibeoryeo.presentation.favorites.model
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+
+data class FavoriteCollectionSpotMapMoveRequest(
+    val targetId: String,
+    val name: String,
+    val type: CollectionSpotType,
+    val address: String,
+    val detailLocation: String?,
+    val latitude: Double,
+    val longitude: Double,
+)

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/model/FavoriteUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/model/FavoriteUiModel.kt
@@ -7,4 +7,5 @@ data class FavoriteUiModel(
     val targetId: String,
     val title: String,
     val subtitle: String?,
+    val collectionSpotMapMoveRequest: FavoriteCollectionSpotMapMoveRequest? = null,
 )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -37,9 +37,11 @@ import com.team.yeogibeoryeo.presentation.map.components.SpotDetailBottomSheetCo
 import com.team.yeogibeoryeo.presentation.map.components.ThreeStepMapBottomSheet
 import com.team.yeogibeoryeo.presentation.map.location.rememberFineLocationPermissionGranted
 import com.team.yeogibeoryeo.presentation.map.location.rememberCurrentLocationSearchRequester
+import com.team.yeogibeoryeo.presentation.map.model.FavoriteSpotMapMoveRequest
 
 @Composable
 fun CollectionSpotMapScreen(
+    favoriteSpotMoveRequest: FavoriteSpotMapMoveRequest? = null,
     modifier: Modifier = Modifier,
     viewModel: CollectionSpotMapViewModel = hiltViewModel(),
 ) {
@@ -77,8 +79,14 @@ fun CollectionSpotMapScreen(
         onDenied = viewModel::onLocationPermissionDenied,
     )
 
-    LaunchedEffect(Unit) {
-        viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+    LaunchedEffect(favoriteSpotMoveRequest) {
+        val request = favoriteSpotMoveRequest
+        if (request == null) {
+            viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
+        } else {
+            locationTrackingMode = LocationTrackingMode.NoFollow
+            viewModel.showFavoriteSpot(request)
+        }
     }
 
     CollectionSpotMapContent(
@@ -129,6 +137,7 @@ private fun CollectionSpotMapContent(
     var sheetLevel by remember { mutableStateOf(MapSheetLevel.Hidden) }
     var sheetRevealRequest by remember { mutableStateOf(0) }
     val selectedSpot = uiState.selectedSpot
+    val selectedSpotMoveRequestSequence = uiState.favoriteSpotMoveRequestSequence
     val hasNoticeOrError = uiState.locationNotice != null ||
         uiState.locationNoticeMessage != null ||
         uiState.errorMessage != null
@@ -183,6 +192,14 @@ private fun CollectionSpotMapContent(
                 sheetLevel = MapSheetLevel.Hidden
                 MapUiMode.Browsing
             }
+        }
+    }
+
+    LaunchedEffect(selectedSpotMoveRequestSequence) {
+        if (selectedSpotMoveRequestSequence > 0 && selectedSpot != null) {
+            mapUiMode = MapUiMode.SpotDetail
+            sheetLevel = MapSheetLevel.Medium
+            sheetRevealRequest += 1
         }
     }
 
@@ -279,6 +296,7 @@ private fun CollectionSpotMapContent(
                     mapUiMode == MapUiMode.SpotDetail && selectedSpot != null -> {
                         SpotDetailBottomSheetContent(
                             spot = selectedSpot,
+                            isNearbyLoading = uiState.isFavoriteSpotNearbyLoading,
                             onFavoriteClick = onSpotFavoriteClick,
                             onCloseClick = {
                                 mapUiMode = MapUiMode.ResultList
@@ -291,7 +309,7 @@ private fun CollectionSpotMapContent(
                         SpotBottomSheetContent(
                             spots = uiState.spots,
                             selectedSpot = selectedSpot,
-                            isLoading = uiState.isLoading,
+                            isLoading = uiState.isLoading || uiState.isFavoriteSpotNearbyLoading,
                             hasSearched = uiState.hasSearched,
                             selectedTypes = uiState.selectedTypes,
                             locationNotice = uiState.locationNotice,
@@ -321,7 +339,8 @@ private val CollectionSpotMapUiState.shouldShowBottomSheet: Boolean
         locationNoticeMessage != null ||
         errorMessage != null ||
         hasSearched ||
-        spots.isNotEmpty()
+        spots.isNotEmpty() ||
+        selectedSpot != null
 
 private enum class MapUiMode {
     Browsing,
@@ -367,6 +386,7 @@ private fun CollectionSpotMapContentPreview() {
             )
         }
     }
+
 }
 
 private val MyLocationButtonHorizontalPadding = 16.dp

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapUiState.kt
@@ -14,6 +14,9 @@ data class CollectionSpotMapUiState(
     val hasSearched: Boolean = false,
     val locationNotice: MapLocationNotice? = null,
     val locationNoticeMessage: String? = null,
+    val favoriteSpotMoveRequestId: String? = null,
+    val favoriteSpotMoveRequestSequence: Int = 0,
+    val isFavoriteSpotNearbyLoading: Boolean = false,
 ) {
     val isEmpty: Boolean
         get() = hasSearched && !isLoading && spots.isEmpty() && errorMessage == null

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -16,6 +16,7 @@ import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByLocation
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationProvider
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationResult
 import com.team.yeogibeoryeo.presentation.map.location.LocationPermissionChecker
+import com.team.yeogibeoryeo.presentation.map.model.FavoriteSpotMapMoveRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
@@ -218,6 +219,33 @@ class CollectionSpotMapViewModel @Inject constructor(
         }
     }
 
+    fun showFavoriteSpot(request: FavoriteSpotMapMoveRequest) {
+        currentLocationRefreshJob?.cancel()
+        spotSearchJob?.cancel()
+
+        val selectedSpot =
+            originalSpots.firstOrNull { spot -> spot.id == request.targetId }
+                ?: uiState.value.spots.firstOrNull { spot -> spot.id == request.targetId }
+                ?: request.toCollectionSpot()
+
+        _uiState.update {
+            it.copy(
+                selectedSpot = selectedSpot.copy(
+                    isBookmarked = request.targetId in favoriteSpotIds,
+                ),
+                isLoading = false,
+                errorMessage = null,
+                locationNotice = null,
+                locationNoticeMessage = null,
+                favoriteSpotMoveRequestId = request.targetId,
+                favoriteSpotMoveRequestSequence = it.favoriteSpotMoveRequestSequence + 1,
+                isFavoriteSpotNearbyLoading = true,
+            )
+        }
+
+        searchNearbySpotsForFavoriteSpot(request)
+    }
+
     fun onSpotFavoriteClick(spot: CollectionSpot) {
         viewModelScope.launch {
             toggleCollectionSpotFavoriteUseCase(spot)
@@ -331,6 +359,52 @@ class CollectionSpotMapViewModel @Inject constructor(
                 locationNotice = null,
                 locationNoticeMessage = null,
             )
+        }
+    }
+
+    private fun searchNearbySpotsForFavoriteSpot(request: FavoriteSpotMapMoveRequest) {
+        spotSearchJob = viewModelScope.launch {
+            runCatching {
+                searchCollectionSpotsByLocationUseCase(
+                    coordinate = request.coordinate,
+                    radiusMeter = DEFAULT_RADIUS_METER,
+                    types = emptySet(),
+                )
+            }.onSuccess { spots ->
+                val selectedSpotId = uiState.value.selectedSpot?.id
+                originalSpots = spots.withFavoriteState()
+
+                val filteredSpots =
+                    filterCollectionSpotsUseCase(
+                        spots = originalSpots,
+                        selectedTypes = uiState.value.selectedTypes,
+                    )
+                val updatedSelectedSpot =
+                    selectedSpotId?.let { id ->
+                        originalSpots.firstOrNull { spot -> spot.id == id }
+                            ?: uiState.value.selectedSpot
+                    }
+
+                _uiState.update {
+                    it.copy(
+                        spots = filteredSpots,
+                        selectedSpot = updatedSelectedSpot,
+                        isLoading = false,
+                        isFavoriteSpotNearbyLoading = false,
+                        hasSearched = true,
+                        errorMessage = null,
+                        locationNotice = null,
+                        locationNoticeMessage = null,
+                        searchMode = MapSearchMode.CURRENT_LOCATION,
+                    )
+                }
+            }.onFailure { throwable ->
+                if (throwable is CancellationException) throw throwable
+
+                _uiState.update {
+                    it.copy(isFavoriteSpotNearbyLoading = false)
+                }
+            }
         }
     }
 
@@ -480,6 +554,18 @@ class CollectionSpotMapViewModel @Inject constructor(
         map { spot ->
             spot.copy(isBookmarked = spot.id in favoriteSpotIds)
         }
+
+    private fun FavoriteSpotMapMoveRequest.toCollectionSpot(): CollectionSpot =
+        CollectionSpot(
+            id = targetId,
+            name = name,
+            type = type,
+            address = address,
+            detailLocation = detailLocation,
+            coordinate = coordinate,
+            distanceMeter = null,
+            isBookmarked = targetId in favoriteSpotIds,
+        )
 
     private companion object {
         const val DEFAULT_RADIUS_METER = 500

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -48,6 +48,7 @@ class CollectionSpotMapViewModel @Inject constructor(
     private var currentLocationRefreshJob: Job? = null
     private var hasRequestedInitialCurrentLocationSearch = false
     private var favoriteSpotIds: Set<String> = emptySet()
+    private val consumedFavoriteSpotMoveRequestIds = mutableSetOf<String>()
 
     init {
         observeCollectionSpotFavorites()
@@ -59,8 +60,9 @@ class CollectionSpotMapViewModel @Inject constructor(
         val shouldCancelCurrentLocationSearch =
             uiState.value.isLoading &&
                 uiState.value.searchMode == MapSearchMode.CURRENT_LOCATION
+        val shouldCancelFavoriteSpotNearbySearch = uiState.value.isFavoriteSpotNearbyLoading
 
-        if (shouldCancelCurrentLocationSearch) {
+        if (shouldCancelCurrentLocationSearch || shouldCancelFavoriteSpotNearbySearch) {
             spotSearchJob?.cancel()
         }
 
@@ -90,6 +92,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 errorMessage = null,
                 locationNotice = null,
                 locationNoticeMessage = null,
+                isFavoriteSpotNearbyLoading = false,
                 searchMode = if (shouldCancelCurrentLocationSearch) {
                     MapSearchMode.KEYWORD
                 } else {
@@ -116,6 +119,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     errorMessage = "검색어를 입력해주세요.",
                     locationNotice = null,
                     locationNoticeMessage = null,
+                    isFavoriteSpotNearbyLoading = false,
                     searchMode = MapSearchMode.KEYWORD,
                 )
             }
@@ -132,6 +136,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     locationNotice = null,
                     locationNoticeMessage = null,
                     selectedSpot = null,
+                    isFavoriteSpotNearbyLoading = false,
                     searchMode = MapSearchMode.KEYWORD,
                 )
             }
@@ -220,6 +225,8 @@ class CollectionSpotMapViewModel @Inject constructor(
     }
 
     fun showFavoriteSpot(request: FavoriteSpotMapMoveRequest) {
+        if (!consumedFavoriteSpotMoveRequestIds.add(request.requestId)) return
+
         currentLocationRefreshJob?.cancel()
         spotSearchJob?.cancel()
 
@@ -264,6 +271,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 errorMessage = null,
                 locationNotice = MapLocationNotices.PermissionDenied,
                 locationNoticeMessage = MapLocationNotices.PermissionDenied.message,
+                isFavoriteSpotNearbyLoading = false,
                 searchMode = MapSearchMode.KEYWORD,
             )
         }
@@ -313,6 +321,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 errorMessage = null,
                 locationNotice = MapLocationNotices.CurrentLocationUnavailable,
                 locationNoticeMessage = MapLocationNotices.CurrentLocationUnavailable.message,
+                isFavoriteSpotNearbyLoading = false,
                 searchMode = MapSearchMode.KEYWORD,
             )
         }
@@ -330,6 +339,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 errorMessage = null,
                 locationNotice = MapLocationNotices.LocationServiceDisabled,
                 locationNoticeMessage = MapLocationNotices.LocationServiceDisabled.message,
+                isFavoriteSpotNearbyLoading = false,
                 searchMode = MapSearchMode.KEYWORD,
             )
         }
@@ -358,6 +368,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 errorMessage = null,
                 locationNotice = null,
                 locationNoticeMessage = null,
+                isFavoriteSpotNearbyLoading = false,
             )
         }
     }
@@ -420,6 +431,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 errorMessage = message,
                 locationNotice = null,
                 locationNoticeMessage = null,
+                isFavoriteSpotNearbyLoading = false,
             )
         }
     }
@@ -438,6 +450,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     locationNotice = null,
                     locationNoticeMessage = null,
                     selectedSpot = null,
+                    isFavoriteSpotNearbyLoading = false,
                     searchMode = MapSearchMode.CURRENT_LOCATION,
                 )
             }
@@ -488,6 +501,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 errorMessage = null,
                 locationNotice = null,
                 locationNoticeMessage = null,
+                isFavoriteSpotNearbyLoading = false,
                 searchMode = MapSearchMode.CURRENT_LOCATION,
             )
         }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CollectionSpotNaverMap.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CollectionSpotNaverMap.kt
@@ -30,9 +30,10 @@ fun CollectionSpotNaverMap(
 ) {
     val defaultMarkerColor = MaterialTheme.colorScheme.primary
     val selectedMarkerColor = MaterialTheme.colorScheme.tertiary
-    val markerSpots = spots.filter { spot ->
-        spot.coordinate != null
-    }
+    val markerSpots =
+        (spots + listOfNotNull(selectedSpot))
+            .distinctBy { spot -> spot.id }
+            .filter { spot -> spot.coordinate != null }
     val locationSource = rememberMapLocationSource()
     val mapProperties = MapProperties(
         locationTrackingMode = if (isLocationPermissionGranted) {
@@ -49,8 +50,10 @@ fun CollectionSpotNaverMap(
         )
     }
 
-    LaunchedEffect(markerSpots) {
-        val firstSpot = markerSpots.firstOrNull()
+    LaunchedEffect(spots) {
+        if (selectedSpot != null) return@LaunchedEffect
+
+        val firstSpot = spots.firstOrNull { spot -> spot.coordinate != null }
         val coordinate = firstSpot?.coordinate
 
         if (coordinate != null) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
@@ -3,9 +3,11 @@ package com.team.yeogibeoryeo.presentation.map.components
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -149,6 +151,7 @@ private fun SpotBottomSheetLoading(
 @Composable
 fun SpotDetailBottomSheetContent(
     spot: CollectionSpot,
+    isNearbyLoading: Boolean = false,
     onFavoriteClick: (CollectionSpot) -> Unit,
     onCloseClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -167,15 +170,35 @@ fun SpotDetailBottomSheetContent(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        Text(
-            text = "목록으로",
+        Row(
             modifier = Modifier
                 .align(Alignment.End)
-                .clickable(onClick = onCloseClick)
                 .padding(top = 12.dp, bottom = 8.dp),
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.primary,
-        )
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (isNearbyLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .padding(end = 8.dp)
+                        .size(16.dp),
+                    strokeWidth = 2.dp,
+                )
+                Text(
+                    text = "주변 목록 준비 중",
+                    modifier = Modifier.padding(end = 12.dp),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Text(
+                text = "목록으로",
+                modifier = Modifier
+                    .clickable(onClick = onCloseClick),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/model/FavoriteSpotMapMoveRequest.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/model/FavoriteSpotMapMoveRequest.kt
@@ -1,0 +1,13 @@
+package com.team.yeogibeoryeo.presentation.map.model
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+
+data class FavoriteSpotMapMoveRequest(
+    val targetId: String,
+    val name: String,
+    val type: CollectionSpotType,
+    val address: String,
+    val detailLocation: String?,
+    val coordinate: Coordinate,
+)

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/model/FavoriteSpotMapMoveRequest.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/model/FavoriteSpotMapMoveRequest.kt
@@ -4,6 +4,7 @@ import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 
 data class FavoriteSpotMapMoveRequest(
+    val requestId: String,
     val targetId: String,
     val name: String,
     val type: CollectionSpotType,

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModelTest.kt
@@ -22,6 +22,7 @@ import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteCollectionSpotUiMapper
 import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteItemGuideUiMapper
 import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteRegionalGuideUiMapper
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteCollectionSpotMapMoveRequest
 import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteTab
 import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteUiModel
 import com.team.yeogibeoryeo.presentation.search.MainDispatcherRule
@@ -154,9 +155,61 @@ class FavoritesViewModelTest {
                         targetId = "spot-1",
                         title = "폐건전지 수거함",
                         subtitle = "폐건전지 · 서울특별시 영등포구 문래동 · 주민센터 앞",
+                        collectionSpotMapMoveRequest =
+                            FavoriteCollectionSpotMapMoveRequest(
+                                targetId = "spot-1",
+                                name = "폐건전지 수거함",
+                                type = CollectionSpotType.BATTERY_BIN,
+                                address = "서울특별시 영등포구 문래동",
+                                detailLocation = "주민센터 앞",
+                                latitude = 37.5,
+                                longitude = 126.9,
+                            ),
                     ),
                 ),
                 viewModel.uiState.value.collectionSpotFavorites,
+            )
+        }
+
+    @Test
+    fun `좌표가 없는 수거 장소 즐겨찾기는 지도 이동 요청 없이 UI 모델로 변환한다`() =
+        runTest {
+            val snapshot =
+                CollectionSpotFavoriteSnapshot(
+                    targetId = "spot-without-coordinate",
+                    name = "좌표 없는 수거함",
+                    type = CollectionSpotType.OTHER,
+                    address = "서울특별시 영등포구",
+                    detailLocation = null,
+                    coordinate = null,
+                )
+            val viewModel =
+                createViewModel(
+                    favoriteRepository =
+                        FakeFavoriteRepository(
+                            initialFavorites =
+                                listOf(
+                                    Favorite(
+                                        type = FavoriteTargetType.COLLECTION_SPOT,
+                                        targetId = snapshot.targetId,
+                                        savedAtMillis = 1L,
+                                    ),
+                                ),
+                        ),
+                    itemRepository = FakeItemRepository(guides = emptyList()),
+                    collectionSpotSnapshotRepository =
+                        FakeCollectionSpotFavoriteSnapshotRepository(
+                            snapshots = listOf(snapshot),
+                        ),
+                )
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.uiState.collect()
+            }
+            advanceUntilIdle()
+
+            assertEquals(
+                null,
+                viewModel.uiState.value.collectionSpotFavorites.single().collectionSpotMapMoveRequest,
             )
         }
 

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -24,6 +24,7 @@ import com.team.yeogibeoryeo.domain.time.TimeProvider
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationProvider
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationResult
 import com.team.yeogibeoryeo.presentation.map.location.LocationPermissionChecker
+import com.team.yeogibeoryeo.presentation.map.model.FavoriteSpotMapMoveRequest
 import com.team.yeogibeoryeo.presentation.search.MainDispatcherRule
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -906,6 +907,100 @@ class CollectionSpotMapViewModelTest {
             assertEquals(false, favoriteRepository.isFavorite(FavoriteTargetType.COLLECTION_SPOT, spot.id))
             assertEquals(emptyList<CollectionSpotFavoriteSnapshot>(), snapshotRepository.snapshots.value)
             assertEquals(false, viewModel.uiState.value.spots.single().isBookmarked)
+        }
+
+    @Test
+    fun `즐겨찾기 장소 지도 이동 요청을 selectedSpot으로 반영한다`() =
+        runTest {
+            val request =
+                FavoriteSpotMapMoveRequest(
+                    targetId = "favorite-spot",
+                    name = "폐건전지 수거함",
+                    type = CollectionSpotType.BATTERY_BIN,
+                    address = "서울특별시 영등포구 문래동",
+                    detailLocation = "주민센터 앞",
+                    coordinate = Coordinate(latitude = 37.5, longitude = 126.9),
+                )
+            val viewModel = createViewModel(
+                repository = FakeCollectionSpotRepository(),
+                currentLocationResult = CurrentLocationResult.NotFound,
+                favoriteRepository = FakeFavoriteRepository(
+                    initialFavorites = listOf(collectionSpotFavorite(request.targetId)),
+                ),
+            )
+            advanceUntilIdle()
+
+            viewModel.showFavoriteSpot(request)
+
+            assertEquals(request.targetId, viewModel.uiState.value.selectedSpot?.id)
+            assertEquals(request.coordinate, viewModel.uiState.value.selectedSpot?.coordinate)
+            assertEquals(true, viewModel.uiState.value.selectedSpot?.isBookmarked)
+            assertEquals(request.targetId, viewModel.uiState.value.favoriteSpotMoveRequestId)
+            assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
+        }
+
+    @Test
+    fun `현재 검색 결과에 같은 즐겨찾기 장소가 있으면 기존 장소 정보를 선택한다`() =
+        runTest {
+            val existingSpot = sampleSpot("favorite-spot", CollectionSpotType.RECYCLING_CENTER)
+            val request =
+                FavoriteSpotMapMoveRequest(
+                    targetId = existingSpot.id,
+                    name = "스냅샷 이름",
+                    type = CollectionSpotType.BATTERY_BIN,
+                    address = "스냅샷 주소",
+                    detailLocation = null,
+                    coordinate = Coordinate(latitude = 37.5, longitude = 126.9),
+                )
+            val viewModel = createViewModel(
+                repository = FakeCollectionSpotRepository(keywordSpots = listOf(existingSpot)),
+                currentLocationResult = CurrentLocationResult.NotFound,
+                favoriteRepository = FakeFavoriteRepository(
+                    initialFavorites = listOf(collectionSpotFavorite(existingSpot.id)),
+                ),
+            )
+            advanceUntilIdle()
+            viewModel.onSearchKeywordChanged("문래동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            viewModel.showFavoriteSpot(request)
+
+            assertEquals(existingSpot.name, viewModel.uiState.value.selectedSpot?.name)
+            assertEquals(existingSpot.type, viewModel.uiState.value.selectedSpot?.type)
+            assertEquals(true, viewModel.uiState.value.selectedSpot?.isBookmarked)
+        }
+
+    @Test
+    fun `즐겨찾기 장소 지도 이동 후 해당 좌표 기준 주변 수거 장소 목록을 갱신한다`() =
+        runTest {
+            val request =
+                FavoriteSpotMapMoveRequest(
+                    targetId = "favorite-spot",
+                    name = "폐건전지 수거함",
+                    type = CollectionSpotType.BATTERY_BIN,
+                    address = "서울특별시 성동구 용답동",
+                    detailLocation = "주민센터 앞",
+                    coordinate = Coordinate(latitude = 37.5, longitude = 126.9),
+                )
+            val nearbySpot = sampleSpot("nearby", CollectionSpotType.RECYCLING_CENTER)
+            val repository =
+                FakeCollectionSpotRepository(
+                    locationSpots = listOf(nearbySpot),
+                )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.showFavoriteSpot(request)
+            advanceUntilIdle()
+
+            assertEquals(request.coordinate, repository.lastLocationCoordinate)
+            assertEquals(listOf(nearbySpot), viewModel.uiState.value.spots)
+            assertEquals(request.targetId, viewModel.uiState.value.selectedSpot?.id)
+            assertEquals(true, viewModel.uiState.value.hasSearched)
+            assertEquals(false, viewModel.uiState.value.isFavoriteSpotNearbyLoading)
         }
 
     private fun createViewModel(

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -1003,6 +1003,74 @@ class CollectionSpotMapViewModelTest {
             assertEquals(false, viewModel.uiState.value.isFavoriteSpotNearbyLoading)
         }
 
+    @Test
+    fun `즐겨찾기 장소 주변 목록 조회 중 로딩 상태를 표시한다`() =
+        runTest {
+            val request = sampleFavoriteSpotMapMoveRequest()
+            val nearbySpot = sampleSpot("nearby", CollectionSpotType.RECYCLING_CENTER)
+            val locationSearchResult = CompletableDeferred<List<CollectionSpot>>()
+            val repository =
+                FakeCollectionSpotRepository(
+                    locationSearchResultProvider = { locationSearchResult.await() },
+                )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.showFavoriteSpot(request)
+            advanceUntilIdle()
+
+            assertEquals(request.targetId, viewModel.uiState.value.selectedSpot?.id)
+            assertEquals(true, viewModel.uiState.value.isFavoriteSpotNearbyLoading)
+
+            locationSearchResult.complete(listOf(nearbySpot))
+            advanceUntilIdle()
+
+            assertEquals(listOf(nearbySpot), viewModel.uiState.value.spots)
+            assertEquals(false, viewModel.uiState.value.isFavoriteSpotNearbyLoading)
+        }
+
+    @Test
+    fun `즐겨찾기 장소 주변 목록 조회 실패 시에도 selectedSpot을 유지한다`() =
+        runTest {
+            val request = sampleFavoriteSpotMapMoveRequest()
+            val viewModel = createViewModel(
+                repository = FakeCollectionSpotRepository(
+                    locationSearchThrowable = IllegalStateException("network error"),
+                ),
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.showFavoriteSpot(request)
+            advanceUntilIdle()
+
+            assertEquals(request.targetId, viewModel.uiState.value.selectedSpot?.id)
+            assertEquals(request.coordinate, viewModel.uiState.value.selectedSpot?.coordinate)
+            assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
+            assertEquals(false, viewModel.uiState.value.isFavoriteSpotNearbyLoading)
+        }
+
+    @Test
+    fun `같은 즐겨찾기 장소 이동 요청도 다시 처리할 수 있도록 sequence를 증가시킨다`() =
+        runTest {
+            val request = sampleFavoriteSpotMapMoveRequest()
+            val viewModel = createViewModel(
+                repository = FakeCollectionSpotRepository(),
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.showFavoriteSpot(request)
+            advanceUntilIdle()
+            val firstSequence = viewModel.uiState.value.favoriteSpotMoveRequestSequence
+
+            viewModel.showFavoriteSpot(request)
+            advanceUntilIdle()
+
+            assertEquals(request.targetId, viewModel.uiState.value.selectedSpot?.id)
+            assertEquals(firstSequence + 1, viewModel.uiState.value.favoriteSpotMoveRequestSequence)
+        }
+
     private fun createViewModel(
         repository: FakeCollectionSpotRepository,
         currentLocationResult: CurrentLocationResult,
@@ -1084,6 +1152,17 @@ class CollectionSpotMapViewModelTest {
         )
     }
 
+    private fun sampleFavoriteSpotMapMoveRequest(): FavoriteSpotMapMoveRequest {
+        return FavoriteSpotMapMoveRequest(
+            targetId = "favorite-spot",
+            name = "폐건전지 수거함",
+            type = CollectionSpotType.BATTERY_BIN,
+            address = "서울특별시 영등포구 문래동",
+            detailLocation = "주민센터 앞",
+            coordinate = Coordinate(latitude = 37.5, longitude = 126.9),
+        )
+    }
+
     private class FakeCurrentLocationProvider(
         private val resultProvider: suspend () -> CurrentLocationResult,
     ) : CurrentLocationProvider {
@@ -1136,6 +1215,7 @@ class CollectionSpotMapViewModelTest {
         private val locationSpots: List<CollectionSpot> = emptyList(),
         private val keywordSearchThrowable: Throwable? = null,
         private val locationSearchThrowable: Throwable? = null,
+        private val locationSearchResultProvider: (suspend () -> List<CollectionSpot>)? = null,
     ) : CollectionSpotRepository {
         val keywords = mutableListOf<String>()
         var locationSearchCallCount = 0
@@ -1160,6 +1240,7 @@ class CollectionSpotMapViewModelTest {
             lastLocationCoordinate = coordinate
             lastRadiusMeter = radiusMeter
             locationSearchThrowable?.let { throw it }
+            locationSearchResultProvider?.let { provider -> return provider() }
             return locationSpots
         }
 

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -914,6 +914,7 @@ class CollectionSpotMapViewModelTest {
         runTest {
             val request =
                 FavoriteSpotMapMoveRequest(
+                    requestId = "request-1",
                     targetId = "favorite-spot",
                     name = "폐건전지 수거함",
                     type = CollectionSpotType.BATTERY_BIN,
@@ -945,6 +946,7 @@ class CollectionSpotMapViewModelTest {
             val existingSpot = sampleSpot("favorite-spot", CollectionSpotType.RECYCLING_CENTER)
             val request =
                 FavoriteSpotMapMoveRequest(
+                    requestId = "request-1",
                     targetId = existingSpot.id,
                     name = "스냅샷 이름",
                     type = CollectionSpotType.BATTERY_BIN,
@@ -976,6 +978,7 @@ class CollectionSpotMapViewModelTest {
         runTest {
             val request =
                 FavoriteSpotMapMoveRequest(
+                    requestId = "request-1",
                     targetId = "favorite-spot",
                     name = "폐건전지 수거함",
                     type = CollectionSpotType.BATTERY_BIN,
@@ -1054,7 +1057,27 @@ class CollectionSpotMapViewModelTest {
     @Test
     fun `같은 즐겨찾기 장소 이동 요청도 다시 처리할 수 있도록 sequence를 증가시킨다`() =
         runTest {
-            val request = sampleFavoriteSpotMapMoveRequest()
+            val request = sampleFavoriteSpotMapMoveRequest(requestId = "request-1")
+            val viewModel = createViewModel(
+                repository = FakeCollectionSpotRepository(),
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.showFavoriteSpot(request)
+            advanceUntilIdle()
+            val firstSequence = viewModel.uiState.value.favoriteSpotMoveRequestSequence
+
+            viewModel.showFavoriteSpot(request.copy(requestId = "request-2"))
+            advanceUntilIdle()
+
+            assertEquals(request.targetId, viewModel.uiState.value.selectedSpot?.id)
+            assertEquals(firstSequence + 1, viewModel.uiState.value.favoriteSpotMoveRequestSequence)
+        }
+
+    @Test
+    fun `이미 소비한 즐겨찾기 장소 이동 요청은 다시 처리하지 않는다`() =
+        runTest {
+            val request = sampleFavoriteSpotMapMoveRequest(requestId = "request-1")
             val viewModel = createViewModel(
                 repository = FakeCollectionSpotRepository(),
                 currentLocationResult = CurrentLocationResult.NotFound,
@@ -1067,8 +1090,36 @@ class CollectionSpotMapViewModelTest {
             viewModel.showFavoriteSpot(request)
             advanceUntilIdle()
 
-            assertEquals(request.targetId, viewModel.uiState.value.selectedSpot?.id)
-            assertEquals(firstSequence + 1, viewModel.uiState.value.favoriteSpotMoveRequestSequence)
+            assertEquals(firstSequence, viewModel.uiState.value.favoriteSpotMoveRequestSequence)
+        }
+
+    @Test
+    fun `즐겨찾기 장소 주변 목록 조회 중 키워드 검색을 시작하면 로딩 상태를 정리한다`() =
+        runTest {
+            val request = sampleFavoriteSpotMapMoveRequest()
+            val locationSearchResult = CompletableDeferred<List<CollectionSpot>>()
+            val keywordSpot = sampleSpot("keyword", CollectionSpotType.OTHER)
+            val repository =
+                FakeCollectionSpotRepository(
+                    keywordSpots = listOf(keywordSpot),
+                    locationSearchResultProvider = { locationSearchResult.await() },
+                )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.showFavoriteSpot(request)
+            advanceUntilIdle()
+            assertEquals(true, viewModel.uiState.value.isFavoriteSpotNearbyLoading)
+
+            viewModel.onSearchKeywordChanged("문래동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            assertEquals(false, viewModel.uiState.value.isFavoriteSpotNearbyLoading)
+            assertEquals(listOf(keywordSpot), viewModel.uiState.value.spots)
+            assertEquals(null, viewModel.uiState.value.selectedSpot)
         }
 
     private fun createViewModel(
@@ -1152,8 +1203,11 @@ class CollectionSpotMapViewModelTest {
         )
     }
 
-    private fun sampleFavoriteSpotMapMoveRequest(): FavoriteSpotMapMoveRequest {
+    private fun sampleFavoriteSpotMapMoveRequest(
+        requestId: String = "request-1",
+    ): FavoriteSpotMapMoveRequest {
         return FavoriteSpotMapMoveRequest(
+            requestId = requestId,
             targetId = "favorite-spot",
             name = "폐건전지 수거함",
             type = CollectionSpotType.BATTERY_BIN,


### PR DESCRIPTION
## 작업 내용

Related #113

Favorites 탭의 `장소` 탭에서 즐겨찾기한 수거 장소 카드를 클릭했을 때, 지도 탭으로 이동해 해당 장소를 바로 확인할 수 있도록 연결했습니다.

| Favorites 장소 탭 | 즐겨찾기 장소 지도 이동 |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/eeed6698-4eb3-4c18-a7b2-1e780028013e" width="280" /> | <img src="https://github.com/user-attachments/assets/c4167d9c-98a6-40f2-91ae-3957e70e8db0" width="280" /> |
| 즐겨찾기한 수거 장소 목록 표시 | 카드 클릭 시 지도 탭 이동, 선택 장소 BottomSheet 표시, 주변 목록 준비 로딩 표시 |

## 주요 변경 사항

- Favorites `장소` 탭 카드 클릭 이벤트 연결
- 즐겨찾기 장소 클릭 시 지도 탭으로 이동하도록 navigation 연결
- 저장된 스냅샷 좌표를 사용해 지도 카메라 이동
- 선택한 즐겨찾기 장소를 `selectedSpot`으로 반영해 상세 BottomSheet 표시
- 즐겨찾기 장소 기준 주변 수거 장소 목록을 백그라운드로 조회
- 주변 목록 조회 중 `주변 목록 준비 중` 로딩 표시 추가
- 주변 목록 조회 실패 시에도 선택한 즐겨찾기 장소 상세가 유지되도록 처리
- 같은 즐겨찾기 장소를 다시 클릭해도 이동 요청이 다시 처리되도록 sequence 상태 추가
- 검색 결과 첫 번째 마커 자동 이동이 즐겨찾기 장소 이동을 덮지 않도록 처리

## 유지한 정책

- 좌표는 지도 이동용 내부 데이터로만 사용하고 UI에 직접 노출하지 않았습니다.
- 수거 장소 즐겨찾기 저장 구조와 `favorites` 테이블 구조는 변경하지 않았습니다.
- `/getSpot` 원격 검색 로직은 변경하지 않았습니다.
- 기존 키워드 검색, 현재 위치 검색, 필터칩, 마커 선택, BottomSheet 동작은 유지했습니다.

## 리뷰 참고 사항

아래 항목은 이번 PR 범위가 아니라 후속 이슈에서 별도로 진행할 예정입니다.  
이번 리뷰에서는 해당 항목은 제외하고 봐주시면 감사하겠습니다.

- 지도 검색 결과가 여러 지역에 퍼져 있을 때 bounds 기준으로 카메라 줌 조정
- `현 지도에서 검색` 버튼 및 지도 기준 검색 UX 개선
- BottomSheet / NavigationBar 노출 정책 정리
- 지도 검색 버튼 문구 정리
- Favorites + snapshot 결합 로직 Repository 계층 이동 리팩터링
- 지도 장소 주소 기반 지역별 배출 가이드 연결

## 테스트

- [x] Favorites 장소 탭 카드 클릭 시 지도 탭으로 이동 확인
- [x] 저장된 좌표 기준으로 지도 카메라 이동 확인
- [x] 선택한 장소 상세 BottomSheet 표시 확인
- [x] 주변 목록 준비 중 로딩 표시 확인
- [x] 목록으로 전환 시 주변 수거 장소 목록 표시 확인
- [x] 같은 즐겨찾기 장소를 다시 클릭해도 이동 동작 확인
- [x] 다른 마커 선택 후 즐겨찾기 장소 클릭 시 선택 장소가 갱신되는지 확인
- [x] 좌표가 UI에 직접 노출되지 않는지 확인

## 실행한 검증

```bash
./gradlew.bat :presentation:testDebugUnitTest :presentation:compileDebugKotlin :app:assembleDebug
```
결과: 성공