### PR TITLE
[Refactor] 품목 상태 UI 슬롯 구조 정리

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailRoute.kt
@@ -1,14 +1,11 @@
 package com.team.yeogibeoryeo.presentation.search
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -17,13 +14,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.favorites.components.FavoriteSnackbar
+import com.team.yeogibeoryeo.presentation.search.components.ItemSearchStatusDescription
+import com.team.yeogibeoryeo.presentation.search.components.ItemSearchStatusContent
+import com.team.yeogibeoryeo.presentation.search.components.ItemSearchStatusTitle
 
 @Composable
 fun ItemGuideDetailRoute(
@@ -40,7 +41,8 @@ fun ItemGuideDetailRoute(
         viewModel.loadGuide(guideId)
     }
 
-    val favoriteMessage = (uiState as? ItemGuideDetailUiState.Success)?.favoriteMessage
+    val favoriteMessageResId = (uiState as? ItemGuideDetailUiState.Success)?.favoriteMessageResId
+    val favoriteMessage = favoriteMessageResId?.let { stringResource(it) }
     LaunchedEffect(favoriteMessage) {
         val message = favoriteMessage ?: return@LaunchedEffect
         snackbarHostState.showSnackbar(message)
@@ -80,28 +82,24 @@ fun ItemGuideDetailRoute(
             }
 
             is ItemGuideDetailUiState.Error -> {
-                Column(
+                ItemSearchStatusContent(
+                    title = {
+                        ItemSearchStatusTitle(
+                            text = stringResource(R.string.item_guide_detail_not_found_title),
+                        )
+                    },
+                    description = {
+                        ItemSearchStatusDescription(text = stringResource(state.messageResId))
+                    },
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(innerPadding)
-                        .padding(24.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Text(
-                        text = "품목 가이드를 찾을 수 없습니다",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                    Text(
-                        text = state.message,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Button(onClick = onBackClick) {
-                        Text("돌아가기")
-                    }
-                }
+                        .padding(innerPadding),
+                    action = {
+                        Button(onClick = onBackClick) {
+                            Text(text = stringResource(R.string.back_action))
+                        }
+                    },
+                )
             }
         }
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModel.kt
@@ -1,5 +1,6 @@
 package com.team.yeogibeoryeo.presentation.search
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.team.yeogibeoryeo.domain.favorite.model.Favorite
@@ -8,6 +9,7 @@ import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoriteUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.ToggleFavoriteUseCase
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalItemGuideUseCase
+import com.team.yeogibeoryeo.presentation.R
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
@@ -45,12 +47,18 @@ constructor(
                         _uiState.value = ItemGuideDetailUiState.Success(guide = guide)
                         observeFavorite(guide)
                     } else {
-                        _uiState.value = ItemGuideDetailUiState.Error("다시 검색해서 품목을 선택해주세요.")
+                        _uiState.value =
+                            ItemGuideDetailUiState.Error(
+                                R.string.item_guide_detail_select_again_message,
+                            )
                     }
                 } catch (exception: CancellationException) {
                     throw exception
                 } catch (exception: Throwable) {
-                    _uiState.value = ItemGuideDetailUiState.Error("품목 정보를 불러오는 중 오류가 발생했습니다.")
+                    _uiState.value =
+                        ItemGuideDetailUiState.Error(
+                            R.string.item_guide_detail_load_failed_message,
+                        )
                 }
             }
     }
@@ -71,11 +79,11 @@ constructor(
             _uiState.update { state ->
                 if (state is ItemGuideDetailUiState.Success && state.guide.id == guide.id) {
                     state.copy(
-                        favoriteMessage =
+                        favoriteMessageResId =
                             if (isFavorite) {
-                                "즐겨찾기에 추가되었습니다"
+                                R.string.item_guide_detail_favorite_added_message
                             } else {
-                                "즐겨찾기에서 제외되었습니다"
+                                R.string.item_guide_detail_favorite_removed_message
                             },
                     )
                 } else {
@@ -88,7 +96,7 @@ constructor(
     fun clearFavoriteMessage() {
         _uiState.update { state ->
             if (state is ItemGuideDetailUiState.Success) {
-                state.copy(favoriteMessage = null)
+                state.copy(favoriteMessageResId = null)
             } else {
                 state
             }
@@ -118,10 +126,10 @@ sealed interface ItemGuideDetailUiState {
     data class Success(
         val guide: DisposalItemGuide,
         val isFavorite: Boolean = false,
-        val favoriteMessage: String? = null,
+        @param:StringRes val favoriteMessageResId: Int? = null,
     ) : ItemGuideDetailUiState
 
     data class Error(
-        val message: String,
+        @param:StringRes val messageResId: Int,
     ) : ItemGuideDetailUiState
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -109,19 +109,19 @@ fun ItemSearchScreen(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
-            .padding(horizontal = 24.dp)
-            .padding(top = 24.dp),
-        verticalArrangement = Arrangement.spacedBy(24.dp),
+            .padding(horizontal = ItemSearchScreenHorizontalPadding)
+            .padding(top = ItemSearchScreenTopPadding),
+        verticalArrangement = Arrangement.spacedBy(ItemSearchScreenContentSpacing),
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(ItemSearchScreenHeaderSpacing)) {
             Text(
-                text = "여기 버려",
+                text = stringResource(R.string.item_search_title),
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface,
             )
             Text(
-                text = "품목 검색, 수거 장소, 지역별 배출 정보를 한 곳에서 확인하세요.",
+                text = stringResource(R.string.item_search_description),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -140,7 +140,7 @@ fun ItemSearchScreen(
         // 검색 결과 또는 제안 섹션
         Column(
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(ItemSearchScreenSectionSpacing),
         ) {
             when {
                 uiState.isLoading -> {
@@ -169,15 +169,15 @@ fun ItemSearchScreen(
                     LazyColumn(
                         state = categoryListState,
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(bottom = 24.dp),
-                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                        contentPadding = PaddingValues(bottom = ItemSearchScreenListBottomPadding),
+                        verticalArrangement = Arrangement.spacedBy(ItemSearchScreenSectionSpacing),
                     ) {
                         item {
                             Text(
                                 text = stringResource(R.string.quick_categories),
                                 style = MaterialTheme.typography.titleMedium.copy(
                                     fontWeight = FontWeight.Bold,
-                                    fontSize = 18.sp,
+                                    fontSize = ItemSearchScreenSectionTitleFontSize,
                                     color = MaterialTheme.colorScheme.onSurface
                                 ),
                             )
@@ -203,14 +203,14 @@ fun ItemSearchScreen(
                         ),
                         style = MaterialTheme.typography.titleMedium.copy(
                             fontWeight = FontWeight.Bold,
-                            fontSize = 16.sp,
+                            fontSize = ItemSearchScreenResultCountFontSize,
                             color = MaterialTheme.colorScheme.onSurface
                         ),
                     )
                     LazyColumn(
                         state = searchResultListState,
-                        contentPadding = PaddingValues(bottom = 24.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                        contentPadding = PaddingValues(bottom = ItemSearchScreenListBottomPadding),
+                        verticalArrangement = Arrangement.spacedBy(ItemSearchScreenResultItemSpacing),
                     ) {
                         items(uiState.guides, key = { it.id }) { guide ->
                             DisposalItemCard(
@@ -225,3 +225,13 @@ fun ItemSearchScreen(
         }
     }
 }
+
+private val ItemSearchScreenHorizontalPadding = 24.dp
+private val ItemSearchScreenTopPadding = 24.dp
+private val ItemSearchScreenContentSpacing = 24.dp
+private val ItemSearchScreenHeaderSpacing = 8.dp
+private val ItemSearchScreenSectionSpacing = 16.dp
+private val ItemSearchScreenResultItemSpacing = 12.dp
+private val ItemSearchScreenListBottomPadding = 24.dp
+private val ItemSearchScreenSectionTitleFontSize = 18.sp
+private val ItemSearchScreenResultCountFontSize = 16.sp

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/EmptySearchResult.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/EmptySearchResult.kt
@@ -1,16 +1,7 @@
 package com.team.yeogibeoryeo.presentation.search.components
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import com.team.yeogibeoryeo.presentation.R
 
 @Composable
 fun EmptySearchResult(
@@ -18,22 +9,13 @@ fun EmptySearchResult(
     description: String,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .padding(vertical = 28.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleMedium,
-        )
-        Text(
-            text = description,
-            style = MaterialTheme.typography.bodyMedium,
-        )
-    }
+    ItemSearchStatusContent(
+        title = {
+            ItemSearchStatusTitle(text = title)
+        },
+        description = {
+            ItemSearchStatusDescription(text = description)
+        },
+        modifier = modifier,
+    )
 }
-

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchStatusContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchStatusContent.kt
@@ -1,0 +1,130 @@
+package com.team.yeogibeoryeo.presentation.search.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.common.design.theme.YeogiBeoryeoTheme
+import com.team.yeogibeoryeo.presentation.R
+
+@Composable
+fun ItemSearchStatusContent(
+    title: @Composable ColumnScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    description: (@Composable ColumnScope.() -> Unit)? = null,
+    contentPadding: PaddingValues =
+        PaddingValues(
+            horizontal = ItemSearchStatusHorizontalPadding,
+            vertical = ItemSearchStatusVerticalPadding,
+        ),
+    action: (@Composable ColumnScope.() -> Unit)? = null,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(contentPadding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(
+            space = ItemSearchStatusContentSpacing,
+            alignment = Alignment.CenterVertically,
+        ),
+    ) {
+        title()
+
+        description?.invoke(this)
+
+        action?.invoke(this)
+    }
+}
+
+@Composable
+fun ItemSearchStatusTitle(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurface,
+        textAlign = TextAlign.Center,
+    )
+}
+
+@Composable
+fun ItemSearchStatusDescription(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ItemSearchStatusContentEmptyPreview() {
+    YeogiBeoryeoTheme {
+        Surface {
+            ItemSearchStatusContent(
+                title = {
+                    ItemSearchStatusTitle(text = stringResource(R.string.no_search_results_title))
+                },
+                description = {
+                    ItemSearchStatusDescription(
+                        text = stringResource(R.string.no_search_results_description),
+                    )
+                },
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ItemSearchStatusContentActionPreview() {
+    YeogiBeoryeoTheme {
+        Surface {
+            ItemSearchStatusContent(
+                title = {
+                    ItemSearchStatusTitle(
+                        text = stringResource(R.string.item_guide_detail_not_found_title),
+                    )
+                },
+                description = {
+                    ItemSearchStatusDescription(
+                        text = stringResource(R.string.item_guide_detail_select_again_message),
+                    )
+                },
+                action = {
+                    Button(onClick = {}) {
+                        Text(text = stringResource(R.string.back_action))
+                    }
+                },
+            )
+        }
+    }
+}
+
+private val ItemSearchStatusHorizontalPadding = 24.dp
+private val ItemSearchStatusVerticalPadding = 28.dp
+private val ItemSearchStatusContentSpacing = 8.dp

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
     <string name="item_search_query_label">무엇을 버리시나요?</string>
+    <string name="item_search_title">여기 버려</string>
+    <string name="item_search_description">품목 검색, 수거 장소, 지역별 배출 정보를 한 곳에서 확인하세요.</string>
     <string name="item_search_greeting">어서오세요!</string>
     <string name="item_search_prompt">무엇을 도와드릴까요?</string>
     <string name="search_action">검색</string>
@@ -18,5 +20,10 @@
     <string name="tip_title">재활용·처리 정보</string>
     <string name="local_disposal_notice_title">지역별 배출 기준 안내</string>
     <string name="local_disposal_notice">배출방법은 지역별로 차이가 있을 수 있으니, 해당 지방자치단체에서 정하는 방법이 있는 경우에는 해당 방법에 따라 배출하시기 바랍니다.</string>
+    <string name="item_guide_detail_not_found_title">품목 가이드를 찾을 수 없습니다</string>
+    <string name="item_guide_detail_select_again_message">다시 검색해서 품목을 선택해주세요.</string>
+    <string name="item_guide_detail_load_failed_message">품목 정보를 불러오는 중 오류가 발생했습니다.</string>
+    <string name="item_guide_detail_favorite_added_message">즐겨찾기에 추가되었습니다</string>
+    <string name="item_guide_detail_favorite_removed_message">즐겨찾기에서 제외되었습니다</string>
     <string name="back_action">뒤로가기</string>
 </resources>

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModelTest.kt
@@ -10,6 +10,7 @@ import com.team.yeogibeoryeo.domain.item.model.DisposalInstruction
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.domain.item.repository.DisposalItemGuideRepository
 import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalItemGuideUseCase
+import com.team.yeogibeoryeo.presentation.R
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -74,7 +75,7 @@ class ItemGuideDetailViewModelTest {
 
             val state = viewModel.uiState.value as ItemGuideDetailUiState.Success
             assertTrue(state.isFavorite)
-            assertEquals("즐겨찾기에 추가되었습니다", state.favoriteMessage)
+            assertEquals(R.string.item_guide_detail_favorite_added_message, state.favoriteMessageResId)
         }
 
     @Test
@@ -105,7 +106,7 @@ class ItemGuideDetailViewModelTest {
 
             val state = viewModel.uiState.value as ItemGuideDetailUiState.Success
             assertFalse(state.isFavorite)
-            assertEquals("즐겨찾기에서 제외되었습니다", state.favoriteMessage)
+            assertEquals(R.string.item_guide_detail_favorite_removed_message, state.favoriteMessageResId)
         }
 
     @Test


### PR DESCRIPTION
## 작업 내용

- 품목 검색/품목 상세 empty/error 상태 UI를 `ItemSearchStatusContent`로 분리했습니다.
- 상태 콘텐츠의 `title`, `description`, `action` 영역을 slot으로 구성했습니다.
- 기본 상태 텍스트 스타일을 `ItemSearchStatusTitle`, `ItemSearchStatusDescription`으로 분리했습니다.
- 사용자에게 노출되는 품목 검색/상세 문구를 string resource로 이동했습니다.
- 품목 상세 ViewModel의 error/snackbar 메시지 상태를 string resource 기반으로 정리했습니다.
- 품목 화면 내부에서만 사용하는 레이아웃/텍스트 크기 기준값은 private 값으로 모아두었고, 공통 token 설계는 별도 이슈에서 다룹니다.

## 변경 이유

품목 검색 화면과 품목 상세 화면의 상태 UI가 비슷한 구조를 각각 구현하고 있어, 먼저 품목 기능 내부에서 반복되는 작은 단위부터 정리했습니다.

## 확인 사항

- 이번 PR에서는 품목 empty/error 상태 UI만 다룹니다.
- 품목 카드, 섹션, 카테고리 컴포넌트의 slot 구조 정리는 후속 이슈에서 다룹니다.
- 여러 화면을 포괄하는 공통 상태 컴포넌트는 이번 PR에서 확정하지 않습니다.

## 테스트

- `./gradlew.bat :presentation:compileDebugKotlin`
- `./gradlew.bat :presentation:testDebugUnitTest`
- `git diff --check`

## 관련 이슈

Related #121
