### PR TITLE
feat: 지도 기준 검색 UX 개선

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -75,7 +75,7 @@ fun YeogiBeoryeoNavHost(
                 }
 
             AnimatedVisibility(
-                visible = !isItemDetailScreen || isBottomBarVisible,
+                visible = isBottomBarVisible,
                 enter = enterTransition,
                 exit = exitTransition,
             ) {
@@ -92,7 +92,10 @@ fun YeogiBeoryeoNavHost(
                                 label = "지도",
                                 iconResId = AppR.drawable.ic_navigation_map,
                                 selected = currentDestination?.hasRoute<MapRoute>() == true,
-                                onClick = { navController.navigateBottomTab(MapRoute()) },
+                                onClick = {
+                                    isBottomBarVisible = true
+                                    navController.navigateBottomTab(MapRoute())
+                                },
                             ),
                             BottomNavigationItem(
                                 label = "안내",
@@ -120,6 +123,11 @@ fun YeogiBeoryeoNavHost(
                 val route = backStackEntry.toRoute<MapRoute>()
                 CollectionSpotMapScreen(
                     favoriteSpotMoveRequest = route.toFavoriteSpotMapMoveRequest(),
+                    onBottomBarVisibilityChanged = { isVisible ->
+                        if (currentDestination?.hasRoute<MapRoute>() == true) {
+                            isBottomBarVisible = isVisible
+                        }
+                    },
                 )
             }
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -77,6 +77,7 @@ fun CollectionSpotMapScreen(
     val requestCurrentLocationSearch = rememberCurrentLocationSearchRequester(
         onGranted = {
             hasGrantedLocationPermissionInSession = true
+            previousFineLocationPermission = true
             locationTrackingMode = LocationTrackingMode.NoFollow
             viewModel.searchByCurrentLocation()
         },

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -25,8 +25,10 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.naver.maps.map.compose.LocationTrackingMode
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.presentation.map.components.CollectionSpotNaverMap
-import com.team.yeogibeoryeo.presentation.map.components.CurrentLocationSearchLoadingOverlay
+import com.team.yeogibeoryeo.presentation.map.components.MapSearchLoadingOverlay
+import com.team.yeogibeoryeo.presentation.map.components.MapCenterSearchButton
 import com.team.yeogibeoryeo.presentation.map.components.MapOverlayControls
 import com.team.yeogibeoryeo.presentation.map.components.MapResultBottomSheetPeekHeight
 import com.team.yeogibeoryeo.presentation.map.components.MapSheetLevel
@@ -42,6 +44,7 @@ import com.team.yeogibeoryeo.presentation.map.model.FavoriteSpotMapMoveRequest
 @Composable
 fun CollectionSpotMapScreen(
     favoriteSpotMoveRequest: FavoriteSpotMapMoveRequest? = null,
+    onBottomBarVisibilityChanged: (Boolean) -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: CollectionSpotMapViewModel = hiltViewModel(),
 ) {
@@ -50,6 +53,9 @@ fun CollectionSpotMapScreen(
     val hasFineLocationPermission = rememberFineLocationPermissionGranted()
     var hasGrantedLocationPermissionInSession by rememberSaveable {
         mutableStateOf(false)
+    }
+    var previousFineLocationPermission by rememberSaveable {
+        mutableStateOf(hasFineLocationPermission)
     }
     val isLocationPermissionGranted =
         hasFineLocationPermission || hasGrantedLocationPermissionInSession
@@ -60,7 +66,12 @@ fun CollectionSpotMapScreen(
     LaunchedEffect(hasFineLocationPermission) {
         if (!hasFineLocationPermission) {
             hasGrantedLocationPermissionInSession = false
+        } else if (!previousFineLocationPermission) {
+            hasGrantedLocationPermissionInSession = true
+            locationTrackingMode = LocationTrackingMode.NoFollow
+            viewModel.searchByCurrentLocation()
         }
+        previousFineLocationPermission = hasFineLocationPermission
     }
 
     val requestCurrentLocationSearch = rememberCurrentLocationSearchRequester(
@@ -71,14 +82,6 @@ fun CollectionSpotMapScreen(
         },
         onDenied = viewModel::onLocationPermissionDenied,
     )
-    val requestMyLocationTracking = rememberCurrentLocationSearchRequester(
-        onGranted = {
-            hasGrantedLocationPermissionInSession = true
-            locationTrackingMode = LocationTrackingMode.Follow
-        },
-        onDenied = viewModel::onLocationPermissionDenied,
-    )
-
     LaunchedEffect(favoriteSpotMoveRequest) {
         val request = favoriteSpotMoveRequest
         if (request == null) {
@@ -101,15 +104,14 @@ fun CollectionSpotMapScreen(
         onCurrentLocationClick = {
             requestCurrentLocationSearch()
         },
-        onMyLocationPermissionRequest = {
-            requestMyLocationTracking()
-        },
+        onMapCenterSearchClick = viewModel::searchByMapCenter,
         onLocationNoticeActionClick = { action ->
             context.startActivity(action.toIntent(context.packageName))
         },
         onTypeClick = viewModel::onSpotTypeClick,
         onSpotClick = viewModel::onSpotClick,
         onSpotFavoriteClick = viewModel::onSpotFavoriteClick,
+        onBottomBarVisibilityChanged = onBottomBarVisibilityChanged,
         modifier = modifier,
     )
 }
@@ -123,19 +125,26 @@ private fun CollectionSpotMapContent(
     onKeywordChanged: (String) -> Unit,
     onSearchClick: () -> Unit,
     onCurrentLocationClick: () -> Unit,
-    onMyLocationPermissionRequest: () -> Unit,
+    onMapCenterSearchClick: (Coordinate) -> Unit,
     onLocationNoticeActionClick: (MapLocationNoticeAction) -> Unit,
     onTypeClick: (CollectionSpotType) -> Unit,
     onSpotClick: (CollectionSpot) -> Unit,
     onSpotFavoriteClick: (CollectionSpot) -> Unit,
+    onBottomBarVisibilityChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val isCurrentLocationSearching = uiState.isLoading &&
-        uiState.searchMode == MapSearchMode.CURRENT_LOCATION
-    val shouldShowBottomSheet = uiState.shouldShowBottomSheet && !isCurrentLocationSearching
+    val isSpotSearchLoading = uiState.isLoading &&
+        uiState.searchMode in setOf(
+            MapSearchMode.KEYWORD,
+            MapSearchMode.CURRENT_LOCATION,
+            MapSearchMode.MAP_CENTER,
+        )
+    val shouldShowBottomSheet = uiState.shouldShowBottomSheet && !isSpotSearchLoading
     var mapUiMode by remember { mutableStateOf(MapUiMode.Browsing) }
     var sheetLevel by remember { mutableStateOf(MapSheetLevel.Hidden) }
     var sheetRevealRequest by remember { mutableStateOf(0) }
+    var mapCenterCoordinate by remember { mutableStateOf<Coordinate?>(null) }
+    var shouldShowMapCenterSearchButton by remember { mutableStateOf(false) }
     val selectedSpot = uiState.selectedSpot
     val selectedSpotMoveRequestSequence = uiState.favoriteSpotMoveRequestSequence
     val hasNoticeOrError = uiState.locationNotice != null ||
@@ -162,7 +171,7 @@ private fun CollectionSpotMapContent(
         uiState.locationNoticeMessage,
     ) {
         when {
-            isCurrentLocationSearching -> {
+            isSpotSearchLoading -> {
                 mapUiMode = MapUiMode.Browsing
                 sheetLevel = MapSheetLevel.Hidden
             }
@@ -203,6 +212,15 @@ private fun CollectionSpotMapContent(
         }
     }
 
+    LaunchedEffect(shouldShowBottomSheet, sheetLevel, mapUiMode) {
+        val shouldHideBottomBar =
+            shouldShowBottomSheet &&
+                sheetLevel != MapSheetLevel.Hidden &&
+                mapUiMode != MapUiMode.Browsing
+
+        onBottomBarVisibilityChanged(!shouldHideBottomBar)
+    }
+
     BoxWithConstraints(
         modifier = modifier.fillMaxSize(),
     ) {
@@ -226,6 +244,16 @@ private fun CollectionSpotMapContent(
                 } else {
                     mapUiMode = MapUiMode.Browsing
                     sheetLevel = MapSheetLevel.Hidden
+                    onBottomBarVisibilityChanged(true)
+                }
+            },
+            onCameraCenterChanged = { coordinate ->
+                mapCenterCoordinate = coordinate
+            },
+            onUserCameraMove = {
+                onLocationTrackingModeChange(LocationTrackingMode.NoFollow)
+                if (!uiState.isLoading && mapUiMode != MapUiMode.SpotDetail) {
+                    shouldShowMapCenterSearchButton = true
                 }
             },
             modifier = Modifier
@@ -235,25 +263,34 @@ private fun CollectionSpotMapContent(
         if (mapUiMode != MapUiMode.SpotDetail) {
             MapOverlayControls(
                 keyword = uiState.searchKeyword,
-                selectedTypes = uiState.selectedTypes,
                 onKeywordChanged = onKeywordChanged,
                 onSearchClick = {
                     onLocationTrackingModeChange(LocationTrackingMode.NoFollow)
+                    shouldShowMapCenterSearchButton = false
                     mapUiMode = MapUiMode.ResultList
                     sheetLevel = MapSheetLevel.Peek
                     onSearchClick()
                 },
-                onTypeClick = { type ->
-                    mapUiMode = MapUiMode.ResultList
-                    sheetLevel = MapSheetLevel.Peek
-                    onTypeClick(type)
-                },
-                onCurrentLocationClick = {
+            )
+        }
+
+        if (
+            shouldShowMapCenterSearchButton &&
+            mapUiMode != MapUiMode.SpotDetail &&
+            !uiState.isLoading
+        ) {
+            MapCenterSearchButton(
+                onClick = {
+                    val coordinate = mapCenterCoordinate ?: return@MapCenterSearchButton
+                    shouldShowMapCenterSearchButton = false
                     onLocationTrackingModeChange(LocationTrackingMode.NoFollow)
                     mapUiMode = MapUiMode.ResultList
                     sheetLevel = MapSheetLevel.Peek
-                    onCurrentLocationClick()
+                    onMapCenterSearchClick(coordinate)
                 },
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = MapCenterSearchButtonTopPadding),
             )
         }
 
@@ -262,9 +299,13 @@ private fun CollectionSpotMapContent(
                 isTracking = mapLocationTrackingMode == LocationTrackingMode.Follow,
                 onClick = {
                     if (isLocationPermissionGranted) {
-                        onLocationTrackingModeChange(LocationTrackingMode.Follow)
+                        onLocationTrackingModeChange(LocationTrackingMode.NoFollow)
+                        shouldShowMapCenterSearchButton = false
+                        mapUiMode = MapUiMode.ResultList
+                        sheetLevel = MapSheetLevel.Peek
+                        onCurrentLocationClick()
                     } else {
-                        onMyLocationPermissionRequest()
+                        onCurrentLocationClick()
                     }
                 },
                 modifier = Modifier
@@ -279,8 +320,10 @@ private fun CollectionSpotMapContent(
             )
         }
 
-        if (isCurrentLocationSearching) {
-            CurrentLocationSearchLoadingOverlay()
+        if (isSpotSearchLoading) {
+            MapSearchLoadingOverlay(
+                description = uiState.searchMode.toLoadingDescription(),
+            )
         }
 
         if (shouldShowBottomSheet) {
@@ -378,19 +421,29 @@ private fun CollectionSpotMapContentPreview() {
                 onKeywordChanged = {},
                 onSearchClick = {},
                 onCurrentLocationClick = {},
-                onMyLocationPermissionRequest = {},
+                onMapCenterSearchClick = {},
                 onLocationNoticeActionClick = {},
                 onTypeClick = {},
                 onSpotClick = {},
                 onSpotFavoriteClick = {},
+                onBottomBarVisibilityChanged = {},
             )
         }
     }
 
 }
 
+private fun MapSearchMode.toLoadingDescription(): String {
+    return when (this) {
+        MapSearchMode.KEYWORD -> "입력한 동네 주변을 찾고 있어요"
+        MapSearchMode.CURRENT_LOCATION -> "현재 위치 주변을 찾고 있어요"
+        MapSearchMode.MAP_CENTER -> "현 지도 주변을 찾고 있어요"
+    }
+}
+
 private val MyLocationButtonHorizontalPadding = 16.dp
 private val MyLocationButtonBottomPadding = 16.dp
+private val MapCenterSearchButtonTopPadding = 112.dp
 
 private fun MapLocationNoticeAction.toIntent(packageName: String): Intent {
     return when (this) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -162,10 +162,54 @@ class CollectionSpotMapViewModel @Inject constructor(
         currentLocationRefreshJob?.cancel()
         spotSearchJob?.cancel()
         spotSearchJob = viewModelScope.launch {
+            val cachedEntry = getFreshRecentCurrentLocationSpotsUseCase()
+
+            if (cachedEntry != null) {
+                showCachedCurrentLocationSpots(cachedEntry.spots)
+                refreshCurrentLocationSilently()
+                return@launch
+            }
+
             searchByCurrentLocationInternal(
                 showLoading = true,
                 preservePreviousResultOnFailure = false,
             )
+        }
+    }
+
+    fun searchByMapCenter(coordinate: Coordinate) {
+        currentLocationRefreshJob?.cancel()
+        spotSearchJob?.cancel()
+        spotSearchJob = viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    isLoading = true,
+                    hasSearched = true,
+                    searchKeyword = "",
+                    errorMessage = null,
+                    locationNotice = null,
+                    locationNoticeMessage = null,
+                    selectedSpot = null,
+                    isFavoriteSpotNearbyLoading = false,
+                    searchMode = MapSearchMode.MAP_CENTER,
+                )
+            }
+
+            runCatching {
+                searchCollectionSpotsByLocationUseCase(
+                    coordinate = coordinate,
+                    radiusMeter = DEFAULT_RADIUS_METER,
+                    types = emptySet(),
+                )
+            }.onSuccess { spots ->
+                updateSpotResult(spots)
+            }.onFailure { throwable ->
+                if (throwable is CancellationException) throw throwable
+
+                updateSpotFailure(
+                    message = MapLocationNotices.SpotSearchFailureMessage,
+                )
+            }
         }
     }
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -57,34 +57,41 @@ class CollectionSpotMapViewModel @Inject constructor(
     fun onSearchKeywordChanged(keyword: String) {
         currentLocationRefreshJob?.cancel()
 
-        val shouldCancelCurrentLocationSearch =
+        val shouldCancelSpotSearch =
             uiState.value.isLoading &&
-                uiState.value.searchMode == MapSearchMode.CURRENT_LOCATION
+                uiState.value.searchMode in setOf(
+                    MapSearchMode.KEYWORD,
+                    MapSearchMode.CURRENT_LOCATION,
+                    MapSearchMode.MAP_CENTER,
+                )
         val shouldCancelFavoriteSpotNearbySearch = uiState.value.isFavoriteSpotNearbyLoading
 
-        if (shouldCancelCurrentLocationSearch || shouldCancelFavoriteSpotNearbySearch) {
+        if (shouldCancelSpotSearch || shouldCancelFavoriteSpotNearbySearch) {
             spotSearchJob?.cancel()
+        }
+        if (shouldCancelSpotSearch) {
+            originalSpots = emptyList()
         }
 
         _uiState.update {
             it.copy(
                 searchKeyword = keyword,
-                spots = if (shouldCancelCurrentLocationSearch) {
+                spots = if (shouldCancelSpotSearch) {
                     emptyList()
                 } else {
                     it.spots
                 },
-                selectedSpot = if (shouldCancelCurrentLocationSearch) {
+                selectedSpot = if (shouldCancelSpotSearch) {
                     null
                 } else {
                     it.selectedSpot
                 },
-                isLoading = if (shouldCancelCurrentLocationSearch) {
+                isLoading = if (shouldCancelSpotSearch) {
                     false
                 } else {
                     it.isLoading
                 },
-                hasSearched = if (shouldCancelCurrentLocationSearch) {
+                hasSearched = if (shouldCancelSpotSearch) {
                     false
                 } else {
                     it.hasSearched
@@ -93,7 +100,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 locationNotice = null,
                 locationNoticeMessage = null,
                 isFavoriteSpotNearbyLoading = false,
-                searchMode = if (shouldCancelCurrentLocationSearch) {
+                searchMode = if (shouldCancelSpotSearch) {
                     MapSearchMode.KEYWORD
                 } else {
                     it.searchMode
@@ -185,7 +192,6 @@ class CollectionSpotMapViewModel @Inject constructor(
                 it.copy(
                     isLoading = true,
                     hasSearched = true,
-                    searchKeyword = "",
                     errorMessage = null,
                     locationNotice = null,
                     locationNoticeMessage = null,
@@ -489,7 +495,6 @@ class CollectionSpotMapViewModel @Inject constructor(
                 it.copy(
                     isLoading = true,
                     hasSearched = true,
-                    searchKeyword = "",
                     errorMessage = null,
                     locationNotice = null,
                     locationNoticeMessage = null,
@@ -572,8 +577,7 @@ class CollectionSpotMapViewModel @Inject constructor(
     private fun canApplyCurrentLocationResult(): Boolean {
         val currentState = uiState.value
 
-        return currentState.searchKeyword.isBlank() &&
-            currentState.searchMode == MapSearchMode.CURRENT_LOCATION
+        return currentState.searchMode == MapSearchMode.CURRENT_LOCATION
     }
 
     private fun observeCollectionSpotFavorites() {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/MapSearchMode.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/MapSearchMode.kt
@@ -3,4 +3,5 @@ package com.team.yeogibeoryeo.presentation.map
 enum class MapSearchMode {
     KEYWORD,
     CURRENT_LOCATION,
+    MAP_CENTER,
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CollectionSpotNaverMap.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CollectionSpotNaverMap.kt
@@ -2,9 +2,16 @@ package com.team.yeogibeoryeo.presentation.map.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.material3.MaterialTheme
 import com.naver.maps.geometry.LatLng
+import com.naver.maps.geometry.LatLngBounds
 import com.naver.maps.map.CameraPosition
 import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
@@ -15,7 +22,9 @@ import com.naver.maps.map.compose.MarkerState
 import com.naver.maps.map.compose.NaverMap
 import com.naver.maps.map.compose.rememberCameraPositionState
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.presentation.map.location.rememberMapLocationSource
+import kotlinx.coroutines.flow.drop
 
 @OptIn(ExperimentalNaverMapApi::class)
 @Composable
@@ -26,6 +35,8 @@ fun CollectionSpotNaverMap(
     locationTrackingMode: LocationTrackingMode,
     onSpotClick: (CollectionSpot) -> Unit,
     onMapClick: () -> Unit,
+    onCameraCenterChanged: (Coordinate) -> Unit,
+    onUserCameraMove: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val defaultMarkerColor = MaterialTheme.colorScheme.primary
@@ -49,23 +60,53 @@ fun CollectionSpotNaverMap(
             DEFAULT_ZOOM,
         )
     }
+    var isProgrammaticCameraMove by remember { mutableStateOf(false) }
+    suspend fun moveCamera(update: CameraUpdate) {
+        isProgrammaticCameraMove = true
+        cameraPositionState.move(update)
+        withFrameNanos { }
+        isProgrammaticCameraMove = false
+    }
+
+    LaunchedEffect(Unit) {
+        snapshotFlow { cameraPositionState.position.target }
+            .drop(1)
+            .collect { target ->
+                onCameraCenterChanged(target.toCoordinate())
+                if (!isProgrammaticCameraMove) {
+                    onUserCameraMove()
+                }
+            }
+    }
 
     LaunchedEffect(spots) {
         if (selectedSpot != null) return@LaunchedEffect
 
-        val firstSpot = spots.firstOrNull { spot -> spot.coordinate != null }
-        val coordinate = firstSpot?.coordinate
+        val coordinates = spots.mapNotNull { spot -> spot.coordinate }
 
-        if (coordinate != null) {
-            cameraPositionState.move(
-                CameraUpdate.scrollAndZoomTo(
-                    LatLng(
-                        coordinate.latitude,
-                        coordinate.longitude,
+        when (coordinates.size) {
+            0 -> Unit
+            1 -> {
+                val coordinate = coordinates.single()
+                moveCamera(
+                    CameraUpdate.scrollAndZoomTo(
+                        LatLng(
+                            coordinate.latitude,
+                            coordinate.longitude,
+                        ),
+                        SEARCH_RESULT_ZOOM,
                     ),
-                    SEARCH_RESULT_ZOOM,
-                ),
-            )
+                )
+            }
+
+            else -> {
+                moveCamera(
+                    CameraUpdate.fitBounds(
+                        coordinates.toLatLngBounds(),
+                        SEARCH_RESULT_BOUNDS_PADDING,
+                    ),
+                )
+            }
         }
     }
 
@@ -73,7 +114,7 @@ fun CollectionSpotNaverMap(
         val coordinate = selectedSpot?.coordinate
 
         if (coordinate != null) {
-            cameraPositionState.move(
+            moveCamera(
                 CameraUpdate.scrollAndZoomTo(
                     LatLng(
                         coordinate.latitude,
@@ -135,6 +176,28 @@ private val DEFAULT_LOCATION = LatLng(
 private const val DEFAULT_ZOOM = 12.0
 private const val SEARCH_RESULT_ZOOM = 15.0
 private const val SELECTED_SPOT_ZOOM = 16.0
+private const val SEARCH_RESULT_BOUNDS_PADDING = 120
 
 private const val DEFAULT_MARKER_Z_INDEX = 0
 private const val SELECTED_MARKER_Z_INDEX = 10
+
+private fun LatLng.toCoordinate(): Coordinate =
+    Coordinate(
+        latitude = latitude,
+        longitude = longitude,
+    )
+
+private fun List<Coordinate>.toLatLngBounds(): LatLngBounds {
+    val builder = LatLngBounds.Builder()
+
+    forEach { coordinate ->
+        builder.include(
+            LatLng(
+                coordinate.latitude,
+                coordinate.longitude,
+            ),
+        )
+    }
+
+    return builder.build()
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CollectionSpotNaverMap.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CollectionSpotNaverMap.kt
@@ -64,15 +64,17 @@ fun CollectionSpotNaverMap(
     suspend fun moveCamera(update: CameraUpdate) {
         isProgrammaticCameraMove = true
         cameraPositionState.move(update)
-        withFrameNanos { }
+        repeat(PROGRAMMATIC_CAMERA_MOVE_GUARD_FRAMES) {
+            withFrameNanos { }
+        }
         isProgrammaticCameraMove = false
     }
 
     LaunchedEffect(Unit) {
-        snapshotFlow { cameraPositionState.position.target }
+        snapshotFlow { cameraPositionState.position.toCameraSnapshot() }
             .drop(1)
-            .collect { target ->
-                onCameraCenterChanged(target.toCoordinate())
+            .collect { cameraSnapshot ->
+                onCameraCenterChanged(cameraSnapshot.toCoordinate())
                 if (!isProgrammaticCameraMove) {
                     onUserCameraMove()
                 }
@@ -177,11 +179,25 @@ private const val DEFAULT_ZOOM = 12.0
 private const val SEARCH_RESULT_ZOOM = 15.0
 private const val SELECTED_SPOT_ZOOM = 16.0
 private const val SEARCH_RESULT_BOUNDS_PADDING = 120
+private const val PROGRAMMATIC_CAMERA_MOVE_GUARD_FRAMES = 3
 
 private const val DEFAULT_MARKER_Z_INDEX = 0
 private const val SELECTED_MARKER_Z_INDEX = 10
 
-private fun LatLng.toCoordinate(): Coordinate =
+private data class CameraSnapshot(
+    val latitude: Double,
+    val longitude: Double,
+    val zoom: Double,
+)
+
+private fun CameraPosition.toCameraSnapshot(): CameraSnapshot =
+    CameraSnapshot(
+        latitude = target.latitude,
+        longitude = target.longitude,
+        zoom = zoom,
+    )
+
+private fun CameraSnapshot.toCoordinate(): Coordinate =
     Coordinate(
         latitude = latitude,
         longitude = longitude,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CurrentLocationSearchLoadingOverlay.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CurrentLocationSearchLoadingOverlay.kt
@@ -18,7 +18,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun CurrentLocationSearchLoadingOverlay(
+fun MapSearchLoadingOverlay(
+    description: String,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -49,7 +50,7 @@ fun CurrentLocationSearchLoadingOverlay(
                     strokeWidth = 4.dp,
                 )
                 Text(
-                    text = "현재 위치 주변을 찾고 있어요",
+                    text = description,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -62,6 +63,8 @@ fun CurrentLocationSearchLoadingOverlay(
 @Composable
 private fun CurrentLocationSearchLoadingOverlayPreview() {
     MaterialTheme {
-        CurrentLocationSearchLoadingOverlay()
+        MapSearchLoadingOverlay(
+            description = "현재 위치 주변을 찾고 있어요",
+        )
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapCenterSearchButton.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapCenterSearchButton.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.common.R as CommonR
 
 @Composable
-fun CurrentLocationButton(
+fun MapCenterSearchButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -22,12 +22,11 @@ fun CurrentLocationButton(
         modifier = modifier,
     ) {
         Icon(
-            painter = painterResource(id = CommonR.drawable.ic_action_current_location),
+            painter = painterResource(id = CommonR.drawable.ic_action_search),
             contentDescription = null,
         )
-
         Text(
-            text = "내 주변 검색",
+            text = "현 지도에서 검색",
             modifier = Modifier.padding(start = 6.dp),
         )
     }
@@ -35,9 +34,9 @@ fun CurrentLocationButton(
 
 @Preview(showBackground = true)
 @Composable
-private fun CurrentLocationButtonPreview() {
+private fun MapCenterSearchButtonPreview() {
     MaterialTheme {
-        CurrentLocationButton(
+        MapCenterSearchButton(
             onClick = {},
             modifier = Modifier.padding(16.dp),
         )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapOverlayControls.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapOverlayControls.kt
@@ -1,35 +1,24 @@
 package com.team.yeogibeoryeo.presentation.map.components
 
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
-import com.team.yeogibeoryeo.presentation.map.mapper.toDisplayName
 
 @Composable
 fun MapOverlayControls(
     keyword: String,
-    selectedTypes: Set<CollectionSpotType>,
     onKeywordChanged: (String) -> Unit,
     onSearchClick: () -> Unit,
-    onTypeClick: (CollectionSpotType) -> Unit,
-    onCurrentLocationClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -39,77 +28,18 @@ fun MapOverlayControls(
             .padding(top = 2.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        MapOverlaySearchArea(
+        MapSearchBar(
             keyword = keyword,
             onKeywordChanged = onKeywordChanged,
             onSearchClick = onSearchClick,
-        )
-
-        MapOverlayQuickControlArea(
-            selectedTypes = selectedTypes,
-            onTypeClick = onTypeClick,
-            onCurrentLocationClick = onCurrentLocationClick,
-        )
-    }
-}
-
-@Composable
-private fun MapOverlaySearchArea(
-    keyword: String,
-    onKeywordChanged: (String) -> Unit,
-    onSearchClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    MapSearchBar(
-        keyword = keyword,
-        onKeywordChanged = onKeywordChanged,
-        onSearchClick = onSearchClick,
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 12.dp),
-    )
-}
-
-@Composable
-private fun MapOverlayQuickControlArea(
-    selectedTypes: Set<CollectionSpotType>,
-    onTypeClick: (CollectionSpotType) -> Unit,
-    onCurrentLocationClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .heightIn(min = 48.dp)
-            .padding(horizontal = 16.dp),
-        contentAlignment = Alignment.CenterEnd,
-    ) {
-        if (selectedTypes.isNotEmpty()) {
-            Row(
-                modifier = Modifier
-                    .align(Alignment.CenterStart)
-                    .fillMaxWidth()
-                    .horizontalScroll(rememberScrollState())
-                    .padding(end = CurrentLocationButtonReservedWidth),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                selectedTypes.forEach { type ->
-                    FilterChip(
-                        selected = true,
-                        onClick = {
-                            onTypeClick(type)
-                        },
-                        label = {
-                            Text(text = type.toDisplayName())
-                        },
-                    )
-                }
-            }
-        }
-
-        CurrentLocationButton(
-            onClick = onCurrentLocationClick,
-            modifier = Modifier.align(Alignment.CenterEnd),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp)
+                .shadow(
+                    elevation = 6.dp,
+                    shape = RoundedCornerShape(12.dp),
+                    clip = false,
+                ),
         )
     }
 }
@@ -121,33 +51,22 @@ private fun MapOverlayControlsPreview() {
         Surface {
             MapOverlayControls(
                 keyword = "",
-                selectedTypes = emptySet(),
                 onKeywordChanged = {},
                 onSearchClick = {},
-                onTypeClick = {},
-                onCurrentLocationClick = {},
             )
         }
     }
 }
 
-private val CurrentLocationButtonReservedWidth = 176.dp
-
 @Preview(showBackground = true)
 @Composable
-private fun MapOverlayControlsSelectedPreview() {
+private fun MapOverlayControlsKeywordPreview() {
     MaterialTheme {
         Surface {
             MapOverlayControls(
                 keyword = "문래동",
-                selectedTypes = setOf(
-                    CollectionSpotType.BATTERY_BIN,
-                    CollectionSpotType.SMALL_E_WASTE_BIN,
-                ),
                 onKeywordChanged = {},
                 onSearchClick = {},
-                onTypeClick = {},
-                onCurrentLocationClick = {},
             )
         }
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MyLocationButton.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MyLocationButton.kt
@@ -33,7 +33,7 @@ fun MyLocationButton(
     ) {
         Icon(
             painter = painterResource(id = CommonR.drawable.ic_action_current_location),
-            contentDescription = "내 위치로 이동",
+            contentDescription = "현 위치 기준 검색",
         )
     }
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -150,6 +150,96 @@ class CollectionSpotMapViewModelTest {
         }
 
     @Test
+    fun `현재 위치 검색은 신선한 캐시가 있으면 캐시를 먼저 표시하고 조용히 갱신한다`() =
+        runTest {
+            val currentLocationResult = CompletableDeferred<CurrentLocationResult>()
+            val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
+            val refreshedSpot = sampleSpot("refresh", CollectionSpotType.RECYCLING_CENTER)
+            val repository = FakeCollectionSpotRepository(
+                locationSpots = listOf(refreshedSpot),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationProvider = FakeCurrentLocationProvider {
+                    currentLocationResult.await()
+                },
+                recentCurrentLocationSpotCacheRepository =
+                    FakeRecentCurrentLocationSpotCacheRepository(
+                        entry = freshCacheEntry(listOf(cachedSpot)),
+                    ),
+            )
+
+            viewModel.searchByCurrentLocation()
+            advanceUntilIdle()
+
+            assertEquals(listOf(cachedSpot), viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.CURRENT_LOCATION, viewModel.uiState.value.searchMode)
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertEquals(0, repository.locationSearchCallCount)
+
+            currentLocationResult.complete(
+                CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(listOf(refreshedSpot), viewModel.uiState.value.spots)
+            assertEquals(1, repository.locationSearchCallCount)
+        }
+
+    @Test
+    fun `지도 중심 검색은 전달된 카메라 중심 좌표로 수거 장소를 검색한다`() =
+        runTest {
+            val mapCenterCoordinate = Coordinate(latitude = 37.5701, longitude = 127.0012)
+            val expectedSpots = listOf(sampleSpot("map-center", CollectionSpotType.RECYCLING_CENTER))
+            val repository = FakeCollectionSpotRepository(
+                locationSpots = expectedSpots,
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.onSearchKeywordChanged("문래동")
+            viewModel.searchByMapCenter(mapCenterCoordinate)
+            advanceUntilIdle()
+
+            assertEquals(mapCenterCoordinate, repository.lastLocationCoordinate)
+            assertEquals(500, repository.lastRadiusMeter)
+            assertEquals(expectedSpots, viewModel.uiState.value.spots)
+            assertEquals("", viewModel.uiState.value.searchKeyword)
+            assertEquals(MapSearchMode.MAP_CENTER, viewModel.uiState.value.searchMode)
+            assertNull(viewModel.uiState.value.selectedSpot)
+            assertFalse(viewModel.uiState.value.isLoading)
+        }
+
+    @Test
+    fun `현재 위치 기준 검색과 지도 중심 기준 검색은 서로 다른 좌표를 사용한다`() =
+        runTest {
+            val currentCoordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881)
+            val mapCenterCoordinate = Coordinate(latitude = 37.5701, longitude = 127.0012)
+            val repository = FakeCollectionSpotRepository(
+                locationSpots = listOf(sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(currentCoordinate),
+            )
+
+            viewModel.searchByCurrentLocation()
+            advanceUntilIdle()
+            assertEquals(currentCoordinate, repository.lastLocationCoordinate)
+            assertEquals(MapSearchMode.CURRENT_LOCATION, viewModel.uiState.value.searchMode)
+
+            viewModel.searchByMapCenter(mapCenterCoordinate)
+            advanceUntilIdle()
+
+            assertEquals(mapCenterCoordinate, repository.lastLocationCoordinate)
+            assertEquals(MapSearchMode.MAP_CENTER, viewModel.uiState.value.searchMode)
+        }
+
+    @Test
     fun `현재 위치 주변 수거 장소 검색 실패 시 errorMessage를 표시하고 notice는 설정하지 않는다`() =
         runTest {
             val repository = FakeCollectionSpotRepository(

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -208,10 +208,42 @@ class CollectionSpotMapViewModelTest {
             assertEquals(mapCenterCoordinate, repository.lastLocationCoordinate)
             assertEquals(500, repository.lastRadiusMeter)
             assertEquals(expectedSpots, viewModel.uiState.value.spots)
-            assertEquals("", viewModel.uiState.value.searchKeyword)
+            assertEquals("문래동", viewModel.uiState.value.searchKeyword)
             assertEquals(MapSearchMode.MAP_CENTER, viewModel.uiState.value.searchMode)
             assertNull(viewModel.uiState.value.selectedSpot)
             assertFalse(viewModel.uiState.value.isLoading)
+        }
+
+    @Test
+    fun `지도 중심 검색 중 검색어를 입력하면 진행 중인 지도 중심 검색을 취소한다`() =
+        runTest {
+            val mapCenterCoordinate = Coordinate(latitude = 37.5701, longitude = 127.0012)
+            val mapCenterSearchResult = CompletableDeferred<List<CollectionSpot>>()
+            val repository = FakeCollectionSpotRepository(
+                locationSearchResultProvider = { mapCenterSearchResult.await() },
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.searchByMapCenter(mapCenterCoordinate)
+            advanceUntilIdle()
+
+            assertEquals(true, viewModel.uiState.value.isLoading)
+            assertEquals(MapSearchMode.MAP_CENTER, viewModel.uiState.value.searchMode)
+
+            viewModel.onSearchKeywordChanged("문래동")
+            mapCenterSearchResult.complete(
+                listOf(sampleSpot("map-center", CollectionSpotType.RECYCLING_CENTER)),
+            )
+            advanceUntilIdle()
+
+            assertEquals("문래동", viewModel.uiState.value.searchKeyword)
+            assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
+            assertEquals(false, viewModel.uiState.value.isLoading)
+            assertEquals(false, viewModel.uiState.value.hasSearched)
+            assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
         }
 
     @Test
@@ -423,7 +455,7 @@ class CollectionSpotMapViewModelTest {
         }
 
     @Test
-    fun `키워드 검색 후 현재 위치 검색을 실행하면 검색어를 비우고 현재 위치 결과를 반영한다`() =
+    fun `키워드 검색 후 현재 위치 검색을 실행하면 검색어를 유지하고 현재 위치 결과를 반영한다`() =
         runTest {
             val keywordSpot = sampleSpot("keyword", CollectionSpotType.OTHER)
             val locationSpot = sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)
@@ -444,7 +476,7 @@ class CollectionSpotMapViewModelTest {
             viewModel.searchByCurrentLocation()
             advanceUntilIdle()
 
-            assertEquals("", viewModel.uiState.value.searchKeyword)
+            assertEquals("용답동", viewModel.uiState.value.searchKeyword)
             assertEquals(listOf(locationSpot), viewModel.uiState.value.spots)
             assertEquals(MapSearchMode.CURRENT_LOCATION, viewModel.uiState.value.searchMode)
             assertFalse(viewModel.uiState.value.isLoading)


### PR DESCRIPTION
## 작업 내용

지도 화면에서 현재 위치 기준 검색과 현 지도 중심 기준 검색의 역할을 명확히 분리하고, 검색 중 로딩 UX를 지도 오버레이 중심으로 정리했습니다.

기존에는 `현 위치에서 검색하기` 버튼과 현재 위치 FAB의 역할이 겹쳐 보여 사용자가 검색 기준을 헷갈릴 수 있었습니다. 이번 작업에서는 `현 위치에서 검색하기` 버튼을 제거하고, 현재 위치 FAB를 현재 위치 기준 검색의 진입점으로 정리했습니다.

또한 지도 이동 후에는 `현 지도에서 검색` 버튼을 노출해, 현재 보고 있는 지도 중심 좌표 기준으로 수거 장소를 다시 검색할 수 있도록 연결했습니다.

## 주요 변경 사항

- `현 위치에서 검색하기` 버튼 제거
- 현재 위치 FAB 클릭 시 현재 위치 기준 검색 실행
- 지도 이동/줌 변경 시 `현 지도에서 검색` 버튼 노출
- `현 지도에서 검색` 클릭 시 현재 지도 카메라 중심 좌표 기준으로 검색
- 키워드 검색 / 현재 위치 검색 / 현 지도 검색 로딩 UI를 지도 오버레이로 통일
- 검색 중 BottomSheet 내부 스피너 대신 지도 오버레이 로딩 표시
- 현재 위치 검색 시 10분 TTL 캐시가 있으면 캐시를 먼저 표시하고 백그라운드에서 조용히 갱신
- 검색 결과가 여러 좌표에 퍼져 있으면 bounds 기준으로 모든 마커가 보이도록 카메라 이동
- 검색 결과가 1개면 해당 위치로 카메라 이동
- 선택된 장소 / 즐겨찾기 장소 이동이 검색 결과 자동 카메라 이동에 덮이지 않도록 유지
- 지도 BottomSheet 표시 상태에 따라 BottomNavigationBar 노출 정리
- 지도 검색바에 shadow 적용
- 관련 ViewModel 테스트 추가 및 보강

## UX 정책 정리

### 현재 위치 FAB

현재 위치 FAB는 지도 카메라를 내 위치로 이동시키는 버튼처럼 보이지만, 이번 작업에서는 지도 화면의 현재 위치 기준 검색 진입점으로 사용합니다.

`현 위치에서 검색하기` 버튼을 별도로 두면 현재 위치 FAB와 역할이 겹쳐 보여 혼란이 생길 수 있어 제거했습니다.

### 현 지도에서 검색

사용자가 지도를 이동하거나 줌을 변경하면 `현 지도에서 검색` 버튼을 표시합니다.

이 버튼은 현재 위치가 아니라, 사용자가 지금 보고 있는 지도 카메라 중심 좌표를 기준으로 수거 장소를 검색합니다.

### 현재 위치 캐시 정책

현재 위치 검색 결과는 기존 정책대로 10분 TTL 캐시를 사용합니다.

현재 위치 FAB를 눌렀을 때 신선한 캐시가 있으면:

1. 캐시된 현재 위치 주변 검색 결과를 먼저 즉시 표시합니다.
2. 사용자는 로딩을 기다리지 않고 기존 결과를 바로 확인할 수 있습니다.
3. 이후 백그라운드에서 현재 위치를 다시 조회하고, 최신 결과가 오면 조용히 갱신합니다.

캐시가 없거나 만료된 경우에는 기존처럼 현재 위치를 조회한 뒤 검색합니다.

## 화면

### 검색 로딩 오버레이

| 현재 위치 주변 검색 | 현 지도 주변 검색 | 입력한 동네 주변 검색 |
| --- | --- | --- |
| <img width="260" alt="현재 위치 주변 검색 오버레이" src="https://github.com/user-attachments/assets/0478f276-4e0c-466a-a1f5-4300f85066d3" /> | <img width="260" alt="현 지도 주변 검색 오버레이" src="https://github.com/user-attachments/assets/10a0794b-ebcb-4c09-bc34-5f9839d05a8c" /> | <img width="260" alt="입력한 동네 주변 검색 오버레이" src="https://github.com/user-attachments/assets/7cb72732-855a-4672-8fee-a21bd2a378ac" /> |

### 검색 결과

| 현재 위치 검색 결과 | 현 지도에서 검색 결과 |
| --- | --- |
| <img width="300" alt="현재 위치 검색 결과" src="https://github.com/user-attachments/assets/eebad558-40a0-431b-9843-1e817e09fd5d" /> | <img width="300" alt="현 지도에서 검색 결과" src="https://github.com/user-attachments/assets/847db49a-7994-4745-ac44-d93460a29b5b" /> |

### BottomSheet / BottomNavigationBar 노출

지도 화면에서 BottomSheet가 주요 정보를 가리지 않도록 BottomNavigationBar 노출 상태를 함께 정리했습니다.

- 지도만 탐색하는 상태에서는 BottomNavigationBar를 표시합니다.
- 검색 결과 BottomSheet 또는 장소 상세 BottomSheet가 올라오면 BottomNavigationBar를 숨겨 하단 카드와 버튼 영역이 가려지지 않도록 했습니다.
- 지도 화면을 다시 탭해 BottomSheet를 닫으면 BottomNavigationBar가 다시 표시됩니다.

| BottomNavigationBar 표시 | BottomSheet 표시 |
| --- | --- |
| <img width="300" alt="BottomNavigationBar 표시 상태" src="https://github.com/user-attachments/assets/940e681a-8bf5-46b9-a590-be5280e3f51a" /> | <img width="300" alt="BottomSheet 표시 상태" src="https://github.com/user-attachments/assets/a34b62d7-7914-4018-acc8-397c6d8733f4" /> |

## 테스트

- [x] 현재 위치 FAB 클릭 시 현재 위치 기준 검색이 실행되는지 확인
- [x] 현재 위치 검색 시 10분 TTL 캐시가 있으면 캐시 결과가 먼저 표시되는지 확인
- [x] 지도 이동 후 `현 지도에서 검색` 버튼이 노출되는지 확인
- [x] `현 지도에서 검색` 클릭 시 현재 지도 중심 좌표 기준으로 검색되는지 확인
- [x] 검색바 직접 검색 시 지도 오버레이 로딩이 표시되는지 확인
- [x] 현재 위치 검색 시 지도 오버레이 로딩이 표시되는지 확인
- [x] 현 지도 검색 시 지도 오버레이 로딩이 표시되는지 확인
- [x] 검색 중 BottomSheet 내부 스피너가 노출되지 않는지 확인
- [x] 검색 결과가 여러 좌표에 퍼져 있을 때 마커들이 보이도록 카메라가 조정되는지 확인
- [x] 기존 마커 선택 / 카드 선택 / BottomSheet 동작이 유지되는지 확인
- [x] 즐겨찾기 별 토글 동작이 유지되는지 확인

## 실행한 검증

```bash
./gradlew.bat :presentation:testDebugUnitTest :presentation:compileDebugKotlin

```

Related #118