### PR TITLE
[Fix] 품목 상세 스낵바 이벤트 처리 개선

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailRoute.kt
@@ -13,9 +13,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -36,17 +38,20 @@ fun ItemGuideDetailRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
+    val currentContext by rememberUpdatedState(LocalContext.current)
 
     LaunchedEffect(guideId) {
         viewModel.loadGuide(guideId)
     }
 
-    val favoriteMessageResId = (uiState as? ItemGuideDetailUiState.Success)?.favoriteMessageResId
-    val favoriteMessage = favoriteMessageResId?.let { stringResource(it) }
-    LaunchedEffect(favoriteMessage) {
-        val message = favoriteMessage ?: return@LaunchedEffect
-        snackbarHostState.showSnackbar(message)
-        viewModel.clearFavoriteMessage()
+    LaunchedEffect(viewModel.events) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is ItemGuideDetailEvent.ShowFavoriteMessage -> {
+                    snackbarHostState.showSnackbar(currentContext.getString(event.messageResId))
+                }
+            }
+        }
     }
 
     Scaffold(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModel.kt
@@ -14,8 +14,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -30,6 +33,8 @@ constructor(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<ItemGuideDetailUiState>(ItemGuideDetailUiState.Loading)
     val uiState: StateFlow<ItemGuideDetailUiState> = _uiState.asStateFlow()
+    private val _events = MutableSharedFlow<ItemGuideDetailEvent>()
+    val events: SharedFlow<ItemGuideDetailEvent> = _events.asSharedFlow()
     private var loadGuideJob: Job? = null
     private var favoriteJob: Job? = null
 
@@ -76,29 +81,15 @@ constructor(
                         savedAtMillis = System.currentTimeMillis(),
                     ),
                 )
-            _uiState.update { state ->
-                if (state is ItemGuideDetailUiState.Success && state.guide.id == guide.id) {
-                    state.copy(
-                        favoriteMessageResId =
-                            if (isFavorite) {
-                                R.string.item_guide_detail_favorite_added_message
-                            } else {
-                                R.string.item_guide_detail_favorite_removed_message
-                            },
-                    )
+            val messageResId =
+                if (isFavorite) {
+                    R.string.item_guide_detail_favorite_added_message
                 } else {
-                    state
+                    R.string.item_guide_detail_favorite_removed_message
                 }
-            }
-        }
-    }
-
-    fun clearFavoriteMessage() {
-        _uiState.update { state ->
-            if (state is ItemGuideDetailUiState.Success) {
-                state.copy(favoriteMessageResId = null)
-            } else {
-                state
+            val latestState = uiState.value
+            if (latestState is ItemGuideDetailUiState.Success && latestState.guide.id == guide.id) {
+                _events.emit(ItemGuideDetailEvent.ShowFavoriteMessage(messageResId))
             }
         }
     }
@@ -126,10 +117,15 @@ sealed interface ItemGuideDetailUiState {
     data class Success(
         val guide: DisposalItemGuide,
         val isFavorite: Boolean = false,
-        @param:StringRes val favoriteMessageResId: Int? = null,
     ) : ItemGuideDetailUiState
 
     data class Error(
         @param:StringRes val messageResId: Int,
     ) : ItemGuideDetailUiState
+}
+
+sealed interface ItemGuideDetailEvent {
+    data class ShowFavoriteMessage(
+        @param:StringRes val messageResId: Int,
+    ) : ItemGuideDetailEvent
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModelTest.kt
@@ -12,9 +12,12 @@ import com.team.yeogibeoryeo.domain.item.repository.DisposalItemGuideRepository
 import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalItemGuideUseCase
 import com.team.yeogibeoryeo.presentation.R
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -59,7 +62,7 @@ class ItemGuideDetailViewModelTest {
         }
 
     @Test
-    fun `즐겨찾기를 추가하면 최종 상태 기준 메시지를 저장한다`() =
+    fun `즐겨찾기를 추가하면 추가 메시지 이벤트를 보낸다`() =
         runTest {
             val guide = sampleGuide("유리병")
             val viewModel =
@@ -70,16 +73,20 @@ class ItemGuideDetailViewModelTest {
 
             viewModel.loadGuide(guide.id)
             advanceUntilIdle()
+            val event = async(start = CoroutineStart.UNDISPATCHED) { viewModel.events.first() }
             viewModel.toggleFavorite()
             advanceUntilIdle()
 
             val state = viewModel.uiState.value as ItemGuideDetailUiState.Success
             assertTrue(state.isFavorite)
-            assertEquals(R.string.item_guide_detail_favorite_added_message, state.favoriteMessageResId)
+            assertEquals(
+                R.string.item_guide_detail_favorite_added_message,
+                (event.await() as ItemGuideDetailEvent.ShowFavoriteMessage).messageResId,
+            )
         }
 
     @Test
-    fun `즐겨찾기를 해제하면 최종 상태 기준 메시지를 저장한다`() =
+    fun `즐겨찾기를 해제하면 해제 메시지 이벤트를 보낸다`() =
         runTest {
             val guide = sampleGuide("유리병")
             val favoriteRepository =
@@ -101,12 +108,16 @@ class ItemGuideDetailViewModelTest {
 
             viewModel.loadGuide(guide.id)
             advanceUntilIdle()
+            val event = async(start = CoroutineStart.UNDISPATCHED) { viewModel.events.first() }
             viewModel.toggleFavorite()
             advanceUntilIdle()
 
             val state = viewModel.uiState.value as ItemGuideDetailUiState.Success
             assertFalse(state.isFavorite)
-            assertEquals(R.string.item_guide_detail_favorite_removed_message, state.favoriteMessageResId)
+            assertEquals(
+                R.string.item_guide_detail_favorite_removed_message,
+                (event.await() as ItemGuideDetailEvent.ShowFavoriteMessage).messageResId,
+            )
         }
 
     @Test


### PR DESCRIPTION
## 작업 내용

- 품목 상세 즐겨찾기 snackbar 메시지를 `UiState`에서 제거했습니다.
- 즐겨찾기 추가/해제 메시지를 `ItemGuideDetailEvent.ShowFavoriteMessage` one-shot event로 분리했습니다.
- `ItemGuideDetailRoute`에서 `viewModel.events`를 수집해 snackbar를 표시하도록 변경했습니다.
- snackbar 메시지 이벤트 테스트를 추가/수정했습니다.

## 변경 이유

기존 구조는 `favoriteMessageResId`를 `UiState.Success`에 저장한 뒤 `showSnackbar()` 종료 후 clear했습니다.

`showSnackbar()`는 suspend 함수라 snackbar 표시 중 화면 재생성/복원이 발생하면 아직 clear되지 않은 메시지가 다시 소비될 수 있습니다. snackbar 표시는 durable screen state가 아니라 1회성 이벤트에 가까워 `SharedFlow` 기반 이벤트로 분리했습니다.

## 확인 사항

- ViewModel에는 `Context`를 전달하거나 저장하지 않았습니다.
- 문자열 변환은 Composable layer에서 `LocalContext`로 처리했습니다.
- 장시간 수집되는 effect에서 최신 context를 사용하도록 `rememberUpdatedState`를 사용했습니다.

## 테스트

- `./gradlew.bat :presentation:testDebugUnitTest --tests "com.team.yeogibeoryeo.presentation.search.ItemGuideDetailViewModelTest"`
- `./gradlew.bat :presentation:compileDebugKotlin`
- `git diff --check`

## 관련 이슈

Refs #127
