### PR TITLE
[Refactor] 품목 화면 Material3 layout 기준값 정리

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -28,8 +27,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
 import com.team.yeogibeoryeo.domain.item.model.DisposalInstruction
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
@@ -53,6 +50,8 @@ fun ItemGuideDetailScreen(
     onBottomBarVisibilityChanged: (Boolean) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+    val size = ItemSearchLayoutDefaults.size
     val scrollState = rememberScrollState()
     val onBottomBarVisibilityChangedState by rememberUpdatedState(onBottomBarVisibilityChanged)
 
@@ -93,12 +92,12 @@ fun ItemGuideDetailScreen(
             .background(MaterialTheme.colorScheme.background)
             .verticalScroll(scrollState)
             .padding(
-                start = 24.dp,
-                top = 16.dp,
-                end = 24.dp,
-                bottom = 24.dp,
+                start = spacing.xl,
+                top = spacing.md,
+                end = spacing.xl,
+                bottom = spacing.xl,
             ),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(spacing.md),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -137,35 +136,34 @@ fun ItemGuideDetailScreen(
 
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(spacing.md),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Box(
                 modifier = Modifier
-                    .size(88.dp)
+                    .size(size.detailIconContainer)
                     .background(
                         color = representativeCategory.containerColor(),
-                        shape = RoundedCornerShape(24.dp)
+                        shape = MaterialTheme.shapes.extraLarge
                     ),
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
                     painter = painterResource(id = representativeCategory.iconResId),
                     contentDescription = null,
-                    modifier = Modifier.size(44.dp),
+                    modifier = Modifier.size(size.iconProminent),
                     tint = representativeCategory.iconTint()
                 )
             }
 
             Column(
                 modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(10.dp),
+                verticalArrangement = Arrangement.spacedBy(spacing.sm),
             ) {
                 Text(
                     text = guide.name,
                     style = MaterialTheme.typography.headlineMedium.copy(
                         fontWeight = FontWeight.ExtraBold,
-                        fontSize = 28.sp,
                         color = MaterialTheme.colorScheme.onSurface
                     )
                 )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchLayoutDefaults.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchLayoutDefaults.kt
@@ -1,0 +1,43 @@
+package com.team.yeogibeoryeo.presentation.search
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+internal object ItemSearchLayoutDefaults {
+    val spacing = ItemSearchSpacingDefaults
+    val size = ItemSearchSizeDefaults
+    val stroke = ItemSearchStrokeDefaults
+    val elevation = ItemSearchElevationDefaults
+}
+
+internal object ItemSearchSpacingDefaults {
+    val xxs: Dp = 4.dp
+    val xs: Dp = 8.dp
+    val sm: Dp = 12.dp
+    val md: Dp = 16.dp
+    val lg: Dp = 20.dp
+    val xl: Dp = 24.dp
+    val xxl: Dp = 32.dp
+}
+
+internal object ItemSearchSizeDefaults {
+    val iconSmall: Dp = 20.dp
+    val iconStandard: Dp = 24.dp
+    val iconLarge: Dp = 32.dp
+    val iconProminent: Dp = 40.dp
+    val minTouchTarget: Dp = 48.dp
+    val searchFieldHeight: Dp = 56.dp
+    val categoryTile: Dp = 64.dp
+    val categoryCell: Dp = 72.dp
+    val detailIconContainer: Dp = 88.dp
+    val infoLabelMinWidth: Dp = 88.dp
+    val infoLabelMaxWidth: Dp = 112.dp
+}
+
+internal object ItemSearchStrokeDefaults {
+    val outline: Dp = 1.dp
+}
+
+internal object ItemSearchElevationDefaults {
+    val none: Dp = 0.dp
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -29,8 +29,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
@@ -105,15 +103,17 @@ fun ItemSearchScreen(
     searchResultListState: LazyListState = rememberLazyListState(),
     categoryListState: LazyListState = rememberLazyListState(),
 ) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+
     Column(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
-            .padding(horizontal = ItemSearchScreenHorizontalPadding)
-            .padding(top = ItemSearchScreenTopPadding),
-        verticalArrangement = Arrangement.spacedBy(ItemSearchScreenContentSpacing),
+            .padding(horizontal = spacing.xl)
+            .padding(top = spacing.xl),
+        verticalArrangement = Arrangement.spacedBy(spacing.xl),
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(ItemSearchScreenHeaderSpacing)) {
+        Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
             Text(
                 text = stringResource(R.string.item_search_title),
                 style = MaterialTheme.typography.headlineSmall,
@@ -140,7 +140,7 @@ fun ItemSearchScreen(
         // 검색 결과 또는 제안 섹션
         Column(
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(ItemSearchScreenSectionSpacing),
+            verticalArrangement = Arrangement.spacedBy(spacing.md)
         ) {
             when {
                 uiState.isLoading -> {
@@ -169,15 +169,14 @@ fun ItemSearchScreen(
                     LazyColumn(
                         state = categoryListState,
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(bottom = ItemSearchScreenListBottomPadding),
-                        verticalArrangement = Arrangement.spacedBy(ItemSearchScreenSectionSpacing),
+                        contentPadding = PaddingValues(bottom = spacing.xl),
+                        verticalArrangement = Arrangement.spacedBy(spacing.md),
                     ) {
                         item {
                             Text(
                                 text = stringResource(R.string.quick_categories),
                                 style = MaterialTheme.typography.titleMedium.copy(
                                     fontWeight = FontWeight.Bold,
-                                    fontSize = ItemSearchScreenSectionTitleFontSize,
                                     color = MaterialTheme.colorScheme.onSurface
                                 ),
                             )
@@ -203,14 +202,13 @@ fun ItemSearchScreen(
                         ),
                         style = MaterialTheme.typography.titleMedium.copy(
                             fontWeight = FontWeight.Bold,
-                            fontSize = ItemSearchScreenResultCountFontSize,
                             color = MaterialTheme.colorScheme.onSurface
                         ),
                     )
                     LazyColumn(
                         state = searchResultListState,
-                        contentPadding = PaddingValues(bottom = ItemSearchScreenListBottomPadding),
-                        verticalArrangement = Arrangement.spacedBy(ItemSearchScreenResultItemSpacing),
+                        contentPadding = PaddingValues(bottom = spacing.xl),
+                        verticalArrangement = Arrangement.spacedBy(spacing.sm),
                     ) {
                         items(uiState.guides, key = { it.id }) { guide ->
                             DisposalItemCard(
@@ -225,13 +223,3 @@ fun ItemSearchScreen(
         }
     }
 }
-
-private val ItemSearchScreenHorizontalPadding = 24.dp
-private val ItemSearchScreenTopPadding = 24.dp
-private val ItemSearchScreenContentSpacing = 24.dp
-private val ItemSearchScreenHeaderSpacing = 8.dp
-private val ItemSearchScreenSectionSpacing = 16.dp
-private val ItemSearchScreenResultItemSpacing = 12.dp
-private val ItemSearchScreenListBottomPadding = 24.dp
-private val ItemSearchScreenSectionTitleFontSize = 18.sp
-private val ItemSearchScreenResultCountFontSize = 16.sp

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalCategoryChip.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalCategoryChip.kt
@@ -3,14 +3,13 @@ package com.team.yeogibeoryeo.presentation.search.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
+import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 
 @Composable
 fun DisposalCategoryChip(
@@ -31,14 +30,16 @@ internal fun MetadataChip(
     containerColor: Color = MaterialTheme.colorScheme.secondaryContainer,
     contentColor: Color = MaterialTheme.colorScheme.onSecondaryContainer,
 ) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+
     Box(
         modifier =
             modifier
                 .background(
                     color = containerColor,
-                    shape = RoundedCornerShape(8.dp),
+                    shape = MaterialTheme.shapes.small,
                 )
-                .padding(horizontal = 12.dp, vertical = 8.dp),
+                .padding(horizontal = spacing.sm, vertical = spacing.xs),
     ) {
         Text(
             text = text,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalGuideMetadataChips.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalGuideMetadataChips.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -18,11 +17,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.common.R as CommonR
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -31,10 +30,12 @@ fun DisposalGuideMetadataChips(
     modifier: Modifier = Modifier,
     showCategoryChip: Boolean = true,
 ) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+
     FlowRow(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+        verticalArrangement = Arrangement.spacedBy(spacing.xs),
     ) {
         DisposalRouteChip(guide = guide)
         if (showCategoryChip) {
@@ -49,6 +50,8 @@ fun DisposalRouteChip(
     guide: DisposalItemGuide,
     modifier: Modifier = Modifier,
 ) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+    val size = ItemSearchLayoutDefaults.size
     val route = DisposalRouteStatus.from(guide) ?: return
     if (route.iconResId == null) {
         MetadataChip(
@@ -66,15 +69,15 @@ fun DisposalRouteChip(
                 .semantics { contentDescription = route.label }
                 .background(
                     color = route.containerColor(),
-                    shape = RoundedCornerShape(8.dp),
+                    shape = MaterialTheme.shapes.small,
                 )
-                .padding(8.dp),
+                .padding(spacing.xs),
         contentAlignment = Alignment.Center,
     ) {
         Icon(
             painter = painterResource(id = route.iconResId),
             contentDescription = null,
-            modifier = Modifier.size(20.dp),
+            modifier = Modifier.size(size.iconSmall),
             tint = route.contentColor(),
         )
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalInstructionCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalInstructionCard.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -14,11 +13,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.LineBreak
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
 import com.team.yeogibeoryeo.domain.item.model.DisposalInstruction
+import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 
 /**
  * '버리는 방법'을 강조하여 보여주는 카드 컴포넌트입니다.
@@ -29,32 +27,32 @@ fun DisposalInstructionCard(
     instructions: List<DisposalInstruction>,
     modifier: Modifier = Modifier,
 ) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+
     Card(
         modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(24.dp),
+        shape = MaterialTheme.shapes.extraLarge,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.primary,
             contentColor = MaterialTheme.colorScheme.onPrimary,
         )
     ) {
         Column(
-            modifier = Modifier.padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.padding(spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
         ) {
             Text(
                 text = stringResource(R.string.disposal_method_title),
                 style = MaterialTheme.typography.titleLarge.copy(
                     fontWeight = FontWeight.Bold,
-                    fontSize = 20.sp
                 ),
             )
             instructions.forEach { instruction ->
-                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Column(verticalArrangement = Arrangement.spacedBy(spacing.xxs)) {
                     Text(
                         text = instruction.method.withKoreanLineBreakOpportunities(),
                         style = MaterialTheme.typography.bodyLarge.copy(
                             fontWeight = FontWeight.Medium,
-                            lineHeight = 24.sp,
                             lineBreak = koreanBodyLineBreak,
                         ),
                     )
@@ -63,7 +61,6 @@ fun DisposalInstructionCard(
                             text = it.withKoreanLineBreakOpportunities(),
                             style = MaterialTheme.typography.bodyMedium.copy(
                                 color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.84f),
-                                lineHeight = 20.sp,
                                 lineBreak = koreanBodyLineBreak,
                             ),
                         )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -23,10 +22,9 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.common.R as CommonR
+import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 
 @Composable
 fun DisposalItemCard(
@@ -35,6 +33,11 @@ fun DisposalItemCard(
     modifier: Modifier = Modifier,
     isFavorite: Boolean = false,
 ) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+    val size = ItemSearchLayoutDefaults.size
+    val stroke = ItemSearchLayoutDefaults.stroke
+    val elevation = ItemSearchLayoutDefaults.elevation
+
     Card(
         modifier = modifier
             .fillMaxWidth()
@@ -47,16 +50,16 @@ fun DisposalItemCard(
                     }
             }
             .clickable(onClick = onClick),
-        shape = RoundedCornerShape(20.dp),
+        shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface,
         ),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+        border = BorderStroke(stroke.outline, MaterialTheme.colorScheme.outlineVariant),
+        elevation = CardDefaults.cardElevation(defaultElevation = elevation.none)
     ) {
         Box(
             modifier = Modifier
-                .padding(20.dp)
+                .padding(spacing.lg)
                 .fillMaxWidth(),
         ) {
             if (isFavorite) {
@@ -65,7 +68,7 @@ fun DisposalItemCard(
                     contentDescription = null,
                     modifier = Modifier
                         .align(Alignment.TopEnd)
-                        .size(20.dp),
+                        .size(size.iconSmall),
                     tint = MaterialTheme.colorScheme.tertiary,
                 )
             }
@@ -73,18 +76,17 @@ fun DisposalItemCard(
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm)
             ) {
                 Column(
                     modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(spacing.xs),
                 ) {
                     Text(
                         text = guide.name,
                         modifier = Modifier.fillMaxWidth(),
                         style = MaterialTheme.typography.titleMedium.copy(
                             fontWeight = FontWeight.Bold,
-                            fontSize = 18.sp,
                             color = MaterialTheme.colorScheme.onSurface
                         ),
                         maxLines = 2,
@@ -99,8 +101,6 @@ fun DisposalItemCard(
                             text = firstInstruction,
                             style = MaterialTheme.typography.bodyMedium.copy(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                fontSize = 14.sp,
-                                lineHeight = 22.sp
                             ),
                             maxLines = 2,
                             overflow = TextOverflow.Ellipsis
@@ -111,7 +111,7 @@ fun DisposalItemCard(
                 Icon(
                     painter = painterResource(id = CommonR.drawable.ic_action_chevron_right),
                     contentDescription = null,
-                    modifier = Modifier.size(20.dp),
+                    modifier = Modifier.size(size.iconSmall),
                     tint = MaterialTheme.colorScheme.outlineVariant
                 )
             }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchBar.kt
@@ -10,10 +10,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.common.R as CommonR
 import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.common.components.SearchBarField
+import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 
 @Composable
 fun ItemSearchBar(
@@ -23,6 +23,8 @@ fun ItemSearchBar(
     modifier: Modifier = Modifier,
     placeholder: String,
 ) {
+    val size = ItemSearchLayoutDefaults.size
+
     SearchBarField(
         modifier = modifier.fillMaxWidth(),
         keyword = keyword,
@@ -50,12 +52,12 @@ fun ItemSearchBar(
                 Icon(
                     painter = painterResource(id = CommonR.drawable.ic_action_search),
                     contentDescription = stringResource(R.string.search_action),
-                    modifier = Modifier.size(20.dp),
+                    modifier = Modifier.size(size.iconSmall),
                     tint = searchIconColor,
                 )
             }
         },
-        minHeight = 56.dp,
+        minHeight = size.searchFieldHeight,
         searchEnabled = { it.isNotBlank() },
     )
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchStatusContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchStatusContent.kt
@@ -17,9 +17,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.common.design.theme.YeogiBeoryeoTheme
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 
 @Composable
 fun ItemSearchStatusContent(
@@ -28,8 +28,8 @@ fun ItemSearchStatusContent(
     description: (@Composable ColumnScope.() -> Unit)? = null,
     contentPadding: PaddingValues =
         PaddingValues(
-            horizontal = ItemSearchStatusHorizontalPadding,
-            vertical = ItemSearchStatusVerticalPadding,
+            horizontal = ItemSearchLayoutDefaults.spacing.xl,
+            vertical = ItemSearchLayoutDefaults.spacing.xxl,
         ),
     action: (@Composable ColumnScope.() -> Unit)? = null,
 ) {
@@ -39,7 +39,7 @@ fun ItemSearchStatusContent(
             .padding(contentPadding),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(
-            space = ItemSearchStatusContentSpacing,
+            space = ItemSearchLayoutDefaults.spacing.xs,
             alignment = Alignment.CenterVertically,
         ),
     ) {
@@ -124,7 +124,3 @@ private fun ItemSearchStatusContentActionPreview() {
         }
     }
 }
-
-private val ItemSearchStatusHorizontalPadding = 24.dp
-private val ItemSearchStatusVerticalPadding = 28.dp
-private val ItemSearchStatusContentSpacing = 8.dp

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -21,8 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.layout.sizeIn
+import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
 
 @Composable
@@ -31,8 +30,10 @@ fun QuickCategoryGrid(
     onCategoryClick: (RepresentativeGuideCategory) -> Unit,
 ) {
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-        val itemWidth = 72.dp
-        val horizontalSpace = 16.dp
+        val spacing = ItemSearchLayoutDefaults.spacing
+        val size = ItemSearchLayoutDefaults.size
+        val itemWidth = size.categoryCell
+        val horizontalSpace = spacing.md
         val columnCount =
             ((maxWidth + horizontalSpace) / (itemWidth + horizontalSpace))
                 .toInt()
@@ -40,7 +41,7 @@ fun QuickCategoryGrid(
 
         Column(
             modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(spacing.md),
             horizontalAlignment = Alignment.Start,
         ) {
             categories.chunked(columnCount).forEach { rowCategories ->
@@ -70,26 +71,33 @@ private fun QuickCategoryItem(
     name: String,
     onClick: () -> Unit
 ) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+    val size = ItemSearchLayoutDefaults.size
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(spacing.xs),
         modifier = Modifier
-            .width(72.dp)
+            .sizeIn(
+                minWidth = size.minTouchTarget,
+                minHeight = size.minTouchTarget,
+            )
+            .width(size.categoryCell)
             .clickable(onClick = onClick)
     ) {
         Box(
             modifier = Modifier
-                .size(64.dp)
+                .size(size.categoryTile)
                 .background(
                     color = category.containerColor(),
-                    shape = RoundedCornerShape(16.dp)
+                    shape = MaterialTheme.shapes.large
                 ),
             contentAlignment = Alignment.Center
         ) {
             Icon(
                 painter = painterResource(id = category.iconResId),
                 contentDescription = null,
-                modifier = Modifier.size(32.dp),
+                modifier = Modifier.size(size.iconLarge),
                 tint = category.iconTint()
             )
         }
@@ -98,7 +106,6 @@ private fun QuickCategoryItem(
             style = MaterialTheme.typography.labelMedium.copy(
                 fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.onBackground,
-                fontSize = 13.sp
             ),
             minLines = 2,
             textAlign = TextAlign.Center,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SectionCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SectionCard.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -16,10 +15,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.LineBreak
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.team.yeogibeoryeo.domain.item.model.DisposalGuideSectionRow
 import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
+import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 
 /**
  * 부가적인 정보를 담는 카드 컴포넌트입니다.
@@ -33,30 +31,34 @@ fun SectionCard(
     numbered: Boolean = false,
     rows: List<DisposalGuideSectionRow> = emptyList(),
 ) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+    val size = ItemSearchLayoutDefaults.size
+    val stroke = ItemSearchLayoutDefaults.stroke
+    val elevation = ItemSearchLayoutDefaults.elevation
+
     Card(
         modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(24.dp),
+        shape = MaterialTheme.shapes.extraLarge,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface,
             contentColor = MaterialTheme.colorScheme.onSurface,
         ),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+        border = BorderStroke(stroke.outline, MaterialTheme.colorScheme.outlineVariant),
+        elevation = CardDefaults.cardElevation(defaultElevation = elevation.none)
     ) {
         Column(
-            modifier = Modifier.padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.padding(spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
         ) {
             Text(
                 text = title,
                 style = MaterialTheme.typography.titleMedium.copy(
                     fontWeight = FontWeight.Bold,
-                    fontSize = 18.sp,
                     color = MaterialTheme.colorScheme.onSurface,
                 ),
             )
             if (lines.isNotEmpty()) {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
                     lines.forEachIndexed { index, line ->
                         Text(
                             text =
@@ -64,8 +66,6 @@ fun SectionCard(
                                     .withKoreanLineBreakOpportunities(),
                             style = MaterialTheme.typography.bodyMedium.copy(
                                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.72f),
-                                lineHeight = 22.sp,
-                                fontSize = 15.sp,
                                 lineBreak = koreanBodyLineBreak,
                             ),
                         )
@@ -74,20 +74,21 @@ fun SectionCard(
             }
 
             if (rows.isNotEmpty()) {
-                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
                     rows.forEach { row ->
                         Row(
                             modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
                         ) {
                             Text(
                                 text = row.label,
-                                modifier = Modifier.widthIn(min = 88.dp, max = 112.dp),
+                                modifier = Modifier.widthIn(
+                                    min = size.infoLabelMinWidth,
+                                    max = size.infoLabelMaxWidth,
+                                ),
                                 style = MaterialTheme.typography.bodyMedium.copy(
                                     color = MaterialTheme.colorScheme.onSurface,
                                     fontWeight = FontWeight.SemiBold,
-                                    lineHeight = 21.sp,
-                                    fontSize = 14.sp,
                                     lineBreak = koreanBodyLineBreak,
                                 ),
                             )
@@ -96,8 +97,6 @@ fun SectionCard(
                                 modifier = Modifier.weight(1f),
                                 style = MaterialTheme.typography.bodyMedium.copy(
                                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.72f),
-                                    lineHeight = 22.sp,
-                                    fontSize = 15.sp,
                                     lineBreak = koreanBodyLineBreak,
                                 ),
                             )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SubGuideSection.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SubGuideSection.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -13,9 +12,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.team.yeogibeoryeo.domain.item.model.DisposalSubGuide
+import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 
 @Composable
 fun SubGuideSection(
@@ -23,31 +21,34 @@ fun SubGuideSection(
     subGuides: List<DisposalSubGuide>,
     modifier: Modifier = Modifier,
 ) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+    val stroke = ItemSearchLayoutDefaults.stroke
+    val elevation = ItemSearchLayoutDefaults.elevation
+
     Card(
         modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(24.dp),
+        shape = MaterialTheme.shapes.extraLarge,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface,
             contentColor = MaterialTheme.colorScheme.onSurface,
         ),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+        border = BorderStroke(stroke.outline, MaterialTheme.colorScheme.outlineVariant),
+        elevation = CardDefaults.cardElevation(defaultElevation = elevation.none),
     ) {
         Column(
-            modifier = Modifier.padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.padding(spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(spacing.md),
         ) {
             Text(
                 text = title,
                 style = MaterialTheme.typography.titleMedium.copy(
                     fontWeight = FontWeight.Bold,
-                    fontSize = 18.sp,
                     color = MaterialTheme.colorScheme.onSurface,
                 ),
             )
 
             subGuides.forEach { subGuide ->
-                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
                     Text(
                         text = subGuide.name,
                         style = MaterialTheme.typography.titleSmall.copy(
@@ -59,8 +60,6 @@ fun SubGuideSection(
                         text = subGuide.summary,
                         style = MaterialTheme.typography.bodyMedium.copy(
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.72f),
-                            lineHeight = 22.sp,
-                            fontSize = 15.sp,
                         ),
                     )
                 }


### PR DESCRIPTION
## 작업 내용

- 품목 검색/상세 화면의 layout 기준값을 `ItemSearchLayoutDefaults`로 정리했습니다.
- 직접 지정된 `sp` 값을 제거하고 `MaterialTheme.typography` 역할을 사용하도록 정리했습니다.
- 직접 지정된 radius 값을 제거하고 `MaterialTheme.shapes` 역할을 사용하도록 정리했습니다.
- 검색바, 카테고리 그리드, 검색 결과 카드, 상태 UI, 상세 섹션 카드의 spacing/size/stroke/elevation 기준을 의미별로 분리했습니다.

## 변경 이유

#121 작업 중 품목 화면에 `dp`, `sp`, `RoundedCornerShape(...)` 값이 직접 사용되는 것을 확인했습니다.

Material Design 3는 layout의 spacing 기준을 다루지만, Compose Material3의 `MaterialTheme` API는 `colorScheme`, `typography`, `shapes`를 기본 theme 축으로 제공하고 spacing은 별도 파라미터로 제공하지 않습니다.

따라서 이번 PR에서는 앱 전체 공통 token을 바로 만들지 않고, 담당 범위가 명확한 품목 화면 내부에서 먼저 `ItemSearchLayoutDefaults`로 기준값을 모았습니다. 이후 #123에서 팀 합의가 끝나면 여러 화면에서 재사용 가능한 값만 공통 token으로 승격할 수 있습니다.

## 주요 변경 사항

- `MaterialTheme.typography` 사용으로 직접 `sp` 지정 제거
- `MaterialTheme.shapes` 사용으로 직접 `RoundedCornerShape(dp)` 지정 제거
- `ItemSearchLayoutDefaults.spacing`으로 품목 화면 spacing 기준 정리
- `ItemSearchLayoutDefaults.size`로 icon, touch target, search field, category tile 기준 정리
- `ItemSearchLayoutDefaults.stroke/elevation`으로 카드 outline/elevation 의미 명시
- 카테고리 item에 최소 `48.dp` touch target 기준 적용
- #125에서 추가된 `ItemSearchStatusContent`의 spacing도 같은 기준으로 정리

## 확인 사항

리뷰 시 아래를 확인해주세요.

- 품목 홈/검색 결과/상세 화면에서 의도하지 않은 시각 변화가 없는지
- `ItemSearchLayoutDefaults`가 공통 token 확정이 아니라 품목 내부 기본값으로 보이는지
- #123에서 공통 token으로 승격할 후보와 품목 전용으로 남길 값이 구분되는지

## 스크린샷
<img width="990" height="1122" alt="compare-item-home" src="https://github.com/user-attachments/assets/f8beaa60-1528-4f13-98bf-e31216818e23" />
<img width="990" height="1122" alt="compare-item-search-results" src="https://github.com/user-attachments/assets/514136f0-20bd-4f11-a18b-74c7efaf11ba" />
<img width="990" height="1122" alt="compare-item-detail-top" src="https://github.com/user-attachments/assets/8c66af30-e131-4f50-9b0d-4786697c6478" />
<img width="990" height="1122" alt="compare-item-detail-sections" src="https://github.com/user-attachments/assets/2ec09ba4-7ea8-49ec-b3b3-3653b311de02" />

## 참고 문서

- Material 3 in Compose: https://developer.android.com/develop/ui/compose/designsystems/material3
- Custom design systems in Compose: https://developer.android.com/develop/ui/compose/designsystems/custom
- Material 3 Grids & Spacing: https://m3.material.io/foundations/layout/grids-spacing/spacing
- Material 3 Touch targets: https://m3.material.io/foundations/designing/structure

## 테스트

- [x] `./gradlew.bat :app:compileDebugKotlin :presentation:compileDebugKotlin`

## 관련 이슈

Related #126
Related #123
