### PR TITLE
[Refactor] 품목 컴포넌트 slot 구조 정리

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
@@ -4,8 +4,11 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -34,7 +37,6 @@ fun DisposalItemCard(
     isFavorite: Boolean = false,
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
-    val size = ItemSearchLayoutDefaults.size
     val stroke = ItemSearchLayoutDefaults.stroke
     val elevation = ItemSearchLayoutDefaults.elevation
 
@@ -57,68 +59,112 @@ fun DisposalItemCard(
         border = BorderStroke(stroke.outline, MaterialTheme.colorScheme.outlineVariant),
         elevation = CardDefaults.cardElevation(defaultElevation = elevation.none)
     ) {
-        Box(
-            modifier = Modifier
-                .padding(spacing.lg)
-                .fillMaxWidth(),
-        ) {
-            if (isFavorite) {
-                Icon(
-                    painter = painterResource(id = CommonR.drawable.ic_favorite_filled),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .size(size.iconSmall),
-                    tint = MaterialTheme.colorScheme.tertiary,
-                )
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(spacing.sm)
-            ) {
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(spacing.xs),
-                ) {
-                    Text(
-                        text = guide.name,
-                        modifier = Modifier.fillMaxWidth(),
-                        style = MaterialTheme.typography.titleMedium.copy(
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface
-                        ),
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-
-                    DisposalGuideMetadataChips(guide = guide)
-
-                    if (guide.instructions.isNotEmpty()) {
-                        val firstInstruction = guide.instructions.first().method.toDisplayLabel()
-                        Text(
-                            text = firstInstruction,
-                            style = MaterialTheme.typography.bodyMedium.copy(
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            ),
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
+        DisposalItemCardLayout(
+            favoriteIndicator = {
+                if (isFavorite) {
+                    FavoriteIndicator()
                 }
+            },
+            content = {
+                DisposalItemTitle(text = guide.name)
+                DisposalGuideMetadataChips(guide = guide)
+                guide.instructions.firstOrNull()?.let { instruction ->
+                    DisposalItemDescription(text = instruction.method.toDisplayLabel())
+                }
+            },
+            trailing = {
+                ChevronIndicator()
+            },
+        )
+    }
+}
 
-                Icon(
-                    painter = painterResource(id = CommonR.drawable.ic_action_chevron_right),
-                    contentDescription = null,
-                    modifier = Modifier.size(size.iconSmall),
-                    tint = MaterialTheme.colorScheme.outlineVariant
-                )
+@Composable
+private fun DisposalItemCardLayout(
+    favoriteIndicator: @Composable BoxScope.() -> Unit,
+    content: @Composable ColumnScope.() -> Unit,
+    trailing: @Composable RowScope.() -> Unit,
+) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+
+    Box(
+        modifier = Modifier
+            .padding(spacing.lg)
+            .fillMaxWidth(),
+    ) {
+        favoriteIndicator()
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            Column(
+                modifier = Modifier.weight(ItemCardContentWeight),
+                verticalArrangement = Arrangement.spacedBy(spacing.xs),
+            ) {
+                content()
             }
+            trailing()
         }
     }
 }
 
+@Composable
+private fun BoxScope.FavoriteIndicator() {
+    val size = ItemSearchLayoutDefaults.size
+
+    Icon(
+        painter = painterResource(id = CommonR.drawable.ic_favorite_filled),
+        contentDescription = null,
+        modifier = Modifier
+            .align(Alignment.TopEnd)
+            .size(size.iconSmall),
+        tint = MaterialTheme.colorScheme.tertiary,
+    )
+}
+
+@Composable
+private fun ColumnScope.DisposalItemTitle(text: String) {
+    Text(
+        text = text,
+        modifier = Modifier.fillMaxWidth(),
+        style = MaterialTheme.typography.titleMedium.copy(
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        ),
+        maxLines = ItemCardTitleMaxLines,
+        overflow = TextOverflow.Ellipsis,
+    )
+}
+
+@Composable
+private fun ColumnScope.DisposalItemDescription(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium.copy(
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        ),
+        maxLines = ItemCardDescriptionMaxLines,
+        overflow = TextOverflow.Ellipsis,
+    )
+}
+
+@Composable
+private fun ChevronIndicator() {
+    val size = ItemSearchLayoutDefaults.size
+
+    Icon(
+        painter = painterResource(id = CommonR.drawable.ic_action_chevron_right),
+        contentDescription = null,
+        modifier = Modifier.size(size.iconSmall),
+        tint = MaterialTheme.colorScheme.outlineVariant,
+    )
+}
 
 private fun String.toDisplayLabel(): String =
     if (this == "일반종량제폐기물") "종량제봉투" else this
+
+private const val ItemCardContentWeight = 1f
+private const val ItemCardTitleMaxLines = 2
+private const val ItemCardDescriptionMaxLines = 2

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemGuideSectionCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemGuideSectionCard.kt
@@ -1,0 +1,63 @@
+package com.team.yeogibeoryeo.presentation.search.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
+
+@Composable
+internal fun ItemGuideSectionCard(
+    title: String,
+    modifier: Modifier = Modifier,
+    contentSpacing: Dp = ItemSearchLayoutDefaults.spacing.sm,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+    val stroke = ItemSearchLayoutDefaults.stroke
+    val elevation = ItemSearchLayoutDefaults.elevation
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        ),
+        border = BorderStroke(stroke.outline, MaterialTheme.colorScheme.outlineVariant),
+        elevation = CardDefaults.cardElevation(defaultElevation = elevation.none),
+    ) {
+        Column(
+            modifier = Modifier.padding(spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(contentSpacing),
+        ) {
+            ItemGuideSectionTitle(text = title)
+            content()
+        }
+    }
+}
+
+@Composable
+internal fun ItemGuideSectionTitle(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        style = MaterialTheme.typography.titleMedium.copy(
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        ),
+    )
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
@@ -28,6 +28,16 @@ import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCatego
 fun QuickCategoryGrid(
     categories: List<RepresentativeGuideCategory> = quickCategoryOrder,
     onCategoryClick: (RepresentativeGuideCategory) -> Unit,
+    itemContent: @Composable (
+        category: RepresentativeGuideCategory,
+        onClick: () -> Unit,
+    ) -> Unit = { category, onClick ->
+        QuickCategoryItem(
+            category = category,
+            name = category.displayName,
+            onClick = onClick,
+        )
+    },
 ) {
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
         val spacing = ItemSearchLayoutDefaults.spacing
@@ -50,10 +60,9 @@ fun QuickCategoryGrid(
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
                     rowCategories.forEach { category ->
-                        QuickCategoryItem(
-                            category = category,
-                            name = category.displayName,
-                            onClick = { onCategoryClick(category) }
+                        itemContent(
+                            category,
+                            { onCategoryClick(category) },
                         )
                     }
                     repeat(columnCount - rowCategories.size) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SectionCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SectionCard.kt
@@ -4,12 +4,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -33,78 +29,86 @@ fun SectionCard(
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
     val size = ItemSearchLayoutDefaults.size
-    val stroke = ItemSearchLayoutDefaults.stroke
-    val elevation = ItemSearchLayoutDefaults.elevation
 
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.extraLarge,
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface,
-            contentColor = MaterialTheme.colorScheme.onSurface,
-        ),
-        border = BorderStroke(stroke.outline, MaterialTheme.colorScheme.outlineVariant),
-        elevation = CardDefaults.cardElevation(defaultElevation = elevation.none)
+    ItemGuideSectionCard(
+        title = title,
+        modifier = modifier,
     ) {
-        Column(
-            modifier = Modifier.padding(spacing.xl),
-            verticalArrangement = Arrangement.spacedBy(spacing.sm),
-        ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium.copy(
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                ),
+        if (lines.isNotEmpty()) {
+            SectionLines(
+                lines = lines,
+                numbered = numbered,
             )
-            if (lines.isNotEmpty()) {
-                Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
-                    lines.forEachIndexed { index, line ->
-                        Text(
-                            text =
-                                (if (numbered) "${index + 1}. $line" else line)
-                                    .withKoreanLineBreakOpportunities(),
-                            style = MaterialTheme.typography.bodyMedium.copy(
-                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.72f),
-                                lineBreak = koreanBodyLineBreak,
-                            ),
-                        )
-                    }
-                }
-            }
+        }
 
-            if (rows.isNotEmpty()) {
-                Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
-                    rows.forEach { row ->
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
-                        ) {
-                            Text(
-                                text = row.label,
-                                modifier = Modifier.widthIn(
-                                    min = size.infoLabelMinWidth,
-                                    max = size.infoLabelMaxWidth,
-                                ),
-                                style = MaterialTheme.typography.bodyMedium.copy(
-                                    color = MaterialTheme.colorScheme.onSurface,
-                                    fontWeight = FontWeight.SemiBold,
-                                    lineBreak = koreanBodyLineBreak,
-                                ),
-                            )
-                            Text(
-                                text = row.value,
-                                modifier = Modifier.weight(1f),
-                                style = MaterialTheme.typography.bodyMedium.copy(
-                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.72f),
-                                    lineBreak = koreanBodyLineBreak,
-                                ),
-                            )
-                        }
-                    }
+        if (rows.isNotEmpty()) {
+            Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                rows.forEach { row ->
+                    SectionRow(
+                        label = row.label,
+                        value = row.value,
+                        labelModifier = Modifier.widthIn(
+                            min = size.infoLabelMinWidth,
+                            max = size.infoLabelMaxWidth,
+                        ),
+                    )
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun SectionLines(
+    lines: List<String>,
+    numbered: Boolean,
+) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+        lines.forEachIndexed { index, line ->
+            Text(
+                text =
+                    (if (numbered) "${index + 1}. $line" else line)
+                        .withKoreanLineBreakOpportunities(),
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    lineBreak = koreanBodyLineBreak,
+                ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionRow(
+    label: String,
+    value: String,
+    labelModifier: Modifier = Modifier,
+) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+    ) {
+        Text(
+            text = label,
+            modifier = labelModifier,
+            style = MaterialTheme.typography.bodyMedium.copy(
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold,
+                lineBreak = koreanBodyLineBreak,
+            ),
+        )
+        Text(
+            text = value,
+            modifier = Modifier.weight(1f),
+            style = MaterialTheme.typography.bodyMedium.copy(
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                lineBreak = koreanBodyLineBreak,
+            ),
+        )
     }
 }
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SubGuideSection.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SubGuideSection.kt
@@ -1,12 +1,7 @@
 package com.team.yeogibeoryeo.presentation.search.components
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,48 +17,41 @@ fun SubGuideSection(
     modifier: Modifier = Modifier,
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
-    val stroke = ItemSearchLayoutDefaults.stroke
-    val elevation = ItemSearchLayoutDefaults.elevation
 
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.extraLarge,
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface,
-            contentColor = MaterialTheme.colorScheme.onSurface,
-        ),
-        border = BorderStroke(stroke.outline, MaterialTheme.colorScheme.outlineVariant),
-        elevation = CardDefaults.cardElevation(defaultElevation = elevation.none),
+    ItemGuideSectionCard(
+        title = title,
+        modifier = modifier,
+        contentSpacing = spacing.md,
     ) {
-        Column(
-            modifier = Modifier.padding(spacing.xl),
-            verticalArrangement = Arrangement.spacedBy(spacing.md),
-        ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium.copy(
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                ),
+        subGuides.forEach { subGuide ->
+            SubGuideItem(
+                name = subGuide.name,
+                summary = subGuide.summary,
             )
-
-            subGuides.forEach { subGuide ->
-                Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
-                    Text(
-                        text = subGuide.name,
-                        style = MaterialTheme.typography.titleSmall.copy(
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        ),
-                    )
-                    Text(
-                        text = subGuide.summary,
-                        style = MaterialTheme.typography.bodyMedium.copy(
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.72f),
-                        ),
-                    )
-                }
-            }
         }
+    }
+}
+
+@Composable
+private fun SubGuideItem(
+    name: String,
+    summary: String,
+) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+        Text(
+            text = name,
+            style = MaterialTheme.typography.titleSmall.copy(
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+            ),
+        )
+        Text(
+            text = summary,
+            style = MaterialTheme.typography.bodyMedium.copy(
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
+        )
     }
 }


### PR DESCRIPTION
## 작업 내용

품목 탭 내부 컴포넌트의 반복 렌더링 구조를 slot 기반으로 정리했습니다.

## 변경 이유

품목 검색/상세 화면의 카드와 섹션 컴포넌트는 컨테이너 구조는 유지하면서 내부 title, content, trailing, item 렌더링만 바뀌는 부분이 있었습니다.
이번 작업에서는 앱 전체 공통 컴포넌트를 확정하지 않고, 품목 탭 안에서 실제로 구조 분리 이득이 있는 영역만 정리했습니다.

## 주요 변경 사항

- `DisposalItemCard` 내부를 layout/content/trailing 구조로 분리했습니다.
- `SectionCard`와 `SubGuideSection`이 공통 섹션 컨테이너인 `ItemGuideSectionCard`를 사용하도록 정리했습니다.
- `QuickCategoryGrid`에 item 렌더링 slot을 추가해 그리드 구조와 항목 렌더링 책임을 분리했습니다.
- 임의 alpha 값은 제거하고 `MaterialTheme.colorScheme.onSurfaceVariant`를 사용하도록 정리했습니다.
- 카드 내부 줄 수와 weight 값은 공통 token이 아닌 로컬 UI 정책으로 이름을 붙였습니다.

## 확인 사항

- 품목 탭 내부 컴포넌트만 변경했습니다.
- layout token, spacing/size 기준, 앱 전체 common 컴포넌트는 변경하지 않았습니다.
- 장식용 아이콘의 `contentDescription = null`은 유지했습니다. 접근성 전반 정리는 #98 범위에서 별도로 다루는 것이 좋습니다.

## 테스트

- [x] `./gradlew.bat :app:compileDebugKotlin :presentation:compileDebugKotlin`

## 관련 이슈

Related #124
