### PR TITLE
[Refactor] 품목 화면 접근성 semantics 보강

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
@@ -24,8 +24,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
 import com.team.yeogibeoryeo.domain.item.model.DisposalInstruction
@@ -79,7 +77,14 @@ fun ItemGuideDetailScreen(
     }
 
     val backActionDescription = stringResource(R.string.back_action)
-    val favoriteActionDescription = if (isFavorite) "즐겨찾기 해제" else "즐겨찾기 추가"
+    val favoriteActionDescription =
+        stringResource(
+            if (isFavorite) {
+                R.string.favorite_remove_action
+            } else {
+                R.string.favorite_add_action
+            },
+        )
     val matchedRepresentativeCategory = RepresentativeGuideCategory.fromGuideName(guide.name)
     val isRepresentativeGuide = matchedRepresentativeCategory != null
     val representativeCategory =
@@ -108,9 +113,6 @@ fun ItemGuideDetailScreen(
                 Icon(
                     painter = painterResource(id = CommonR.drawable.ic_action_back),
                     contentDescription = backActionDescription,
-                    modifier = Modifier.semantics {
-                        contentDescription = backActionDescription
-                    },
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
             }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
@@ -152,6 +152,7 @@ fun ItemGuideDetailScreen(
             ) {
                 Icon(
                     painter = painterResource(id = representativeCategory.iconResId),
+                    // 옆의 품목명과 metadata chip이 의미를 제공하므로 아이콘은 중복 읽기를 피합니다.
                     contentDescription = null,
                     modifier = Modifier.size(size.iconProminent),
                     tint = representativeCategory.iconTint()

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
@@ -39,7 +39,6 @@ fun DisposalItemCard(
     modifier: Modifier = Modifier,
     isFavorite: Boolean = false,
 ) {
-    val spacing = ItemSearchLayoutDefaults.spacing
     val stroke = ItemSearchLayoutDefaults.stroke
     val elevation = ItemSearchLayoutDefaults.elevation
     val favoriteStateDescription =
@@ -127,6 +126,7 @@ private fun BoxScope.FavoriteIndicator() {
 
     Icon(
         painter = painterResource(id = CommonR.drawable.ic_favorite_filled),
+        // 카드 stateDescription이 즐겨찾기 상태를 제공하므로 아이콘은 중복 읽기를 피합니다.
         contentDescription = null,
         modifier = Modifier
             .align(Alignment.TopEnd)
@@ -167,6 +167,7 @@ private fun ChevronIndicator() {
 
     Icon(
         painter = painterResource(id = CommonR.drawable.ic_action_chevron_right),
+        // 카드의 click action label이 상세 이동을 제공하므로 아이콘은 중복 읽기를 피합니다.
         contentDescription = null,
         modifier = Modifier.size(size.iconSmall),
         tint = MaterialTheme.colorScheme.outlineVariant,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
@@ -21,12 +21,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.common.R as CommonR
+import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 
 @Composable
@@ -39,19 +42,27 @@ fun DisposalItemCard(
     val spacing = ItemSearchLayoutDefaults.spacing
     val stroke = ItemSearchLayoutDefaults.stroke
     val elevation = ItemSearchLayoutDefaults.elevation
+    val favoriteStateDescription =
+        stringResource(
+            if (isFavorite) {
+                R.string.item_card_favorite_saved_state
+            } else {
+                R.string.item_card_favorite_not_saved_state
+            },
+        )
+    val openActionLabel = stringResource(R.string.item_card_open_action_label)
 
     Card(
         modifier = modifier
             .fillMaxWidth()
             .semantics {
-                stateDescription =
-                    if (isFavorite) {
-                        "즐겨찾기됨"
-                    } else {
-                        "즐겨찾기 안 됨"
-                    }
+                stateDescription = favoriteStateDescription
             }
-            .clickable(onClick = onClick),
+            .clickable(
+                onClickLabel = openActionLabel,
+                role = Role.Button,
+                onClick = onClick,
+            ),
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
@@ -20,8 +20,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.foundation.layout.sizeIn
@@ -87,7 +85,7 @@ private fun QuickCategoryItem(
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
     val size = ItemSearchLayoutDefaults.size
-    val actionDescription = stringResource(R.string.quick_category_action_description, name)
+    val clickActionLabel = stringResource(R.string.quick_category_click_action)
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -98,11 +96,8 @@ private fun QuickCategoryItem(
                 minHeight = size.minTouchTarget,
             )
             .width(size.categoryCell)
-            .semantics(mergeDescendants = true) {
-                contentDescription = actionDescription
-            }
             .clickable(
-                onClickLabel = actionDescription,
+                onClickLabel = clickActionLabel,
                 role = Role.Button,
                 onClick = onClick,
             )
@@ -118,7 +113,7 @@ private fun QuickCategoryItem(
         ) {
             Icon(
                 painter = painterResource(id = category.iconResId),
-                // 부모 항목이 TalkBack 설명과 동작을 제공하므로 아이콘은 중복 읽기를 피합니다.
+                // 항목의 Text와 click action이 의미를 제공하므로 아이콘은 중복 읽기를 피합니다.
                 contentDescription = null,
                 modifier = Modifier.size(size.iconLarge),
                 tint = category.iconTint()

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
@@ -18,9 +18,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.foundation.layout.sizeIn
+import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
 
@@ -82,6 +87,7 @@ private fun QuickCategoryItem(
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
     val size = ItemSearchLayoutDefaults.size
+    val actionDescription = stringResource(R.string.quick_category_action_description, name)
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -92,7 +98,14 @@ private fun QuickCategoryItem(
                 minHeight = size.minTouchTarget,
             )
             .width(size.categoryCell)
-            .clickable(onClick = onClick)
+            .semantics(mergeDescendants = true) {
+                contentDescription = actionDescription
+            }
+            .clickable(
+                onClickLabel = actionDescription,
+                role = Role.Button,
+                onClick = onClick,
+            )
     ) {
         Box(
             modifier = Modifier

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
@@ -118,6 +118,7 @@ private fun QuickCategoryItem(
         ) {
             Icon(
                 painter = painterResource(id = category.iconResId),
+                // 부모 항목이 TalkBack 설명과 동작을 제공하므로 아이콘은 중복 읽기를 피합니다.
                 contentDescription = null,
                 modifier = Modifier.size(size.iconLarge),
                 tint = category.iconTint()

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -26,4 +26,10 @@
     <string name="item_guide_detail_favorite_added_message">즐겨찾기에 추가되었습니다</string>
     <string name="item_guide_detail_favorite_removed_message">즐겨찾기에서 제외되었습니다</string>
     <string name="back_action">뒤로가기</string>
+    <string name="favorite_add_action">즐겨찾기 추가</string>
+    <string name="favorite_remove_action">즐겨찾기 해제</string>
+    <string name="item_card_open_action_label">상세 보기</string>
+    <string name="item_card_favorite_saved_state">즐겨찾기됨</string>
+    <string name="item_card_favorite_not_saved_state">즐겨찾기 안 됨</string>
+    <string name="quick_category_action_description">%1$s 배출 방법 보기</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -31,5 +31,5 @@
     <string name="item_card_open_action_label">상세 보기</string>
     <string name="item_card_favorite_saved_state">즐겨찾기됨</string>
     <string name="item_card_favorite_not_saved_state">즐겨찾기 안 됨</string>
-    <string name="quick_category_action_description">%1$s 배출 방법 보기</string>
+    <string name="quick_category_click_action">배출 방법 보기</string>
 </resources>


### PR DESCRIPTION
## 작업 내용

품목 화면의 클릭 가능한 UI 요소에 접근성 role과 action label을 보강했습니다.

## 변경 이유

#98의 접근성 점검 항목 중 품목 담당 범위에서 먼저 확인 가능한 부분을 분리했습니다.  
품목 검색 결과 카드와 빠른 카테고리 항목은 화면상으로는 클릭 가능하지만, TalkBack 사용자가 들었을 때 어떤 동작으로 이어지는지 더 명확히 드러낼 필요가 있었습니다.

## 주요 변경 사항

- `DisposalItemCard`에 `Role.Button`과 `상세 보기` action label을 추가했습니다.
- `DisposalItemCard`의 즐겨찾기 상태 설명을 string resource로 정리했습니다.
- `QuickCategoryGrid` 항목에 `Role.Button`과 `배출 방법 보기` action label을 추가했습니다.
- Quick category 항목의 카테고리명은 자식 `Text` semantics로 제공하고, click action label은 동작만 설명하도록 정리했습니다.
- 품목 상세 즐겨찾기 버튼의 action description을 string resource로 이동했습니다.
- 뒤로가기 아이콘의 중복 semantics 지정은 제거하고 `contentDescription`만 유지했습니다.
- 부모 컴포넌트가 이미 TalkBack 의미를 제공하는 보조 아이콘에는 중복 읽기 방지 근거를 주석으로 남겼습니다.

## 확인 사항

- 부모 컴포넌트가 의미와 동작을 제공하는 보조 아이콘은 `contentDescription = null`을 유지했습니다.
- 품목 화면 내부 접근성 보강만 다룹니다.
- 지도/지역/즐겨찾기 화면 접근성은 이번 PR 범위가 아닙니다.
- 수동 TalkBack 읽기 순서와 글자 크기 확대 상태는 리뷰에서 추가 확인이 필요합니다.

## 테스트

- [x] `./gradlew.bat :app:compileDebugKotlin :presentation:compileDebugKotlin`
- [x] `./gradlew.bat :app:installDebug`

## 관련 이슈

Related #134
