### PR TITLE
[Fix] Favorites 탭 재진입 시 목록 복귀

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -107,7 +107,7 @@ fun YeogiBeoryeoNavHost(
                                 label = "저장",
                                 iconResId = CommonR.drawable.ic_favorite,
                                 selected = currentBackStackEntry.isFavoritesSelected(),
-                                onClick = { navController.navigateBottomTab(FavoritesRoute) },
+                                onClick = { navController.navigateFavoritesRoot() },
                             ),
                         ),
                 )
@@ -204,6 +204,16 @@ private fun NavBackStackEntry?.isItemGuideDetailSource(source: ItemGuideDetailSo
     this != null &&
         destination.hasRoute<ItemGuideDetailRoute>() &&
         toRoute<ItemGuideDetailRoute>().source == source
+
+private fun NavHostController.navigateFavoritesRoot() {
+    navigate(FavoritesRoute) {
+        popUpTo(graph.findStartDestination().id) {
+            saveState = true
+        }
+        launchSingleTop = true
+        restoreState = false
+    }
+}
 
 private fun FavoriteCollectionSpotMapMoveRequest.toMapRoute(): MapRoute =
     MapRoute(

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -107,7 +107,11 @@ fun YeogiBeoryeoNavHost(
                                 label = "저장",
                                 iconResId = CommonR.drawable.ic_favorite,
                                 selected = currentBackStackEntry.isFavoritesSelected(),
-                                onClick = { navController.navigateFavoritesRoot() },
+                                onClick = {
+                                    navController.navigateFavoritesRoot(
+                                        currentBackStackEntry = currentBackStackEntry,
+                                    )
+                                },
                             ),
                         ),
                 )
@@ -205,13 +209,23 @@ private fun NavBackStackEntry?.isItemGuideDetailSource(source: ItemGuideDetailSo
         destination.hasRoute<ItemGuideDetailRoute>() &&
         toRoute<ItemGuideDetailRoute>().source == source
 
-private fun NavHostController.navigateFavoritesRoot() {
-    navigate(FavoritesRoute) {
-        popUpTo(graph.findStartDestination().id) {
-            saveState = true
+private fun NavHostController.navigateFavoritesRoot(
+    currentBackStackEntry: NavBackStackEntry?,
+) {
+    when {
+        currentBackStackEntry?.destination?.hasRoute<FavoritesRoute>() == true -> return
+        currentBackStackEntry.isItemGuideDetailSource(ItemGuideDetailSource.FAVORITES) -> {
+            popBackStack<FavoritesRoute>(inclusive = false)
         }
-        launchSingleTop = true
-        restoreState = false
+        else -> {
+            navigate(FavoritesRoute) {
+                popUpTo(graph.findStartDestination().id) {
+                    saveState = true
+                }
+                launchSingleTop = true
+                restoreState = false
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## 작업 내용

Favorites 하단 탭 재진입 시 이전 품목 상세 route가 복원되지 않고 Favorites 목록으로 진입하도록 수정했습니다.

## 변경 이유

Favorites 품목 탭에서 저장된 품목을 선택해 상세 화면으로 이동한 뒤, 다른 하단 탭을 거쳐 다시 Favorites 탭을 선택하면 이전 품목 상세 화면이 복원되는 문제가 있었습니다.

하단 탭을 다시 선택하는 사용자는 이전 상세 화면보다 해당 탭의 루트 목록으로 돌아가는 흐름을 기대하기 쉽습니다.  
그래서 공통 `navigateBottomTab()` 정책은 유지하고, Favorites 탭 선택에만 root 진입 정책을 적용했습니다.

## 주요 변경 사항

- Favorites 탭 클릭 시 현재 위치에 따라 동작을 분기했습니다.
- 이미 Favorites 목록 루트에 있으면 no-op 처리합니다.
- Favorites 출처의 품목 상세 화면에 있으면 새 navigate 대신 `popBackStack<FavoritesRoute>(inclusive = false)`로 목록에 복귀합니다.
- 다른 하단 탭에서 Favorites로 진입할 때만 `saveState = true`, `restoreState = false` navigation을 실행합니다.
- 다른 하단 탭의 state 복원 정책은 변경하지 않았습니다.

## 확인 사항

- Favorites 목록 루트에서 저장 탭을 다시 눌러도 불필요한 재탐색을 하지 않습니다.
- Favorites 품목 상세에서 저장 탭을 누르면 Favorites 목록으로 돌아갑니다.
- 다른 하단 탭을 거쳐 Favorites 탭을 다시 선택하면 Favorites 목록으로 진입합니다.
- 즐겨찾기 저장/삭제 로직은 변경하지 않았습니다.

## 테스트

- [x] `./gradlew.bat :app:compileDebugKotlin`
- [x] `./gradlew.bat :app:installDebug`

## 관련 이슈

Related #136
