### PR TITLE
feat: 지역 가이드 즐겨찾기 저장 및 재진입 연결

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
@@ -18,6 +18,7 @@ data class MapRoute(
 data class RegionalGuideRoute(
     val initialKeyword: String? = null,
     val initialAddress: String? = null,
+    val initialFavoriteTargetId: String? = null,
 )
 
 @Serializable

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -128,6 +128,7 @@ fun YeogiBeoryeoNavHost(
                 RegionalGuideScreenRoute(
                     initialKeyword = route.initialKeyword,
                     initialAddress = route.initialAddress,
+                    initialFavoriteTargetId = route.initialFavoriteTargetId,
                 )
             }
 
@@ -149,6 +150,11 @@ fun YeogiBeoryeoNavHost(
                             launchSingleTop = true
                             restoreState = false
                         }
+                    },
+                    onRegionalGuideClick = { targetId ->
+                        navController.navigate(
+                            RegionalGuideRoute(initialFavoriteTargetId = targetId),
+                        )
                     },
                 )
             }

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -86,25 +86,51 @@ fun YeogiBeoryeoNavHost(
                                 label = "품목",
                                 iconResId = CommonR.drawable.ic_symbol_recycle,
                                 selected = currentBackStackEntry.isItemSearchSelected(),
-                                onClick = { navController.navigateBottomTab(ItemSearchRoute()) },
+                                onClick = {
+                                    navController.navigateBottomTabClearingFavoriteReentry(
+                                        currentBackStackEntry = currentBackStackEntry,
+                                        route = ItemSearchRoute(),
+                                    )
+                                },
                             ),
                             BottomNavigationItem(
                                 label = "지도",
                                 iconResId = AppR.drawable.ic_navigation_map,
                                 selected = currentDestination?.hasRoute<MapRoute>() == true,
-                                onClick = { navController.navigateBottomTab(MapRoute()) },
+                                onClick = {
+                                    navController.navigateBottomTabClearingFavoriteReentry(
+                                        currentBackStackEntry = currentBackStackEntry,
+                                        route = MapRoute(),
+                                    )
+                                },
                             ),
                             BottomNavigationItem(
                                 label = "안내",
                                 iconResId = AppR.drawable.ic_navigation_guide,
-                                selected = currentDestination?.hasRoute<RegionalGuideRoute>() == true,
-                                onClick = { navController.navigateBottomTab(RegionalGuideRoute()) },
+                                selected = currentBackStackEntry.isRegionalGuideSelected(),
+                                onClick = {
+                                    navController.navigateBottomTabClearingFavoriteReentry(
+                                        currentBackStackEntry = currentBackStackEntry,
+                                        route = RegionalGuideRoute(),
+                                    )
+                                },
                             ),
                             BottomNavigationItem(
                                 label = "저장",
                                 iconResId = CommonR.drawable.ic_favorite,
                                 selected = currentBackStackEntry.isFavoritesSelected(),
-                                onClick = { navController.navigateBottomTab(FavoritesRoute) },
+                                onClick = {
+                                    if (currentBackStackEntry.isFavoriteRegionalGuideSelected()) {
+                                        navController.navigate(FavoritesRoute) {
+                                            popUpTo<FavoritesRoute> {
+                                                inclusive = false
+                                            }
+                                            launchSingleTop = true
+                                        }
+                                    } else {
+                                        navController.navigateBottomTab(FavoritesRoute)
+                                    }
+                                },
                             ),
                         ),
                 )
@@ -196,7 +222,31 @@ private fun NavBackStackEntry?.isItemSearchSelected(): Boolean =
 
 private fun NavBackStackEntry?.isFavoritesSelected(): Boolean =
     this?.destination?.hasRoute<FavoritesRoute>() == true ||
-        isItemGuideDetailSource(ItemGuideDetailSource.FAVORITES)
+        isItemGuideDetailSource(ItemGuideDetailSource.FAVORITES) ||
+        isFavoriteRegionalGuideSelected()
+
+private fun NavBackStackEntry?.isRegionalGuideSelected(): Boolean =
+    this?.destination?.hasRoute<RegionalGuideRoute>() == true &&
+        !isFavoriteRegionalGuideSelected()
+
+private fun NavBackStackEntry?.isFavoriteRegionalGuideSelected(): Boolean =
+    this != null &&
+        destination.hasRoute<RegionalGuideRoute>() &&
+        toRoute<RegionalGuideRoute>().isFavoriteReentryRoute()
+
+internal fun RegionalGuideRoute.isFavoriteReentryRoute(): Boolean =
+    !initialFavoriteTargetId.isNullOrBlank()
+
+private inline fun <reified T : Any> NavHostController.navigateBottomTabClearingFavoriteReentry(
+    currentBackStackEntry: NavBackStackEntry?,
+    route: T,
+) {
+    if (currentBackStackEntry.isFavoriteRegionalGuideSelected()) {
+        popBackStack<FavoritesRoute>(inclusive = false)
+    }
+
+    navigateBottomTab(route)
+}
 
 private fun NavBackStackEntry?.isItemGuideDetailSource(source: ItemGuideDetailSource): Boolean =
     this != null &&

--- a/app/src/test/java/com/team/yeogibeoryeo/navigation/RegionalGuideRouteNavigationPolicyTest.kt
+++ b/app/src/test/java/com/team/yeogibeoryeo/navigation/RegionalGuideRouteNavigationPolicyTest.kt
@@ -1,0 +1,25 @@
+package com.team.yeogibeoryeo.navigation
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RegionalGuideRouteNavigationPolicyTest {
+    @Test
+    fun `regional guide route without favorite target is guide tab route`() {
+        assertFalse(RegionalGuideRoute().isFavoriteReentryRoute())
+    }
+
+    @Test
+    fun `regional guide route with favorite target is favorites reentry route`() {
+        assertTrue(
+            RegionalGuideRoute(initialFavoriteTargetId = "regional-guide-v1|4:Sido")
+                .isFavoriteReentryRoute(),
+        )
+    }
+
+    @Test
+    fun `blank favorite target is not favorites reentry route`() {
+        assertFalse(RegionalGuideRoute(initialFavoriteTargetId = " ").isFavoriteReentryRoute())
+    }
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/di/FavoriteDataModule.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/di/FavoriteDataModule.kt
@@ -7,12 +7,17 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import com.team.yeogibeoryeo.data.favorite.local.CollectionSpotFavoriteSnapshotDao
 import com.team.yeogibeoryeo.data.favorite.local.FavoriteDao
 import com.team.yeogibeoryeo.data.favorite.local.FavoriteDatabase
+import com.team.yeogibeoryeo.data.favorite.local.RegionalGuideFavoriteSnapshotDao
 import com.team.yeogibeoryeo.data.favorite.repository.CollectionSpotFavoriteSnapshotRepositoryImpl
 import com.team.yeogibeoryeo.data.favorite.repository.CollectionSpotFavoriteRepositoryImpl
 import com.team.yeogibeoryeo.data.favorite.repository.FavoriteRepositoryImpl
+import com.team.yeogibeoryeo.data.favorite.repository.RegionalGuideFavoriteRepositoryImpl
+import com.team.yeogibeoryeo.data.favorite.repository.RegionalGuideFavoriteSnapshotRepositoryImpl
 import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteRepository
 import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
 import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteSnapshotRepository
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -35,6 +40,7 @@ object FavoriteDatabaseModule {
             "yeogi_beoryeo_favorites.db",
         )
             .addMigrations(FAVORITE_DATABASE_MIGRATION_1_2)
+            .addMigrations(FAVORITE_DATABASE_MIGRATION_2_3)
             .build()
 
     @Provides
@@ -46,6 +52,12 @@ object FavoriteDatabaseModule {
     fun provideCollectionSpotFavoriteSnapshotDao(
         database: FavoriteDatabase,
     ): CollectionSpotFavoriteSnapshotDao = database.collectionSpotFavoriteSnapshotDao()
+
+    @Provides
+    @Singleton
+    fun provideRegionalGuideFavoriteSnapshotDao(
+        database: FavoriteDatabase,
+    ): RegionalGuideFavoriteSnapshotDao = database.regionalGuideFavoriteSnapshotDao()
 
     private val FAVORITE_DATABASE_MIGRATION_1_2 =
         object : Migration(1, 2) {
@@ -60,6 +72,25 @@ object FavoriteDatabaseModule {
                         detailLocation TEXT,
                         latitude REAL,
                         longitude REAL,
+                        PRIMARY KEY(targetId)
+                    )
+                    """.trimIndent(),
+                )
+            }
+        }
+
+    private val FAVORITE_DATABASE_MIGRATION_2_3 =
+        object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS regional_guide_favorite_snapshots (
+                        targetId TEXT NOT NULL,
+                        sido TEXT,
+                        sigungu TEXT,
+                        eupmyeondong TEXT,
+                        targetRegionName TEXT,
+                        managementZoneName TEXT,
                         PRIMARY KEY(targetId)
                     )
                     """.trimIndent(),
@@ -86,4 +117,16 @@ abstract class FavoriteBindModule {
     abstract fun bindCollectionSpotFavoriteRepository(
         repository: CollectionSpotFavoriteRepositoryImpl,
     ): CollectionSpotFavoriteRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindRegionalGuideFavoriteSnapshotRepository(
+        repository: RegionalGuideFavoriteSnapshotRepositoryImpl,
+    ): RegionalGuideFavoriteSnapshotRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindRegionalGuideFavoriteRepository(
+        repository: RegionalGuideFavoriteRepositoryImpl,
+    ): RegionalGuideFavoriteRepository
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/FavoriteDatabase.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/FavoriteDatabase.kt
@@ -7,12 +7,15 @@ import androidx.room.RoomDatabase
     entities = [
         FavoriteEntity::class,
         CollectionSpotFavoriteSnapshotEntity::class,
+        RegionalGuideFavoriteSnapshotEntity::class,
     ],
-    version = 2,
+    version = 3,
     exportSchema = false,
 )
 abstract class FavoriteDatabase : RoomDatabase() {
     abstract fun favoriteDao(): FavoriteDao
 
     abstract fun collectionSpotFavoriteSnapshotDao(): CollectionSpotFavoriteSnapshotDao
+
+    abstract fun regionalGuideFavoriteSnapshotDao(): RegionalGuideFavoriteSnapshotDao
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/RegionalGuideFavoriteSnapshotDao.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/RegionalGuideFavoriteSnapshotDao.kt
@@ -1,0 +1,21 @@
+package com.team.yeogibeoryeo.data.favorite.local
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface RegionalGuideFavoriteSnapshotDao {
+    @Query("SELECT * FROM regional_guide_favorite_snapshots")
+    fun observeSnapshots(): Flow<List<RegionalGuideFavoriteSnapshotEntity>>
+
+    @Query("SELECT * FROM regional_guide_favorite_snapshots WHERE targetId = :targetId")
+    suspend fun getSnapshot(targetId: String): RegionalGuideFavoriteSnapshotEntity?
+
+    @Upsert
+    suspend fun upsertSnapshot(entity: RegionalGuideFavoriteSnapshotEntity)
+
+    @Query("DELETE FROM regional_guide_favorite_snapshots WHERE targetId = :targetId")
+    suspend fun deleteSnapshot(targetId: String)
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/RegionalGuideFavoriteSnapshotEntity.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/local/RegionalGuideFavoriteSnapshotEntity.kt
@@ -1,0 +1,14 @@
+package com.team.yeogibeoryeo.data.favorite.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "regional_guide_favorite_snapshots")
+data class RegionalGuideFavoriteSnapshotEntity(
+    @PrimaryKey val targetId: String,
+    val sido: String?,
+    val sigungu: String?,
+    val eupmyeondong: String?,
+    val targetRegionName: String?,
+    val managementZoneName: String?,
+)

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/mapper/RegionalGuideFavoriteSnapshotMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/mapper/RegionalGuideFavoriteSnapshotMapper.kt
@@ -1,0 +1,32 @@
+package com.team.yeogibeoryeo.data.favorite.mapper
+
+import com.team.yeogibeoryeo.data.favorite.local.RegionalGuideFavoriteSnapshotEntity
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteKey
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.region.model.Region
+
+fun RegionalGuideFavoriteSnapshot.toEntity(): RegionalGuideFavoriteSnapshotEntity =
+    RegionalGuideFavoriteSnapshotEntity(
+        targetId = targetId,
+        sido = region.sido,
+        sigungu = region.sigungu,
+        eupmyeondong = region.eupmyeondong,
+        targetRegionName = targetRegionName,
+        managementZoneName = managementZoneName,
+    )
+
+fun RegionalGuideFavoriteSnapshotEntity.toDomain(): RegionalGuideFavoriteSnapshot? {
+    val key = RegionalGuideFavoriteKey.decodeOrNull(targetId) ?: return null
+
+    return RegionalGuideFavoriteSnapshot(
+        targetId = targetId,
+        region =
+            Region(
+                sido = sido ?: key.sido,
+                sigungu = sigungu ?: key.sigungu,
+                eupmyeondong = eupmyeondong ?: key.eupmyeondong,
+            ),
+        targetRegionName = targetRegionName ?: key.targetRegionName,
+        managementZoneName = managementZoneName,
+    )
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/repository/RegionalGuideFavoriteRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/repository/RegionalGuideFavoriteRepositoryImpl.kt
@@ -1,0 +1,48 @@
+package com.team.yeogibeoryeo.data.favorite.repository
+
+import androidx.room.withTransaction
+import com.team.yeogibeoryeo.data.favorite.local.FavoriteDatabase
+import com.team.yeogibeoryeo.data.favorite.mapper.toEntity
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteRepository
+import javax.inject.Inject
+
+class RegionalGuideFavoriteRepositoryImpl
+    @Inject
+    constructor(
+        private val database: FavoriteDatabase,
+    ) : RegionalGuideFavoriteRepository {
+        override suspend fun toggleFavorite(snapshot: RegionalGuideFavoriteSnapshot): Boolean =
+            database.withTransaction {
+                val favoriteDao = database.favoriteDao()
+                val snapshotDao = database.regionalGuideFavoriteSnapshotDao()
+                val favorite =
+                    Favorite(
+                        type = FavoriteTargetType.REGIONAL_GUIDE,
+                        targetId = snapshot.targetId,
+                        savedAtMillis = System.currentTimeMillis(),
+                    )
+
+                if (favoriteDao.isFavorite(favorite.type.name, favorite.targetId)) {
+                    favoriteDao.deleteFavorite(favorite.type.name, favorite.targetId)
+                    snapshotDao.deleteSnapshot(snapshot.targetId)
+                    false
+                } else {
+                    favoriteDao.upsertFavorite(favorite.toEntity())
+                    snapshotDao.upsertSnapshot(snapshot.toEntity())
+                    true
+                }
+            }
+
+        override suspend fun removeFavorite(targetId: String) {
+            database.withTransaction {
+                database.favoriteDao().deleteFavorite(
+                    type = FavoriteTargetType.REGIONAL_GUIDE.name,
+                    targetId = targetId,
+                )
+                database.regionalGuideFavoriteSnapshotDao().deleteSnapshot(targetId)
+            }
+        }
+    }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/repository/RegionalGuideFavoriteSnapshotRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/repository/RegionalGuideFavoriteSnapshotRepositoryImpl.kt
@@ -1,0 +1,31 @@
+package com.team.yeogibeoryeo.data.favorite.repository
+
+import com.team.yeogibeoryeo.data.favorite.local.RegionalGuideFavoriteSnapshotDao
+import com.team.yeogibeoryeo.data.favorite.mapper.toDomain
+import com.team.yeogibeoryeo.data.favorite.mapper.toEntity
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteSnapshotRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class RegionalGuideFavoriteSnapshotRepositoryImpl
+    @Inject
+    constructor(
+        private val snapshotDao: RegionalGuideFavoriteSnapshotDao,
+    ) : RegionalGuideFavoriteSnapshotRepository {
+        override fun observeSnapshots(): Flow<List<RegionalGuideFavoriteSnapshot>> =
+            snapshotDao.observeSnapshots()
+                .map { entities -> entities.mapNotNull { entity -> entity.toDomain() } }
+
+        override suspend fun getSnapshot(targetId: String): RegionalGuideFavoriteSnapshot? =
+            snapshotDao.getSnapshot(targetId)?.toDomain()
+
+        override suspend fun upsertSnapshot(snapshot: RegionalGuideFavoriteSnapshot) {
+            snapshotDao.upsertSnapshot(snapshot.toEntity())
+        }
+
+        override suspend fun deleteSnapshot(targetId: String) {
+            snapshotDao.deleteSnapshot(targetId)
+        }
+    }

--- a/data/src/test/java/com/team/yeogibeoryeo/data/favorite/mapper/RegionalGuideFavoriteSnapshotMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/favorite/mapper/RegionalGuideFavoriteSnapshotMapperTest.kt
@@ -1,0 +1,49 @@
+package com.team.yeogibeoryeo.data.favorite.mapper
+
+import com.team.yeogibeoryeo.data.favorite.local.RegionalGuideFavoriteSnapshotEntity
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteKey
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.region.model.Region
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RegionalGuideFavoriteSnapshotMapperTest {
+    @Test
+    fun `snapshot maps to entity and back`() {
+        val snapshot =
+            RegionalGuideFavoriteSnapshot(
+                targetId =
+                    RegionalGuideFavoriteKey(
+                        sido = "인천광역시",
+                        sigungu = "중구",
+                        eupmyeondong = "신흥동",
+                        targetRegionName = "신흥동+율목동",
+                    ).encode(),
+                region = Region(
+                    sido = "인천광역시",
+                    sigungu = "중구",
+                    eupmyeondong = "신흥동",
+                ),
+                targetRegionName = "신흥동+율목동",
+                managementZoneName = "중구 관리구역",
+            )
+
+        assertEquals(snapshot, snapshot.toEntity().toDomain())
+    }
+
+    @Test
+    fun `invalid target id maps to null`() {
+        val entity =
+            RegionalGuideFavoriteSnapshotEntity(
+                targetId = "broken-target-id",
+                sido = "인천광역시",
+                sigungu = "중구",
+                eupmyeondong = null,
+                targetRegionName = "신흥동+율목동",
+                managementZoneName = "중구 관리구역",
+            )
+
+        assertNull(entity.toDomain())
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/RegionalGuideFavoriteKey.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/RegionalGuideFavoriteKey.kt
@@ -1,0 +1,88 @@
+package com.team.yeogibeoryeo.domain.favorite.model
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+
+data class RegionalGuideFavoriteKey(
+    val sido: String?,
+    val sigungu: String?,
+    val eupmyeondong: String?,
+    val targetRegionName: String?,
+) {
+    fun toRegion(): Region =
+        Region(
+            sido = sido,
+            sigungu = sigungu,
+            eupmyeondong = eupmyeondong,
+        )
+
+    fun encode(): String =
+        buildString {
+            append(VERSION)
+            append(FIELD_DELIMITER)
+            appendEncoded(sido)
+            appendEncoded(sigungu)
+            appendEncoded(eupmyeondong)
+            appendEncoded(targetRegionName)
+        }
+
+    companion object {
+        private const val VERSION = "regional-guide-v1"
+        private const val FIELD_DELIMITER = '|'
+        private const val NULL_LENGTH = -1
+
+        fun decodeOrNull(value: String): RegionalGuideFavoriteKey? {
+            if (!value.startsWith("$VERSION$FIELD_DELIMITER")) return null
+
+            val payload = value.substringAfter(FIELD_DELIMITER)
+            val fields = mutableListOf<String?>()
+            var cursor = 0
+
+            repeat(KEY_FIELD_COUNT) {
+                val delimiterIndex = payload.indexOf(':', startIndex = cursor)
+                if (delimiterIndex == -1) return null
+
+                val length = payload
+                    .substring(startIndex = cursor, endIndex = delimiterIndex)
+                    .toIntOrNull()
+                    ?: return null
+
+                cursor = delimiterIndex + 1
+
+                if (length == NULL_LENGTH) {
+                    fields += null
+                    return@repeat
+                }
+
+                if (length < 0 || cursor + length > payload.length) return null
+
+                fields += payload.substring(startIndex = cursor, endIndex = cursor + length)
+                cursor += length
+            }
+
+            if (cursor != payload.length) return null
+
+            return RegionalGuideFavoriteKey(
+                sido = fields[0],
+                sigungu = fields[1],
+                eupmyeondong = fields[2],
+                targetRegionName = fields[3],
+            )
+                .takeIf { key -> !key.sido.isNullOrBlank() || !key.sigungu.isNullOrBlank() }
+        }
+
+        private const val KEY_FIELD_COUNT = 4
+
+        private fun StringBuilder.appendEncoded(value: String?) {
+            val normalizedValue = value?.trim()?.takeIf { it.isNotBlank() }
+
+            if (normalizedValue == null) {
+                append(NULL_LENGTH)
+                append(':')
+            } else {
+                append(normalizedValue.length)
+                append(':')
+                append(normalizedValue)
+            }
+        }
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/RegionalGuideFavoriteSnapshot.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/RegionalGuideFavoriteSnapshot.kt
@@ -1,0 +1,31 @@
+package com.team.yeogibeoryeo.domain.favorite.model
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
+
+data class RegionalGuideFavoriteSnapshot(
+    val targetId: String,
+    val region: Region,
+    val targetRegionName: String?,
+    val managementZoneName: String?,
+) {
+    val key: RegionalGuideFavoriteKey?
+        get() = RegionalGuideFavoriteKey.decodeOrNull(targetId)
+}
+
+fun RegionalDisposalGuide.toFavoriteSnapshot(): RegionalGuideFavoriteSnapshot {
+    val key =
+        RegionalGuideFavoriteKey(
+            sido = region.sido,
+            sigungu = region.sigungu,
+            eupmyeondong = region.eupmyeondong,
+            targetRegionName = targetRegionName,
+        )
+
+    return RegionalGuideFavoriteSnapshot(
+        targetId = key.encode(),
+        region = region,
+        targetRegionName = targetRegionName?.trim()?.takeIf { it.isNotBlank() },
+        managementZoneName = managementZoneName?.trim()?.takeIf { it.isNotBlank() },
+    )
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/repository/RegionalGuideFavoriteRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/repository/RegionalGuideFavoriteRepository.kt
@@ -1,0 +1,9 @@
+package com.team.yeogibeoryeo.domain.favorite.repository
+
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
+
+interface RegionalGuideFavoriteRepository {
+    suspend fun toggleFavorite(snapshot: RegionalGuideFavoriteSnapshot): Boolean
+
+    suspend fun removeFavorite(targetId: String)
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/repository/RegionalGuideFavoriteSnapshotRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/repository/RegionalGuideFavoriteSnapshotRepository.kt
@@ -1,0 +1,14 @@
+package com.team.yeogibeoryeo.domain.favorite.repository
+
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
+import kotlinx.coroutines.flow.Flow
+
+interface RegionalGuideFavoriteSnapshotRepository {
+    fun observeSnapshots(): Flow<List<RegionalGuideFavoriteSnapshot>>
+
+    suspend fun getSnapshot(targetId: String): RegionalGuideFavoriteSnapshot?
+
+    suspend fun upsertSnapshot(snapshot: RegionalGuideFavoriteSnapshot)
+
+    suspend fun deleteSnapshot(targetId: String)
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/GetRegionalGuideFavoriteSnapshotUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/GetRegionalGuideFavoriteSnapshotUseCase.kt
@@ -1,0 +1,12 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteSnapshotRepository
+import javax.inject.Inject
+
+class GetRegionalGuideFavoriteSnapshotUseCase
+    @Inject
+    constructor(
+        private val repository: RegionalGuideFavoriteSnapshotRepository,
+    ) {
+        suspend operator fun invoke(targetId: String) = repository.getSnapshot(targetId)
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ObserveRegionalGuideFavoriteSnapshotsUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ObserveRegionalGuideFavoriteSnapshotsUseCase.kt
@@ -1,0 +1,12 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteSnapshotRepository
+import javax.inject.Inject
+
+class ObserveRegionalGuideFavoriteSnapshotsUseCase
+    @Inject
+    constructor(
+        private val repository: RegionalGuideFavoriteSnapshotRepository,
+    ) {
+        operator fun invoke() = repository.observeSnapshots()
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/RemoveRegionalGuideFavoriteUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/RemoveRegionalGuideFavoriteUseCase.kt
@@ -1,0 +1,14 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteRepository
+import javax.inject.Inject
+
+class RemoveRegionalGuideFavoriteUseCase
+    @Inject
+    constructor(
+        private val repository: RegionalGuideFavoriteRepository,
+    ) {
+        suspend operator fun invoke(targetId: String) {
+            repository.removeFavorite(targetId)
+        }
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ToggleRegionalGuideFavoriteUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ToggleRegionalGuideFavoriteUseCase.kt
@@ -1,0 +1,14 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteRepository
+import javax.inject.Inject
+
+class ToggleRegionalGuideFavoriteUseCase
+    @Inject
+    constructor(
+        private val repository: RegionalGuideFavoriteRepository,
+    ) {
+        suspend operator fun invoke(snapshot: RegionalGuideFavoriteSnapshot): Boolean =
+            repository.toggleFavorite(snapshot)
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/GetRegionalDisposalGuideUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/GetRegionalDisposalGuideUseCase.kt
@@ -12,7 +12,10 @@ class GetRegionalDisposalGuideUseCase @Inject constructor(
     private val normalizeRegionalGuideQueryUseCase: NormalizeRegionalGuideQueryUseCase,
     private val selectRegionalGuideCandidateUseCase: SelectRegionalGuideCandidateUseCase
 ) {
-    suspend operator fun invoke(region: Region): RegionalGuideLookupResult {
+    suspend operator fun invoke(
+        region: Region,
+        preferredTargetRegionName: String? = null
+    ): RegionalGuideLookupResult {
         val query = normalizeRegionalGuideQueryUseCase(region)
             ?: return RegionalGuideLookupResult.NotFound
 
@@ -26,7 +29,8 @@ class GetRegionalDisposalGuideUseCase @Inject constructor(
 
         return selectRegionalGuideCandidateUseCase(
             candidates = candidates,
-            query = query
+            query = query,
+            preferredTargetRegionName = preferredTargetRegionName
         )
     }
 

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
@@ -10,7 +10,8 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
 
     operator fun invoke(
         candidates: List<RegionalDisposalGuide>,
-        query: RegionalGuideQuery
+        query: RegionalGuideQuery,
+        preferredTargetRegionName: String? = null,
     ): RegionalGuideLookupResult {
         if (candidates.isEmpty()) return RegionalGuideLookupResult.NotFound
 
@@ -27,6 +28,23 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
                 guide = filteredCandidates.first().withDisplayRegion(query.displayRegion)
             )
         }
+
+        preferredTargetRegionName
+            ?.trim()
+            ?.takeIf { targetRegionName -> targetRegionName.isNotBlank() }
+            ?.let { targetRegionName ->
+                val preferredGuide = filteredCandidates.firstOrNull { guide ->
+                    guide.targetRegionName?.trim() == targetRegionName
+                }
+
+                return if (preferredGuide != null) {
+                    RegionalGuideLookupResult.Success(
+                        guide = preferredGuide.withDisplayRegion(query.displayRegion)
+                    )
+                } else {
+                    RegionalGuideLookupResult.CandidateNotFound
+                }
+            }
 
         filteredCandidates.selectSingleOverallCandidate(query.sigunguQuery)?.let { guide ->
             return RegionalGuideLookupResult.Success(

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/model/RegionalGuideFavoriteKeyTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/model/RegionalGuideFavoriteKeyTest.kt
@@ -1,0 +1,41 @@
+package com.team.yeogibeoryeo.domain.favorite.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class RegionalGuideFavoriteKeyTest {
+    @Test
+    fun `encode and decode preserves region and target region`() {
+        val key =
+            RegionalGuideFavoriteKey(
+                sido = "인천광역시",
+                sigungu = "중구",
+                eupmyeondong = "신흥동",
+                targetRegionName = "신흥동+율목동",
+            )
+
+        assertEquals(key, RegionalGuideFavoriteKey.decodeOrNull(key.encode()))
+    }
+
+    @Test
+    fun `target region separates multiple guide zones in same region`() {
+        val baseRegion =
+            RegionalGuideFavoriteKey(
+                sido = "인천광역시",
+                sigungu = "중구",
+                eupmyeondong = null,
+                targetRegionName = "신흥동+율목동",
+            )
+        val otherZone = baseRegion.copy(targetRegionName = "신포동+연안동")
+
+        assertNotEquals(baseRegion.encode(), otherZone.encode())
+    }
+
+    @Test
+    fun `invalid key returns null instead of throwing`() {
+        assertNull(RegionalGuideFavoriteKey.decodeOrNull("broken-target-id"))
+        assertNull(RegionalGuideFavoriteKey.decodeOrNull("regional-guide-v1|4:Sido"))
+    }
+}

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
@@ -297,6 +297,42 @@ class SelectRegionalGuideCandidateUseCaseTest {
         assertEquals("신흥동+율목동", guide.targetRegionName)
     }
 
+    @Test
+    fun `preferred 대상지역이 있으면 해당 후보를 우선 선택한다`() {
+        val result = useCase(
+            candidates = listOf(
+                guide(sido = "인천광역시", sigungu = "중구", targetRegionName = "신흥동+율목동"),
+                guide(sido = "인천광역시", sigungu = "중구", targetRegionName = "신포동+연안동")
+            ),
+            query = query(
+                displayRegion = Region(sido = "인천광역시", sigungu = "중구"),
+                sigunguQuery = "중구"
+            ),
+            preferredTargetRegionName = "신포동+연안동"
+        )
+
+        val guide = (result as RegionalGuideLookupResult.Success).guide
+
+        assertEquals("신포동+연안동", guide.targetRegionName)
+    }
+
+    @Test
+    fun `preferred 대상지역이 후보에 없으면 임의 후보를 선택하지 않는다`() {
+        val result = useCase(
+            candidates = listOf(
+                guide(sido = "인천광역시", sigungu = "중구", targetRegionName = "신흥동+율목동"),
+                guide(sido = "인천광역시", sigungu = "중구", targetRegionName = "신포동+연안동")
+            ),
+            query = query(
+                displayRegion = Region(sido = "인천광역시", sigungu = "중구"),
+                sigunguQuery = "중구"
+            ),
+            preferredTargetRegionName = "사라진 권역"
+        )
+
+        assertEquals(RegionalGuideLookupResult.CandidateNotFound, result)
+    }
+
     private fun query(
         displayRegion: Region,
         sigunguQuery: String

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesRoute.kt
@@ -11,6 +11,7 @@ import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteCollectionSpot
 fun FavoritesRoute(
     onItemGuideClick: (String) -> Unit,
     onCollectionSpotClick: (FavoriteCollectionSpotMapMoveRequest) -> Unit,
+    onRegionalGuideClick: (String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: FavoritesViewModel = hiltViewModel(),
 ) {
@@ -21,8 +22,9 @@ fun FavoritesRoute(
         onTabClick = viewModel::selectTab,
         onItemGuideClick = onItemGuideClick,
         onCollectionSpotClick = onCollectionSpotClick,
-        onRegionalGuideClick = {},
+        onRegionalGuideClick = onRegionalGuideClick,
         onCollectionSpotFavoriteRemoveClick = viewModel::removeCollectionSpotFavorite,
+        onRegionalGuideFavoriteRemoveClick = viewModel::removeRegionalGuideFavorite,
         modifier = modifier,
     )
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreen.kt
@@ -32,6 +32,7 @@ fun FavoritesScreen(
     onCollectionSpotClick: (FavoriteCollectionSpotMapMoveRequest) -> Unit,
     onRegionalGuideClick: (String) -> Unit,
     onCollectionSpotFavoriteRemoveClick: (String) -> Unit,
+    onRegionalGuideFavoriteRemoveClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(
@@ -107,8 +108,11 @@ fun FavoritesScreen(
                                 { onCollectionSpotFavoriteRemoveClick(favorite.targetId) }
                             }
 
-                            FavoriteTargetType.ITEM_GUIDE,
-                            FavoriteTargetType.REGIONAL_GUIDE -> null
+                            FavoriteTargetType.REGIONAL_GUIDE -> {
+                                { onRegionalGuideFavoriteRemoveClick(favorite.targetId) }
+                            }
+
+                            FavoriteTargetType.ITEM_GUIDE -> null
                         },
                     )
                 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreenPreview.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesScreenPreview.kt
@@ -19,6 +19,7 @@ private fun FavoritesScreenLoadingPreview() {
             onCollectionSpotClick = {},
             onRegionalGuideClick = {},
             onCollectionSpotFavoriteRemoveClick = {},
+            onRegionalGuideFavoriteRemoveClick = {},
         )
     }
 }
@@ -34,6 +35,7 @@ private fun FavoritesScreenEmptyPreview() {
             onCollectionSpotClick = {},
             onRegionalGuideClick = {},
             onCollectionSpotFavoriteRemoveClick = {},
+            onRegionalGuideFavoriteRemoveClick = {},
         )
     }
 }
@@ -49,6 +51,7 @@ private fun FavoritesScreenSpotEmptyPreview() {
             onCollectionSpotClick = {},
             onRegionalGuideClick = {},
             onCollectionSpotFavoriteRemoveClick = {},
+            onRegionalGuideFavoriteRemoveClick = {},
         )
     }
 }
@@ -87,6 +90,7 @@ private fun FavoritesScreenListPreview() {
             onCollectionSpotClick = {},
             onRegionalGuideClick = {},
             onCollectionSpotFavoriteRemoveClick = {},
+            onRegionalGuideFavoriteRemoveClick = {},
         )
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.viewModelScope
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveCollectionSpotFavoriteSnapshotsUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveRegionalGuideFavoriteSnapshotsUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.RemoveCollectionSpotFavoriteUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.RemoveRegionalGuideFavoriteUseCase
 import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteCollectionSpotUiMapper
 import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteItemGuideUiMapper
 import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteRegionalGuideUiMapper
@@ -25,7 +27,9 @@ class FavoritesViewModel
     constructor(
         observeFavoritesUseCase: ObserveFavoritesUseCase,
         observeCollectionSpotFavoriteSnapshotsUseCase: ObserveCollectionSpotFavoriteSnapshotsUseCase,
+        observeRegionalGuideFavoriteSnapshotsUseCase: ObserveRegionalGuideFavoriteSnapshotsUseCase,
         private val removeCollectionSpotFavoriteUseCase: RemoveCollectionSpotFavoriteUseCase,
+        private val removeRegionalGuideFavoriteUseCase: RemoveRegionalGuideFavoriteUseCase,
         private val itemGuideUiMapper: FavoriteItemGuideUiMapper,
         private val collectionSpotUiMapper: FavoriteCollectionSpotUiMapper,
         private val regionalGuideUiMapper: FavoriteRegionalGuideUiMapper,
@@ -37,7 +41,8 @@ class FavoritesViewModel
                 selectedTab,
                 observeFavoritesUseCase(),
                 observeCollectionSpotFavoriteSnapshotsUseCase(),
-            ) { selectedTab, favorites, collectionSpotSnapshots ->
+                observeRegionalGuideFavoriteSnapshotsUseCase(),
+            ) { selectedTab, favorites, collectionSpotSnapshots, regionalGuideSnapshots ->
                 val itemGuideFavorites =
                     favorites
                         .filter { it.type == FavoriteTargetType.ITEM_GUIDE }
@@ -53,10 +58,15 @@ class FavoritesViewModel
                             collectionSpotSnapshotsById[favorite.targetId]
                                 ?.let { snapshot -> collectionSpotUiMapper.map(snapshot) }
                         }
+                val regionalGuideSnapshotsById =
+                    regionalGuideSnapshots.associateBy { snapshot -> snapshot.targetId }
                 val regionalGuideFavorites =
                     favorites
                         .filter { it.type == FavoriteTargetType.REGIONAL_GUIDE }
-                        .mapNotNull { favorite -> regionalGuideUiMapper.map(favorite) }
+                        .mapNotNull { favorite ->
+                            regionalGuideSnapshotsById[favorite.targetId]
+                                ?.let { snapshot -> regionalGuideUiMapper.map(snapshot) }
+                        }
 
                     FavoritesUiState(
                         selectedTab = selectedTab,
@@ -78,6 +88,12 @@ class FavoritesViewModel
         fun removeCollectionSpotFavorite(targetId: String) {
             viewModelScope.launch {
                 removeCollectionSpotFavoriteUseCase(targetId)
+            }
+        }
+
+        fun removeRegionalGuideFavorite(targetId: String) {
+            viewModelScope.launch {
+                removeRegionalGuideFavoriteUseCase(targetId)
             }
         }
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/mapper/FavoriteRegionalGuideUiMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/mapper/FavoriteRegionalGuideUiMapper.kt
@@ -1,14 +1,40 @@
 package com.team.yeogibeoryeo.presentation.favorites.mapper
 
-import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
 import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteUiModel
 import javax.inject.Inject
 
 class FavoriteRegionalGuideUiMapper
     @Inject
     constructor() {
-    suspend fun map(favorite: Favorite): FavoriteUiModel? {
-        // TODO: Resolve regional guide source data when REGIONAL_GUIDE favorites are connected.
-        return null
+        fun map(snapshot: RegionalGuideFavoriteSnapshot): FavoriteUiModel =
+            FavoriteUiModel(
+                type = FavoriteTargetType.REGIONAL_GUIDE,
+                targetId = snapshot.targetId,
+                title = snapshot.regionDisplayName(),
+                subtitle = snapshot.toSubtitle(),
+            )
+
+        private fun RegionalGuideFavoriteSnapshot.regionDisplayName(): String =
+            listOfNotNull(
+                region.sido,
+                region.sigungu,
+                region.eupmyeondong,
+            )
+                .filter { regionName -> regionName.isNotBlank() }
+                .joinToString(" > ")
+                .ifBlank {
+                    targetRegionName
+                        ?: managementZoneName
+                        ?: "지역 가이드"
+                }
+
+        private fun RegionalGuideFavoriteSnapshot.toSubtitle(): String? =
+            listOfNotNull(
+                targetRegionName?.takeIf { it.isNotBlank() },
+                managementZoneName?.takeIf { it.isNotBlank() },
+            )
+                .joinToString(" · ")
+                .takeIf { it.isNotBlank() }
     }
-}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
@@ -48,14 +48,16 @@ fun RegionalGuideRoute(
     modifier: Modifier = Modifier,
     initialKeyword: String? = null,
     initialAddress: String? = null,
+    initialFavoriteTargetId: String? = null,
     viewModel: RegionalGuideViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val searchKeyword by viewModel.searchKeyword.collectAsStateWithLifecycle()
     val regionSelectorUiState by viewModel.regionSelectorUiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(initialKeyword, initialAddress) {
+    LaunchedEffect(initialKeyword, initialAddress, initialFavoriteTargetId) {
         when {
+            !initialFavoriteTargetId.isNullOrBlank() -> viewModel.loadByFavoriteTargetId(initialFavoriteTargetId)
             !initialAddress.isNullOrBlank() -> viewModel.loadByAddress(initialAddress)
             !initialKeyword.isNullOrBlank() -> {
                 viewModel.onSearchKeywordChanged(initialKeyword)
@@ -79,6 +81,7 @@ fun RegionalGuideRoute(
         onRegionSelectionSearchClick = viewModel::onRegionSelectionSearchClick,
         onCandidateClick = viewModel::onRegionCandidateSelected,
         onGuideCandidateClick = viewModel::onRegionalGuideCandidateSelected,
+        onFavoriteClick = viewModel::onFavoriteClick,
         modifier = modifier,
     )
 }
@@ -99,6 +102,7 @@ fun RegionalGuideScreen(
     onRegionSelectionSearchClick: () -> Unit,
     onCandidateClick: (RegionSearchCandidateUiModel) -> Unit,
     onGuideCandidateClick: (RegionalGuideCandidateUiModel) -> Unit,
+    onFavoriteClick: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     var isRegionSelectorExpanded by rememberSaveable { mutableStateOf(false) }
@@ -218,6 +222,7 @@ fun RegionalGuideScreen(
             onRetryClick = onRetryClick,
             onCandidateClick = onCandidateClick,
             onGuideCandidateClick = onGuideCandidateClick,
+            onFavoriteClick = onFavoriteClick,
             modifier = Modifier
                 .weight(1f)
                 .padding(horizontal = 20.dp),
@@ -242,6 +247,7 @@ private fun RegionalGuideContent(
     onRetryClick: () -> Unit,
     onCandidateClick: (RegionSearchCandidateUiModel) -> Unit,
     onGuideCandidateClick: (RegionalGuideCandidateUiModel) -> Unit,
+    onFavoriteClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     when (uiState) {
@@ -259,6 +265,8 @@ private fun RegionalGuideContent(
         is RegionalGuideUiState.Success -> {
             RegionalGuideSuccessContent(
                 guide = uiState.guide,
+                isFavorite = uiState.isFavorite,
+                onFavoriteClick = onFavoriteClick,
                 modifier = modifier
             )
         }
@@ -313,6 +321,8 @@ private fun RegionalGuideLoadingContent(
 @Composable
 private fun RegionalGuideSuccessContent(
     guide: RegionalGuideUiModel,
+    isFavorite: Boolean,
+    onFavoriteClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -320,7 +330,11 @@ private fun RegionalGuideSuccessContent(
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         item {
-            RegionalGuideSummaryCard(guide = guide)
+            RegionalGuideSummaryCard(
+                guide = guide,
+                isFavorite = isFavorite,
+                onFavoriteClick = onFavoriteClick,
+            )
         }
 
         item {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideUiState.kt
@@ -13,7 +13,8 @@ sealed interface RegionalGuideUiState {
 
     data class Success(
         val query: String,
-        val guide: RegionalGuideUiModel
+        val guide: RegionalGuideUiModel,
+        val isFavorite: Boolean = false,
     ) : RegionalGuideUiState
 
     data class Empty(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
@@ -2,6 +2,12 @@ package com.team.yeogibeoryeo.presentation.regionalguide
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.model.toFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.usecase.GetRegionalGuideFavoriteSnapshotUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoriteUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ToggleRegionalGuideFavoriteUseCase
 import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.region.usecase.ExtractRegionFromAddressUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.GetEupmyeondongOptionsUseCase
@@ -11,6 +17,7 @@ import com.team.yeogibeoryeo.domain.region.usecase.NormalizeRegionForRegionalGui
 import com.team.yeogibeoryeo.domain.region.usecase.ResolveRegionFromKeywordUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.ResolveRegionFromKeywordResult
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideFailureReason
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideLookupResult
 import com.team.yeogibeoryeo.domain.regionalguide.usecase.GetRegionalDisposalGuideUseCase
 import com.team.yeogibeoryeo.presentation.regionalguide.mapper.toUiModel
@@ -36,7 +43,10 @@ class RegionalGuideViewModel @Inject constructor(
     private val getSidoOptionsUseCase: GetSidoOptionsUseCase,
     private val getSigunguOptionsUseCase: GetSigunguOptionsUseCase,
     private val getEupmyeondongOptionsUseCase: GetEupmyeondongOptionsUseCase,
-    private val normalizeRegionForRegionalGuideUseCase: NormalizeRegionForRegionalGuideUseCase
+    private val normalizeRegionForRegionalGuideUseCase: NormalizeRegionForRegionalGuideUseCase,
+    private val observeFavoriteUseCase: ObserveFavoriteUseCase,
+    private val toggleRegionalGuideFavoriteUseCase: ToggleRegionalGuideFavoriteUseCase,
+    private val getRegionalGuideFavoriteSnapshotUseCase: GetRegionalGuideFavoriteSnapshotUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<RegionalGuideUiState>(RegionalGuideUiState.Idle)
@@ -53,7 +63,9 @@ class RegionalGuideViewModel @Inject constructor(
     private var keywordSuggestionJob: Job? = null
     private var sigunguOptionsJob: Job? = null
     private var eupmyeondongOptionsJob: Job? = null
+    private var favoriteStateJob: Job? = null
     private var lastRequest: RegionalGuideRequest? = null
+    private var currentRegionalGuideFavoriteSnapshot: RegionalGuideFavoriteSnapshot? = null
 
     init {
         loadSidoOptions()
@@ -178,6 +190,7 @@ class RegionalGuideViewModel @Inject constructor(
         when (val request = lastRequest) {
             is RegionalGuideRequest.Keyword -> searchByKeyword(request.keyword)
             is RegionalGuideRequest.Address -> loadByAddress(request.address)
+            is RegionalGuideRequest.Favorite -> loadByFavoriteTargetId(request.targetId)
             is RegionalGuideRequest.SelectedRegion -> searchBySelectedRegion(
                 query = request.query,
                 region = request.region
@@ -207,10 +220,30 @@ class RegionalGuideViewModel @Inject constructor(
 
         applyRegionSelection(candidate.toRegion())
 
+        val snapshot = candidate.toFavoriteSnapshot()
+        currentRegionalGuideFavoriteSnapshot = snapshot
+        observeRegionalGuideFavoriteState(snapshot.targetId)
+
         _uiState.value = RegionalGuideUiState.Success(
             query = query,
             guide = candidate.guide
         )
+    }
+
+    fun onFavoriteClick() {
+        val snapshot = currentRegionalGuideFavoriteSnapshot ?: return
+
+        viewModelScope.launch {
+            val isFavorite = toggleRegionalGuideFavoriteUseCase(snapshot)
+
+            _uiState.update { state ->
+                if (state is RegionalGuideUiState.Success) {
+                    state.copy(isFavorite = isFavorite)
+                } else {
+                    state
+                }
+            }
+        }
     }
 
     fun searchByKeyword(keyword: String) {
@@ -318,12 +351,51 @@ class RegionalGuideViewModel @Inject constructor(
         }
     }
 
+    fun loadByFavoriteTargetId(targetId: String) {
+        keywordSuggestionJob?.cancel()
+        guideLookupJob?.cancel()
+
+        lastRequest = RegionalGuideRequest.Favorite(targetId)
+
+        guideLookupJob = viewModelScope.launch {
+            _uiState.value = RegionalGuideUiState.Loading(query = "")
+
+            try {
+                val snapshot = getRegionalGuideFavoriteSnapshotUseCase(targetId)
+
+                if (snapshot == null) {
+                    _uiState.value = RegionalGuideUiState.Empty(
+                        query = "",
+                        message = "저장된 지역 가이드를 찾을 수 없습니다."
+                    )
+                    return@launch
+                }
+
+                val regionalGuideRegion = normalizeAndApplyRegionSelection(snapshot.region)
+                loadRegionalGuide(
+                    query = snapshot.displayText(),
+                    region = regionalGuideRegion,
+                    preferredTargetRegionName = snapshot.targetRegionName
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _uiState.value = RegionalGuideUiState.Error(
+                    query = "",
+                    message = e.message ?: "저장된 지역 가이드를 불러오는 중 오류가 발생했습니다."
+                )
+            }
+        }
+    }
+
     fun resetState() {
         guideLookupJob?.cancel()
         keywordSuggestionJob?.cancel()
         sigunguOptionsJob?.cancel()
         eupmyeondongOptionsJob?.cancel()
+        favoriteStateJob?.cancel()
         lastRequest = null
+        currentRegionalGuideFavoriteSnapshot = null
         _uiState.value = RegionalGuideUiState.Idle
     }
 
@@ -445,6 +517,27 @@ class RegionalGuideViewModel @Inject constructor(
         }
     }
 
+    private fun observeRegionalGuideFavoriteState(targetId: String) {
+        favoriteStateJob?.cancel()
+        favoriteStateJob = viewModelScope.launch {
+            observeFavoriteUseCase(
+                type = FavoriteTargetType.REGIONAL_GUIDE,
+                targetId = targetId,
+            ).collect { isFavorite ->
+                _uiState.update { state ->
+                    if (
+                        state is RegionalGuideUiState.Success &&
+                        currentRegionalGuideFavoriteSnapshot?.targetId == targetId
+                    ) {
+                        state.copy(isFavorite = isFavorite)
+                    } else {
+                        state
+                    }
+                }
+            }
+        }
+    }
+
     private fun applyRegionSelection(region: Region) {
         val selectedSido = region.sido
         val selectedSigungu = region.sigungu
@@ -497,9 +590,13 @@ class RegionalGuideViewModel @Inject constructor(
 
     private suspend fun loadRegionalGuide(
         query: String,
-        region: Region
+        region: Region,
+        preferredTargetRegionName: String? = null
     ) {
-        val result = getRegionalDisposalGuideUseCase(region)
+        val result = getRegionalDisposalGuideUseCase(
+            region = region,
+            preferredTargetRegionName = preferredTargetRegionName
+        )
 
         _uiState.value = result.toUiState(query)
     }
@@ -508,10 +605,16 @@ class RegionalGuideViewModel @Inject constructor(
         query: String
     ): RegionalGuideUiState {
         return when (this) {
-            is RegionalGuideLookupResult.Success -> RegionalGuideUiState.Success(
-                query = query,
-                guide = guide.toUiModel()
-            )
+            is RegionalGuideLookupResult.Success -> {
+                val snapshot = guide.toFavoriteSnapshot()
+                currentRegionalGuideFavoriteSnapshot = snapshot
+                observeRegionalGuideFavoriteState(snapshot.targetId)
+
+                RegionalGuideUiState.Success(
+                    query = query,
+                    guide = guide.toUiModel()
+                )
+            }
 
             is RegionalGuideLookupResult.Candidates -> RegionalGuideUiState.GuideCandidates(
                 query = query,
@@ -577,6 +680,32 @@ class RegionalGuideViewModel @Inject constructor(
             eupmyeondong = eupmyeondong
         )
 
+    private fun RegionalGuideCandidateUiModel.toFavoriteSnapshot(): RegionalGuideFavoriteSnapshot {
+        val region = toRegion()
+
+        return RegionalGuideFavoriteSnapshot(
+            targetId = com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteKey(
+                sido = region.sido,
+                sigungu = region.sigungu,
+                eupmyeondong = region.eupmyeondong,
+                targetRegionName = guide.targetRegionName,
+            ).encode(),
+            region = region,
+            targetRegionName = guide.targetRegionName,
+            managementZoneName = guide.managementZoneName,
+        )
+    }
+
+    private fun RegionalGuideFavoriteSnapshot.displayText(): String =
+        listOfNotNull(
+            region.sido,
+            region.sigungu,
+            region.eupmyeondong,
+        )
+            .filter { regionName -> regionName.isNotBlank() }
+            .joinToString(" > ")
+            .ifBlank { targetRegionName ?: managementZoneName ?: "" }
+
     private fun collapseRegionSelectorDropdowns() {
         _regionSelectorUiState.update { state ->
             if (state.expandedDropdown == null) {
@@ -594,6 +723,10 @@ class RegionalGuideViewModel @Inject constructor(
 
         data class Address(
             val address: String
+        ) : RegionalGuideRequest
+
+        data class Favorite(
+            val targetId: String
         ) : RegionalGuideRequest
 
         data class SelectedRegion(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSummaryCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSummaryCard.kt
@@ -3,24 +3,33 @@ package com.team.yeogibeoryeo.presentation.regionalguide.components
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalWasteScheduleUiModel
+import com.team.yeogibeoryeo.common.R as CommonR
 
 @Composable
 fun RegionalGuideSummaryCard(
     guide: RegionalGuideUiModel,
+    isFavorite: Boolean = false,
+    onFavoriteClick: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -37,11 +46,37 @@ fun RegionalGuideSummaryCard(
             modifier = Modifier.padding(24.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Text(
-                text = guide.regionName,
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = guide.regionName,
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold
+                )
+
+                IconButton(onClick = onFavoriteClick) {
+                    Icon(
+                        painter = painterResource(
+                            id = if (isFavorite) {
+                                CommonR.drawable.ic_favorite_filled
+                            } else {
+                                CommonR.drawable.ic_favorite
+                            },
+                        ),
+                        contentDescription = if (isFavorite) {
+                            "즐겨찾기 해제"
+                        } else {
+                            "즐겨찾기 추가"
+                        },
+                        modifier = Modifier.size(22.dp),
+                        tint = MaterialTheme.colorScheme.tertiary,
+                    )
+                }
+            }
 
             guide.managementZoneName?.let { managementZoneName ->
                 RegionalGuideInfoRow(

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModelTest.kt
@@ -1,22 +1,28 @@
 package com.team.yeogibeoryeo.presentation.favorites
 
-import com.team.yeogibeoryeo.domain.favorite.model.Favorite
 import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
 import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteRepository
 import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
 import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
-import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteSnapshotRepository
 import com.team.yeogibeoryeo.domain.favorite.usecase.GetCollectionSpotFavoriteSnapshotUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveCollectionSpotFavoriteSnapshotsUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveRegionalGuideFavoriteSnapshotsUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.RemoveCollectionSpotFavoriteUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.RemoveRegionalGuideFavoriteUseCase
 import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
 import com.team.yeogibeoryeo.domain.item.model.DisposalInstruction
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.domain.item.model.DisposalSubCategory
 import com.team.yeogibeoryeo.domain.item.repository.DisposalItemGuideRepository
 import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalItemGuideUseCase
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.presentation.favorites.mapper.FavoriteCollectionSpotUiMapper
@@ -367,22 +373,137 @@ class FavoritesViewModelTest {
             assertEquals(FavoriteTab.COLLECTION_SPOT, viewModel.uiState.value.selectedTab)
         }
 
+    @Test
+    fun `regional guide favorites are mapped from snapshots in favorite order`() =
+        runTest {
+            val olderSnapshot =
+                RegionalGuideFavoriteSnapshot(
+                    targetId = "regional-guide-v1|4:서울시2:중구-1:4:권역A",
+                    region = Region(sido = "서울시", sigungu = "중구"),
+                    targetRegionName = "권역A",
+                    managementZoneName = "관리구역A",
+                )
+            val newerSnapshot =
+                RegionalGuideFavoriteSnapshot(
+                    targetId = "regional-guide-v1|4:서울시2:중구-1:4:권역B",
+                    region = Region(sido = "서울시", sigungu = "중구"),
+                    targetRegionName = "권역B",
+                    managementZoneName = "관리구역B",
+                )
+            val viewModel =
+                createViewModel(
+                    favoriteRepository =
+                        FakeFavoriteRepository(
+                            initialFavorites =
+                                listOf(
+                                    Favorite(
+                                        type = FavoriteTargetType.REGIONAL_GUIDE,
+                                        targetId = newerSnapshot.targetId,
+                                        savedAtMillis = 2L,
+                                    ),
+                                    Favorite(
+                                        type = FavoriteTargetType.REGIONAL_GUIDE,
+                                        targetId = olderSnapshot.targetId,
+                                        savedAtMillis = 1L,
+                                    ),
+                                ),
+                        ),
+                    itemRepository = FakeItemRepository(guides = emptyList()),
+                    regionalGuideSnapshotRepository =
+                        FakeRegionalGuideFavoriteSnapshotRepository(
+                            snapshots = listOf(olderSnapshot, newerSnapshot),
+                        ),
+                )
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.uiState.collect()
+            }
+            advanceUntilIdle()
+
+            viewModel.selectTab(FavoriteTab.REGIONAL_GUIDE)
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(newerSnapshot.targetId, olderSnapshot.targetId),
+                viewModel.uiState.value.selectedFavorites.map { it.targetId },
+            )
+            assertEquals("서울시 > 중구", viewModel.uiState.value.selectedFavorites.first().title)
+            assertEquals("권역B · 관리구역B", viewModel.uiState.value.selectedFavorites.first().subtitle)
+        }
+
+    @Test
+    fun `regional guide favorite remove deletes favorite and snapshot`() =
+        runTest {
+            val snapshot =
+                RegionalGuideFavoriteSnapshot(
+                    targetId = "regional-guide-v1|4:서울시2:중구-1:4:권역A",
+                    region = Region(sido = "서울시", sigungu = "중구"),
+                    targetRegionName = "권역A",
+                    managementZoneName = "관리구역A",
+                )
+            val favoriteRepository =
+                FakeFavoriteRepository(
+                    initialFavorites =
+                        listOf(
+                            Favorite(
+                                type = FavoriteTargetType.REGIONAL_GUIDE,
+                                targetId = snapshot.targetId,
+                                savedAtMillis = 1L,
+                            ),
+                        ),
+                )
+            val snapshotRepository =
+                FakeRegionalGuideFavoriteSnapshotRepository(snapshots = listOf(snapshot))
+            val viewModel =
+                createViewModel(
+                    favoriteRepository = favoriteRepository,
+                    itemRepository = FakeItemRepository(guides = emptyList()),
+                    regionalGuideSnapshotRepository = snapshotRepository,
+                )
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.uiState.collect()
+            }
+            advanceUntilIdle()
+
+            viewModel.selectTab(FavoriteTab.REGIONAL_GUIDE)
+            advanceUntilIdle()
+            assertEquals(1, viewModel.uiState.value.selectedFavorites.size)
+
+            viewModel.removeRegionalGuideFavorite(snapshot.targetId)
+            advanceUntilIdle()
+
+            assertEquals(emptyList<FavoriteUiModel>(), viewModel.uiState.value.selectedFavorites)
+            assertEquals(false, favoriteRepository.isFavorite(FavoriteTargetType.REGIONAL_GUIDE, snapshot.targetId))
+            assertEquals(emptyList<RegionalGuideFavoriteSnapshot>(), snapshotRepository.snapshots.value)
+        }
+
     private fun createViewModel(
         favoriteRepository: FakeFavoriteRepository,
         itemRepository: FakeItemRepository,
         collectionSpotSnapshotRepository: FakeCollectionSpotFavoriteSnapshotRepository =
             FakeCollectionSpotFavoriteSnapshotRepository(),
+        regionalGuideSnapshotRepository: FakeRegionalGuideFavoriteSnapshotRepository =
+            FakeRegionalGuideFavoriteSnapshotRepository(),
     ): FavoritesViewModel =
         FavoritesViewModel(
             observeFavoritesUseCase = ObserveFavoritesUseCase(favoriteRepository),
             observeCollectionSpotFavoriteSnapshotsUseCase =
                 ObserveCollectionSpotFavoriteSnapshotsUseCase(collectionSpotSnapshotRepository),
+            observeRegionalGuideFavoriteSnapshotsUseCase =
+                ObserveRegionalGuideFavoriteSnapshotsUseCase(regionalGuideSnapshotRepository),
             removeCollectionSpotFavoriteUseCase =
                 RemoveCollectionSpotFavoriteUseCase(
                     collectionSpotFavoriteRepository =
                         FakeCollectionSpotFavoriteRepository(
                             favoriteRepository = favoriteRepository,
                             snapshotRepository = collectionSpotSnapshotRepository,
+                        ),
+                ),
+            removeRegionalGuideFavoriteUseCase =
+                RemoveRegionalGuideFavoriteUseCase(
+                    repository =
+                        FakeRegionalGuideFavoriteRepository(
+                            favoriteRepository = favoriteRepository,
+                            snapshotRepository = regionalGuideSnapshotRepository,
                         ),
                 ),
             itemGuideUiMapper = FavoriteItemGuideUiMapper(GetDisposalItemGuideUseCase(itemRepository)),
@@ -500,6 +621,39 @@ class FavoritesViewModelTest {
 
         override suspend fun removeFavorite(targetId: String) {
             favoriteRepository.removeFavorite(FavoriteTargetType.COLLECTION_SPOT, targetId)
+            snapshotRepository.deleteSnapshot(targetId)
+        }
+    }
+
+    private class FakeRegionalGuideFavoriteSnapshotRepository(
+        snapshots: List<RegionalGuideFavoriteSnapshot> = emptyList(),
+    ) : RegionalGuideFavoriteSnapshotRepository {
+        val snapshots = MutableStateFlow(snapshots)
+
+        override fun observeSnapshots(): Flow<List<RegionalGuideFavoriteSnapshot>> = snapshots
+
+        override suspend fun getSnapshot(targetId: String): RegionalGuideFavoriteSnapshot? =
+            snapshots.value.firstOrNull { snapshot -> snapshot.targetId == targetId }
+
+        override suspend fun upsertSnapshot(snapshot: RegionalGuideFavoriteSnapshot) {
+            snapshots.value =
+                snapshots.value
+                    .filterNot { it.targetId == snapshot.targetId } + snapshot
+        }
+
+        override suspend fun deleteSnapshot(targetId: String) {
+            snapshots.value = snapshots.value.filterNot { it.targetId == targetId }
+        }
+    }
+
+    private class FakeRegionalGuideFavoriteRepository(
+        private val favoriteRepository: FakeFavoriteRepository,
+        private val snapshotRepository: FakeRegionalGuideFavoriteSnapshotRepository,
+    ) : RegionalGuideFavoriteRepository {
+        override suspend fun toggleFavorite(snapshot: RegionalGuideFavoriteSnapshot): Boolean = false
+
+        override suspend fun removeFavorite(targetId: String) {
+            favoriteRepository.removeFavorite(FavoriteTargetType.REGIONAL_GUIDE, targetId)
             snapshotRepository.deleteSnapshot(targetId)
         }
     }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModelTest.kt
@@ -1,5 +1,15 @@
 package com.team.yeogibeoryeo.presentation.regionalguide
 
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.model.toFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteSnapshotRepository
+import com.team.yeogibeoryeo.domain.favorite.usecase.GetRegionalGuideFavoriteSnapshotUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoriteUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ToggleRegionalGuideFavoriteUseCase
 import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.region.repository.RegionOptionsRepository
 import com.team.yeogibeoryeo.domain.region.repository.RegionRepository
@@ -19,6 +29,9 @@ import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionSearchCandid
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -723,10 +736,104 @@ class RegionalGuideViewModelTest {
         }
     }
 
+    @Test
+    fun `favorite click stores regional guide favorite and observes state`() = runTest {
+        val guide =
+            RegionalDisposalGuide(
+                region = Region(sido = "Sido", sigungu = "Sigungu"),
+                targetRegionName = "Zone A",
+                managementZoneName = "Management A",
+                schedules = emptyList(),
+            )
+        val favoriteRepository = FakeFavoriteRepository()
+        val snapshotRepository = FakeRegionalGuideFavoriteSnapshotRepository()
+        val viewModel =
+            createViewModel(
+                regionRepository = FakeRegionRepository(resolvedRegion = guide.region),
+                regionalGuideRepository = FakeRegionalDisposalGuideRepository(candidates = listOf(guide)),
+                favoriteRepository = favoriteRepository,
+                regionalGuideSnapshotRepository = snapshotRepository,
+                regionalGuideFavoriteRepository =
+                    FakeRegionalGuideFavoriteRepository(
+                        favoriteRepository = favoriteRepository,
+                        snapshotRepository = snapshotRepository,
+                    ),
+            )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("Sigungu")
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        assertEquals(false, (viewModel.uiState.value as RegionalGuideUiState.Success).isFavorite)
+
+        viewModel.onFavoriteClick()
+        advanceUntilIdle()
+
+        val snapshot = guide.toFavoriteSnapshot()
+        assertEquals(true, (viewModel.uiState.value as RegionalGuideUiState.Success).isFavorite)
+        assertEquals(true, favoriteRepository.isFavorite(FavoriteTargetType.REGIONAL_GUIDE, snapshot.targetId))
+        assertEquals(snapshot, snapshotRepository.getSnapshot(snapshot.targetId))
+    }
+
+    @Test
+    fun `favorite target id restores saved regional guide candidate`() = runTest {
+        val region = Region(sido = "Sido", sigungu = "Sigungu")
+        val firstGuide =
+            RegionalDisposalGuide(
+                region = region,
+                targetRegionName = "Zone A",
+                schedules = emptyList(),
+            )
+        val savedGuide =
+            RegionalDisposalGuide(
+                region = region,
+                targetRegionName = "Zone B",
+                managementZoneName = "Management B",
+                schedules = emptyList(),
+            )
+        val snapshot = savedGuide.toFavoriteSnapshot()
+        val favoriteRepository =
+            FakeFavoriteRepository(
+                initialFavorites =
+                    listOf(
+                        Favorite(
+                            type = FavoriteTargetType.REGIONAL_GUIDE,
+                            targetId = snapshot.targetId,
+                            savedAtMillis = 1L,
+                        ),
+                    ),
+            )
+        val viewModel =
+            createViewModel(
+                regionalGuideRepository =
+                    FakeRegionalDisposalGuideRepository(candidates = listOf(firstGuide, savedGuide)),
+                favoriteRepository = favoriteRepository,
+                regionalGuideSnapshotRepository =
+                    FakeRegionalGuideFavoriteSnapshotRepository(snapshots = listOf(snapshot)),
+            )
+        advanceUntilIdle()
+
+        viewModel.loadByFavoriteTargetId(snapshot.targetId)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value as RegionalGuideUiState.Success
+        assertEquals("Zone B", state.guide.targetRegionName)
+        assertEquals(true, state.isFavorite)
+    }
+
     private fun createViewModel(
         regionRepository: RegionRepository = FakeRegionRepository(),
         regionOptionsRepository: RegionOptionsRepository = FakeRegionOptionsRepository(),
-        regionalGuideRepository: RegionalDisposalGuideRepository = FakeRegionalDisposalGuideRepository()
+        regionalGuideRepository: RegionalDisposalGuideRepository = FakeRegionalDisposalGuideRepository(),
+        favoriteRepository: FavoriteRepository = FakeFavoriteRepository(),
+        regionalGuideSnapshotRepository: RegionalGuideFavoriteSnapshotRepository =
+            FakeRegionalGuideFavoriteSnapshotRepository(),
+        regionalGuideFavoriteRepository: RegionalGuideFavoriteRepository =
+            FakeRegionalGuideFavoriteRepository(
+                favoriteRepository = favoriteRepository,
+                snapshotRepository = regionalGuideSnapshotRepository,
+            ),
     ): RegionalGuideViewModel {
         return RegionalGuideViewModel(
             resolveRegionFromKeywordUseCase = ResolveRegionFromKeywordUseCase(
@@ -744,7 +851,11 @@ class RegionalGuideViewModelTest {
             getEupmyeondongOptionsUseCase = GetEupmyeondongOptionsUseCase(regionOptionsRepository),
             normalizeRegionForRegionalGuideUseCase = NormalizeRegionForRegionalGuideUseCase(
                 regionOptionsRepository
-            )
+            ),
+            observeFavoriteUseCase = ObserveFavoriteUseCase(favoriteRepository),
+            toggleRegionalGuideFavoriteUseCase = ToggleRegionalGuideFavoriteUseCase(regionalGuideFavoriteRepository),
+            getRegionalGuideFavoriteSnapshotUseCase =
+                GetRegionalGuideFavoriteSnapshotUseCase(regionalGuideSnapshotRepository),
         )
     }
 
@@ -865,6 +976,104 @@ class RegionalGuideViewModelTest {
         ): Result<List<RegionalDisposalGuide>> {
             queries += query
             return Result.success(candidates)
+        }
+    }
+
+    private class FakeFavoriteRepository(
+        initialFavorites: List<Favorite> = emptyList(),
+    ) : FavoriteRepository {
+        private val favorites = MutableStateFlow(initialFavorites)
+
+        override fun observeFavorites(): Flow<List<Favorite>> = favorites
+
+        override fun observeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Flow<Boolean> =
+            favorites.map { items ->
+                items.any { favorite -> favorite.type == type && favorite.targetId == targetId }
+            }
+
+        override suspend fun isFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Boolean =
+            favorites.value.any { favorite -> favorite.type == type && favorite.targetId == targetId }
+
+        override suspend fun toggleFavorite(favorite: Favorite): Boolean {
+            return if (isFavorite(favorite.type, favorite.targetId)) {
+                removeFavorite(favorite.type, favorite.targetId)
+                false
+            } else {
+                addFavorite(favorite)
+                true
+            }
+        }
+
+        override suspend fun addFavorite(favorite: Favorite) {
+            favorites.value =
+                favorites.value
+                    .filterNot { it.type == favorite.type && it.targetId == favorite.targetId } + favorite
+        }
+
+        override suspend fun removeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ) {
+            favorites.value =
+                favorites.value.filterNot { favorite ->
+                    favorite.type == type && favorite.targetId == targetId
+                }
+        }
+    }
+
+    private class FakeRegionalGuideFavoriteSnapshotRepository(
+        snapshots: List<RegionalGuideFavoriteSnapshot> = emptyList(),
+    ) : RegionalGuideFavoriteSnapshotRepository {
+        private val snapshots = MutableStateFlow(snapshots)
+
+        override fun observeSnapshots(): Flow<List<RegionalGuideFavoriteSnapshot>> = snapshots
+
+        override suspend fun getSnapshot(targetId: String): RegionalGuideFavoriteSnapshot? =
+            snapshots.value.firstOrNull { snapshot -> snapshot.targetId == targetId }
+
+        override suspend fun upsertSnapshot(snapshot: RegionalGuideFavoriteSnapshot) {
+            snapshots.value =
+                snapshots.value
+                    .filterNot { it.targetId == snapshot.targetId } + snapshot
+        }
+
+        override suspend fun deleteSnapshot(targetId: String) {
+            snapshots.value = snapshots.value.filterNot { snapshot -> snapshot.targetId == targetId }
+        }
+    }
+
+    private class FakeRegionalGuideFavoriteRepository(
+        private val favoriteRepository: FavoriteRepository,
+        private val snapshotRepository: RegionalGuideFavoriteSnapshotRepository,
+    ) : RegionalGuideFavoriteRepository {
+        override suspend fun toggleFavorite(snapshot: RegionalGuideFavoriteSnapshot): Boolean {
+            val favorite =
+                Favorite(
+                    type = FavoriteTargetType.REGIONAL_GUIDE,
+                    targetId = snapshot.targetId,
+                    savedAtMillis = 1L,
+                )
+
+            return if (favoriteRepository.isFavorite(favorite.type, favorite.targetId)) {
+                favoriteRepository.removeFavorite(favorite.type, favorite.targetId)
+                snapshotRepository.deleteSnapshot(snapshot.targetId)
+                false
+            } else {
+                favoriteRepository.addFavorite(favorite)
+                snapshotRepository.upsertSnapshot(snapshot)
+                true
+            }
+        }
+
+        override suspend fun removeFavorite(targetId: String) {
+            favoriteRepository.removeFavorite(FavoriteTargetType.REGIONAL_GUIDE, targetId)
+            snapshotRepository.deleteSnapshot(targetId)
         }
     }
 }


### PR DESCRIPTION
## 작업 내용

- 지역 가이드 조회 결과를 `FavoriteTargetType.REGIONAL_GUIDE`로 저장·해제하도록 연결했습니다.
- `RegionalGuideFavoriteKey`와 지역 가이드 전용 snapshot 저장 구조를 추가했습니다.
  - `sido / sigungu / eupmyeondong / targetRegionName` 조합
  - version prefix와 length-prefix 기반 encode/decode 적용
- `FavoriteDatabase`를 v3으로 올리고 v2 → v3 migration을 추가했습니다.
- 공통 Favorite row와 지역 가이드 snapshot row를 Room transaction으로 함께 저장·삭제하도록 처리했습니다.
- Favorites `지역` 탭의 목록 표시, 해제, 저장 항목 재진입을 연결했습니다.
- 복수 배출 권역을 `targetRegionName`으로 구분하고, 재진입 시 저장했던 동일 권역을 우선 복원하도록 처리했습니다.
- `Region.eupmyeondong`과 배출 권역 설명인 `targetRegionName`을 분리해 저장·표시했습니다.
- 잘못된 key, snapshot 누락, 저장 권역 미일치 시 임의 후보를 선택하지 않고 안전하게 제외하거나 Empty 상태로 처리했습니다.
- 지역 가이드 재진입 후 다른 하단 탭을 거쳐 Favorites를 다시 선택하면 이전 상세가 아닌 Favorites 목록이 표시되도록 Navigation 상태를 보정했습니다.

## 테스트

- [x] `:domain:test`
- [x] `:data:testDebugUnitTest`
- [x] `:presentation:testDebugUnitTest`
- [x] `:presentation:compileDebugKotlin`
- [x] `:app:testDebugUnitTest`
- [x] `:app:assembleDebug`
- [x] `git diff --check`

> v2 → v3 migration 코드는 포함했으나, 실제 구버전 DB 파일을 사용하는 instrumentation migration test는 이번 PR에 포함하지 않았습니다.

## 확인한 주요 케이스

- 지역 가이드 저장·해제 및 Favorites `지역` 탭 목록 반영
- 저장 항목 클릭 시 기존 `/info` 조회 흐름으로 재진입
- 복수 배출 권역 저장 및 동일 권역 복원
- 읍면동과 배출 권역 설명이 섞이지 않는지 확인
- 앱 재실행 후 즐겨찾기 목록과 상태 유지
- 잘못된 key 또는 snapshot 누락 시 안전 처리
- 시스템 뒤로가기 시 Favorites `지역` 탭 복귀
- 다른 탭 이동 후 Favorites 재선택 시 이전 상세 화면 미복원
- 기존 품목·장소 즐겨찾기 흐름 유지

## 스크린샷

| 지역 가이드 즐겨찾기 | Favorites 지역 탭 |
| --- | --- |
| <img width="720" height="1520" alt="Screenshot_20260612_192349" src="https://github.com/user-attachments/assets/9d489921-cf59-47dd-aa2e-e28419f3b1b8" /> | <img width="720" height="1520" alt="Screenshot_20260612_192415" src="https://github.com/user-attachments/assets/f37d3541-7ad7-459d-9f78-b8ee9b47d087" /> |

## 후속 작업

- 지도 장소 주소 기반 지역 가이드 연결은 #61에서 진행합니다.
- 실제 DB 파일 기반 migration 검증과 즐겨찾기 연속 클릭 방지는 필요 시 별도 이슈에서 보강합니다.

## 관련 이슈

- Related #128