### PR TITLE
[Refactor] App NavHost 보조 정책 분리

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/BottomTabNavigation.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/BottomTabNavigation.kt
@@ -1,0 +1,125 @@
+package com.team.yeogibeoryeo.navigation
+
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavDestination
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.toRoute
+import com.team.yeogibeoryeo.R as AppR
+import com.team.yeogibeoryeo.common.R as CommonR
+import com.team.yeogibeoryeo.common.navigation.BottomNavigationItem
+import com.team.yeogibeoryeo.common.navigation.navigateBottomTab
+
+internal fun NavHostController.createBottomNavigationItems(
+    currentBackStackEntry: NavBackStackEntry?,
+    currentDestination: NavDestination?,
+    onMapTabSelected: () -> Unit,
+): List<BottomNavigationItem> =
+    listOf(
+        BottomNavigationItem(
+            label = "품목",
+            iconResId = CommonR.drawable.ic_symbol_recycle,
+            selected = currentBackStackEntry.isItemSearchSelected(),
+            onClick = {
+                navigateBottomTabClearingFavoriteReentry(
+                    currentBackStackEntry = currentBackStackEntry,
+                    route = ItemSearchRoute(),
+                )
+            },
+        ),
+        BottomNavigationItem(
+            label = "지도",
+            iconResId = AppR.drawable.ic_navigation_map,
+            selected = currentDestination?.hasRoute<MapRoute>() == true,
+            onClick = {
+                onMapTabSelected()
+                navigateBottomTabClearingFavoriteReentry(
+                    currentBackStackEntry = currentBackStackEntry,
+                    route = MapRoute(),
+                )
+            },
+        ),
+        BottomNavigationItem(
+            label = "안내",
+            iconResId = AppR.drawable.ic_navigation_guide,
+            selected = currentBackStackEntry.isRegionalGuideSelected(),
+            onClick = {
+                navigateBottomTabClearingFavoriteReentry(
+                    currentBackStackEntry = currentBackStackEntry,
+                    route = RegionalGuideRoute(),
+                )
+            },
+        ),
+        BottomNavigationItem(
+            label = "저장",
+            iconResId = CommonR.drawable.ic_favorite,
+            selected = currentBackStackEntry.isFavoritesSelected(),
+            onClick = {
+                if (currentBackStackEntry.isFavoriteRegionalGuideSelected()) {
+                    popBackStack<FavoritesRoute>(inclusive = false)
+                } else {
+                    navigateFavoritesRoot(
+                        currentBackStackEntry = currentBackStackEntry,
+                    )
+                }
+            },
+        ),
+    )
+
+private fun NavBackStackEntry?.isItemSearchSelected(): Boolean =
+    this?.destination?.hasRoute<ItemSearchRoute>() == true ||
+        isItemGuideDetailSource(ItemGuideDetailSource.SEARCH)
+
+private fun NavBackStackEntry?.isFavoritesSelected(): Boolean =
+    this?.destination?.hasRoute<FavoritesRoute>() == true ||
+        isItemGuideDetailSource(ItemGuideDetailSource.FAVORITES) ||
+        isFavoriteRegionalGuideSelected()
+
+private fun NavBackStackEntry?.isRegionalGuideSelected(): Boolean =
+    this?.destination?.hasRoute<RegionalGuideRoute>() == true &&
+        !isFavoriteRegionalGuideSelected()
+
+private fun NavBackStackEntry?.isFavoriteRegionalGuideSelected(): Boolean =
+    this != null &&
+        destination.hasRoute<RegionalGuideRoute>() &&
+        toRoute<RegionalGuideRoute>().isFavoriteReentryRoute()
+
+internal fun RegionalGuideRoute.isFavoriteReentryRoute(): Boolean =
+    !initialFavoriteTargetId.isNullOrBlank()
+
+private inline fun <reified T : Any> NavHostController.navigateBottomTabClearingFavoriteReentry(
+    currentBackStackEntry: NavBackStackEntry?,
+    route: T,
+) {
+    if (currentBackStackEntry.isFavoriteRegionalGuideSelected()) {
+        popBackStack<FavoritesRoute>(inclusive = false)
+    }
+
+    navigateBottomTab(route)
+}
+
+private fun NavBackStackEntry?.isItemGuideDetailSource(source: ItemGuideDetailSource): Boolean =
+    this != null &&
+        destination.hasRoute<ItemGuideDetailRoute>() &&
+        toRoute<ItemGuideDetailRoute>().source == source
+
+private fun NavHostController.navigateFavoritesRoot(
+    currentBackStackEntry: NavBackStackEntry?,
+) {
+    when {
+        currentBackStackEntry?.destination?.hasRoute<FavoritesRoute>() == true -> return
+        currentBackStackEntry.isItemGuideDetailSource(ItemGuideDetailSource.FAVORITES) -> {
+            popBackStack<FavoritesRoute>(inclusive = false)
+        }
+        else -> {
+            navigate(FavoritesRoute) {
+                popUpTo(graph.findStartDestination().id) {
+                    saveState = true
+                }
+                launchSingleTop = true
+                restoreState = false
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/FavoriteSpotNavigationMapper.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/FavoriteSpotNavigationMapper.kt
@@ -1,0 +1,45 @@
+package com.team.yeogibeoryeo.navigation
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteCollectionSpotMapMoveRequest
+import com.team.yeogibeoryeo.presentation.map.model.FavoriteSpotMapMoveRequest
+import java.util.UUID
+
+internal fun FavoriteCollectionSpotMapMoveRequest.toMapRoute(): MapRoute =
+    MapRoute(
+        favoriteSpotRequestId = UUID.randomUUID().toString(),
+        favoriteSpotTargetId = targetId,
+        favoriteSpotName = name,
+        favoriteSpotType = type.name,
+        favoriteSpotAddress = address,
+        favoriteSpotDetailLocation = detailLocation,
+        favoriteSpotLatitude = latitude,
+        favoriteSpotLongitude = longitude,
+    )
+
+internal fun MapRoute.toFavoriteSpotMapMoveRequest(): FavoriteSpotMapMoveRequest? {
+    val targetId = favoriteSpotTargetId ?: return null
+    val name = favoriteSpotName ?: return null
+    val typeName = favoriteSpotType ?: return null
+    val address = favoriteSpotAddress ?: return null
+    val latitude = favoriteSpotLatitude ?: return null
+    val longitude = favoriteSpotLongitude ?: return null
+    val type =
+        runCatching {
+            CollectionSpotType.valueOf(typeName)
+        }.getOrNull() ?: return null
+
+    return FavoriteSpotMapMoveRequest(
+        requestId = favoriteSpotRequestId ?: targetId,
+        targetId = targetId,
+        name = name,
+        type = type,
+        address = address,
+        detailLocation = favoriteSpotDetailLocation,
+        coordinate = Coordinate(
+            latitude = latitude,
+            longitude = longitude,
+        ),
+    )
+}

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -28,19 +27,10 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
-import java.util.UUID
 import com.team.yeogibeoryeo.common.navigation.AppBottomNavigationBar
-import com.team.yeogibeoryeo.common.navigation.BottomNavigationItem
-import com.team.yeogibeoryeo.common.navigation.navigateBottomTab
 import com.team.yeogibeoryeo.presentation.favorites.FavoritesRoute as FavoritesScreenRoute
-import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteCollectionSpotMapMoveRequest
 import com.team.yeogibeoryeo.presentation.map.CollectionSpotMapScreen
-import com.team.yeogibeoryeo.presentation.map.model.FavoriteSpotMapMoveRequest
 import com.team.yeogibeoryeo.presentation.regionalguide.RegionalGuideRoute as RegionalGuideScreenRoute
-import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
-import com.team.yeogibeoryeo.domain.spot.model.Coordinate
-import com.team.yeogibeoryeo.common.R as CommonR
-import com.team.yeogibeoryeo.R as AppR
 import com.team.yeogibeoryeo.presentation.search.ItemGuideDetailRoute as ItemGuideDetailScreenRoute
 import com.team.yeogibeoryeo.presentation.search.ItemSearchRoute as ItemSearchScreenRoute
 
@@ -80,57 +70,11 @@ fun YeogiBeoryeoNavHost(
                 exit = exitTransition,
             ) {
                 AppBottomNavigationBar(
-                    items =
-                        listOf(
-                            BottomNavigationItem(
-                                label = "품목",
-                                iconResId = CommonR.drawable.ic_symbol_recycle,
-                                selected = currentBackStackEntry.isItemSearchSelected(),
-                                onClick = {
-                                    navController.navigateBottomTabClearingFavoriteReentry(
-                                        currentBackStackEntry = currentBackStackEntry,
-                                        route = ItemSearchRoute(),
-                                    )
-                                },
-                            ),
-                            BottomNavigationItem(
-                                label = "지도",
-                                iconResId = AppR.drawable.ic_navigation_map,
-                                selected = currentDestination?.hasRoute<MapRoute>() == true,
-                                onClick = {
-                                    isBottomBarVisible = true
-                                    navController.navigateBottomTabClearingFavoriteReentry(
-                                        currentBackStackEntry = currentBackStackEntry,
-                                        route = MapRoute(),
-                                    )
-                                },
-                            ),
-                            BottomNavigationItem(
-                                label = "안내",
-                                iconResId = AppR.drawable.ic_navigation_guide,
-                                selected = currentBackStackEntry.isRegionalGuideSelected(),
-                                onClick = {
-                                    navController.navigateBottomTabClearingFavoriteReentry(
-                                        currentBackStackEntry = currentBackStackEntry,
-                                        route = RegionalGuideRoute(),
-                                    )
-                                },
-                            ),
-                            BottomNavigationItem(
-                                label = "저장",
-                                iconResId = CommonR.drawable.ic_favorite,
-                                selected = currentBackStackEntry.isFavoritesSelected(),
-                                onClick = {
-                                  if (currentBackStackEntry.isFavoriteRegionalGuideSelected()) {
-                                      navController.popBackStack<FavoritesRoute>(inclusive = false)
-                                  } else {
-                                      navController.navigateFavoritesRoot(
-                                          currentBackStackEntry = currentBackStackEntry,
-                                      )
-                                  }
-                                },
-                            ),
-                        ),
+                    items = navController.createBottomNavigationItems(
+                        currentBackStackEntry = currentBackStackEntry,
+                        currentDestination = currentDestination,
+                        onMapTabSelected = { isBottomBarVisible = true },
+                    ),
                 )
             }
         },
@@ -217,99 +161,4 @@ fun YeogiBeoryeoNavHost(
             }
         }
     }
-}
-
-private fun NavBackStackEntry?.isItemSearchSelected(): Boolean =
-    this?.destination?.hasRoute<ItemSearchRoute>() == true ||
-        isItemGuideDetailSource(ItemGuideDetailSource.SEARCH)
-
-private fun NavBackStackEntry?.isFavoritesSelected(): Boolean =
-    this?.destination?.hasRoute<FavoritesRoute>() == true ||
-        isItemGuideDetailSource(ItemGuideDetailSource.FAVORITES) ||
-        isFavoriteRegionalGuideSelected()
-
-private fun NavBackStackEntry?.isRegionalGuideSelected(): Boolean =
-    this?.destination?.hasRoute<RegionalGuideRoute>() == true &&
-        !isFavoriteRegionalGuideSelected()
-
-private fun NavBackStackEntry?.isFavoriteRegionalGuideSelected(): Boolean =
-    this != null &&
-        destination.hasRoute<RegionalGuideRoute>() &&
-        toRoute<RegionalGuideRoute>().isFavoriteReentryRoute()
-
-internal fun RegionalGuideRoute.isFavoriteReentryRoute(): Boolean =
-    !initialFavoriteTargetId.isNullOrBlank()
-
-private inline fun <reified T : Any> NavHostController.navigateBottomTabClearingFavoriteReentry(
-    currentBackStackEntry: NavBackStackEntry?,
-    route: T,
-) {
-    if (currentBackStackEntry.isFavoriteRegionalGuideSelected()) {
-        popBackStack<FavoritesRoute>(inclusive = false)
-    }
-
-    navigateBottomTab(route)
-}
-
-private fun NavBackStackEntry?.isItemGuideDetailSource(source: ItemGuideDetailSource): Boolean =
-    this != null &&
-        destination.hasRoute<ItemGuideDetailRoute>() &&
-        toRoute<ItemGuideDetailRoute>().source == source
-
-private fun NavHostController.navigateFavoritesRoot(
-    currentBackStackEntry: NavBackStackEntry?,
-) {
-    when {
-        currentBackStackEntry?.destination?.hasRoute<FavoritesRoute>() == true -> return
-        currentBackStackEntry.isItemGuideDetailSource(ItemGuideDetailSource.FAVORITES) -> {
-            popBackStack<FavoritesRoute>(inclusive = false)
-        }
-        else -> {
-            navigate(FavoritesRoute) {
-                popUpTo(graph.findStartDestination().id) {
-                    saveState = true
-                }
-                launchSingleTop = true
-                restoreState = false
-            }
-        }
-    }
-}
-
-private fun FavoriteCollectionSpotMapMoveRequest.toMapRoute(): MapRoute =
-    MapRoute(
-        favoriteSpotRequestId = UUID.randomUUID().toString(),
-        favoriteSpotTargetId = targetId,
-        favoriteSpotName = name,
-        favoriteSpotType = type.name,
-        favoriteSpotAddress = address,
-        favoriteSpotDetailLocation = detailLocation,
-        favoriteSpotLatitude = latitude,
-        favoriteSpotLongitude = longitude,
-    )
-
-private fun MapRoute.toFavoriteSpotMapMoveRequest(): FavoriteSpotMapMoveRequest? {
-    val targetId = favoriteSpotTargetId ?: return null
-    val name = favoriteSpotName ?: return null
-    val typeName = favoriteSpotType ?: return null
-    val address = favoriteSpotAddress ?: return null
-    val latitude = favoriteSpotLatitude ?: return null
-    val longitude = favoriteSpotLongitude ?: return null
-    val type =
-        runCatching {
-            CollectionSpotType.valueOf(typeName)
-        }.getOrNull() ?: return null
-
-    return FavoriteSpotMapMoveRequest(
-        requestId = favoriteSpotRequestId ?: targetId,
-        targetId = targetId,
-        name = name,
-        type = type,
-        address = address,
-        detailLocation = favoriteSpotDetailLocation,
-        coordinate = Coordinate(
-            latitude = latitude,
-            longitude = longitude,
-        ),
-    )
 }


### PR DESCRIPTION
## 작업 내용

- `YeogiBeoryeoNavHost.kt`에서 하단 탭 item 구성과 selected 판별 로직을 분리했습니다.
- Favorites root 재진입 정책을 `BottomTabNavigation.kt`로 옮겼습니다.
- 즐겨찾기 장소 이동 request와 `MapRoute` 간 변환 로직을 `FavoriteSpotNavigationMapper.kt`로 분리했습니다.
- feature별 graph 분리는 팀 의견대로 이번 범위에서 제외했습니다.

## 변경 이유

#138에서 팀원 의견을 받은 결과, 전체 navigation 구조를 크게 바꾸기보다 `app/navigation` 패키지 안에서 BottomBar 정책과 route 변환 로직만 작게 분리하는 방향으로 합의했습니다.

이번 변경은 `YeogiBeoryeoNavHost.kt`가 Scaffold/NavHost 조립과 route 연결 흐름에 더 집중하도록 보조 정책을 별도 파일로 옮기는 refactor입니다.

## 주요 변경 사항

- `BottomTabNavigation.kt`
  - 하단 탭 item 구성
  - 탭 selected 상태 판별
  - Favorites root 재진입 정책
  - 지역 가이드 즐겨찾기 재진입 route 정리

- `FavoriteSpotNavigationMapper.kt`
  - `FavoriteCollectionSpotMapMoveRequest.toMapRoute()`
  - `MapRoute.toFavoriteSpotMapMoveRequest()`

- `YeogiBeoryeoNavHost.kt`
  - BottomBar item 생성 세부 구현 제거
  - route 연결 흐름 중심으로 정리

## 확인 사항

- route type 변경 없음
- BottomNavigation UI 변경 없음
- 품목/지도/지역/즐겨찾기 동작 변경 없음
- feature별 graph 분리는 후순위로 유지

## 테스트

- `git diff --check`
- `./gradlew.bat :app:compileDebugKotlin`
- `./gradlew.bat :app:testDebugUnitTest`

## 관련 이슈

Related #138
