### PR TITLE
refactor: 수거 장소 즐겨찾기 결합 로직을 UseCase로 이동

### DIFF
--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/CollectionSpotFavorite.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/CollectionSpotFavorite.kt
@@ -1,0 +1,7 @@
+package com.team.yeogibeoryeo.domain.favorite.model
+
+data class CollectionSpotFavorite(
+    val targetId: String,
+    val savedAtMillis: Long,
+    val snapshot: CollectionSpotFavoriteSnapshot,
+)

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ObserveCollectionSpotFavoritesUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/usecase/ObserveCollectionSpotFavoritesUseCase.kt
@@ -1,0 +1,36 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.combine
+
+class ObserveCollectionSpotFavoritesUseCase
+    @Inject
+    constructor(
+        private val favoriteRepository: FavoriteRepository,
+        private val snapshotRepository: CollectionSpotFavoriteSnapshotRepository,
+    ) {
+        operator fun invoke() =
+            combine(
+                favoriteRepository.observeFavorites(),
+                snapshotRepository.observeSnapshots(),
+            ) { favorites, snapshots ->
+                val snapshotsByTargetId = snapshots.associateBy { snapshot -> snapshot.targetId }
+
+                favorites
+                    .filter { favorite -> favorite.type == FavoriteTargetType.COLLECTION_SPOT }
+                    .sortedByDescending { favorite -> favorite.savedAtMillis }
+                    .mapNotNull { favorite ->
+                        snapshotsByTargetId[favorite.targetId]?.let { snapshot ->
+                            CollectionSpotFavorite(
+                                targetId = favorite.targetId,
+                                savedAtMillis = favorite.savedAtMillis,
+                                snapshot = snapshot,
+                            )
+                        }
+                    }
+            }
+    }

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/usecase/ObserveCollectionSpotFavoritesUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/usecase/ObserveCollectionSpotFavoritesUseCaseTest.kt
@@ -1,0 +1,201 @@
+package com.team.yeogibeoryeo.domain.favorite.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavorite
+import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSnapshotRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ObserveCollectionSpotFavoritesUseCaseTest {
+    @Test
+    fun `collection spot favorites are emitted in favorite order`() =
+        runBlocking {
+            val olderSnapshot = snapshot(targetId = "spot-older")
+            val newerSnapshot = snapshot(targetId = "spot-newer")
+            val useCase =
+                ObserveCollectionSpotFavoritesUseCase(
+                    favoriteRepository =
+                        FakeFavoriteRepository(
+                            favorites =
+                                listOf(
+                                    favorite(targetId = olderSnapshot.targetId, savedAtMillis = 1L),
+                                    favorite(targetId = newerSnapshot.targetId, savedAtMillis = 2L),
+                                ),
+                        ),
+                    snapshotRepository =
+                        FakeCollectionSpotFavoriteSnapshotRepository(
+                            snapshots = listOf(olderSnapshot, newerSnapshot),
+                        ),
+                )
+
+            val result = useCase().first()
+
+            assertEquals(
+                listOf("spot-newer", "spot-older"),
+                result.map { favorite -> favorite.targetId },
+            )
+            assertEquals(listOf(2L, 1L), result.map { favorite -> favorite.savedAtMillis })
+        }
+
+    @Test
+    fun `favorite without snapshot is excluded`() =
+        runBlocking {
+            val useCase =
+                ObserveCollectionSpotFavoritesUseCase(
+                    favoriteRepository =
+                        FakeFavoriteRepository(
+                            favorites = listOf(favorite(targetId = "missing-snapshot")),
+                        ),
+                    snapshotRepository = FakeCollectionSpotFavoriteSnapshotRepository(),
+                )
+
+            assertEquals(emptyList<CollectionSpotFavorite>(), useCase().first())
+        }
+
+    @Test
+    fun `snapshot without favorite is excluded`() =
+        runBlocking {
+            val useCase =
+                ObserveCollectionSpotFavoritesUseCase(
+                    favoriteRepository = FakeFavoriteRepository(),
+                    snapshotRepository =
+                        FakeCollectionSpotFavoriteSnapshotRepository(
+                            snapshots = listOf(snapshot(targetId = "snapshot-only")),
+                        ),
+                )
+
+            assertEquals(emptyList<CollectionSpotFavorite>(), useCase().first())
+        }
+
+    @Test
+    fun `non collection spot favorites are excluded`() =
+        runBlocking {
+            val snapshot = snapshot(targetId = "spot-1")
+            val useCase =
+                ObserveCollectionSpotFavoritesUseCase(
+                    favoriteRepository =
+                        FakeFavoriteRepository(
+                            favorites =
+                                listOf(
+                                    Favorite(
+                                        type = FavoriteTargetType.ITEM_GUIDE,
+                                        targetId = snapshot.targetId,
+                                        savedAtMillis = 1L,
+                                    ),
+                                ),
+                        ),
+                    snapshotRepository =
+                        FakeCollectionSpotFavoriteSnapshotRepository(snapshots = listOf(snapshot)),
+                )
+
+            assertEquals(emptyList<CollectionSpotFavorite>(), useCase().first())
+        }
+
+    @Test
+    fun `combined result keeps favorite metadata and snapshot`() =
+        runBlocking {
+            val snapshot = snapshot(targetId = "spot-1")
+            val useCase =
+                ObserveCollectionSpotFavoritesUseCase(
+                    favoriteRepository =
+                        FakeFavoriteRepository(
+                            favorites = listOf(favorite(targetId = snapshot.targetId, savedAtMillis = 3L)),
+                        ),
+                    snapshotRepository =
+                        FakeCollectionSpotFavoriteSnapshotRepository(snapshots = listOf(snapshot)),
+                )
+
+            val result = useCase().first().single()
+
+            assertEquals("spot-1", result.targetId)
+            assertEquals(3L, result.savedAtMillis)
+            assertEquals(snapshot, result.snapshot)
+        }
+
+    private fun favorite(
+        targetId: String,
+        savedAtMillis: Long = 1L,
+    ): Favorite =
+        Favorite(
+            type = FavoriteTargetType.COLLECTION_SPOT,
+            targetId = targetId,
+            savedAtMillis = savedAtMillis,
+        )
+
+    private fun snapshot(targetId: String): CollectionSpotFavoriteSnapshot =
+        CollectionSpotFavoriteSnapshot(
+            targetId = targetId,
+            name = "수거함",
+            type = CollectionSpotType.BATTERY_BIN,
+            address = "서울특별시 영등포구",
+            detailLocation = null,
+            coordinate = Coordinate(latitude = 37.5, longitude = 126.9),
+        )
+
+    private class FakeFavoriteRepository(
+        favorites: List<Favorite> = emptyList(),
+    ) : FavoriteRepository {
+        private val favorites = MutableStateFlow(favorites)
+
+        override fun observeFavorites(): Flow<List<Favorite>> = favorites
+
+        override fun observeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Flow<Boolean> =
+            favorites.map { items ->
+                items.any { favorite -> favorite.type == type && favorite.targetId == targetId }
+            }
+
+        override suspend fun isFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Boolean =
+            favorites.value.any { favorite -> favorite.type == type && favorite.targetId == targetId }
+
+        override suspend fun toggleFavorite(favorite: Favorite): Boolean = false
+
+        override suspend fun addFavorite(favorite: Favorite) {
+            favorites.value = favorites.value + favorite
+        }
+
+        override suspend fun removeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ) {
+            favorites.value =
+                favorites.value.filterNot { favorite -> favorite.type == type && favorite.targetId == targetId }
+        }
+    }
+
+    private class FakeCollectionSpotFavoriteSnapshotRepository(
+        snapshots: List<CollectionSpotFavoriteSnapshot> = emptyList(),
+    ) : CollectionSpotFavoriteSnapshotRepository {
+        private val snapshots = MutableStateFlow(snapshots)
+
+        override fun observeSnapshots(): Flow<List<CollectionSpotFavoriteSnapshot>> = snapshots
+
+        override suspend fun getSnapshot(targetId: String): CollectionSpotFavoriteSnapshot? =
+            snapshots.value.firstOrNull { snapshot -> snapshot.targetId == targetId }
+
+        override suspend fun upsertSnapshot(snapshot: CollectionSpotFavoriteSnapshot) {
+            snapshots.value =
+                snapshots.value
+                    .filterNot { it.targetId == snapshot.targetId } + snapshot
+        }
+
+        override suspend fun deleteSnapshot(targetId: String) {
+            snapshots.value = snapshots.value.filterNot { snapshot -> snapshot.targetId == targetId }
+        }
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModel.kt
@@ -3,7 +3,7 @@ package com.team.yeogibeoryeo.presentation.favorites
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
-import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveCollectionSpotFavoriteSnapshotsUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveCollectionSpotFavoritesUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveRegionalGuideFavoriteSnapshotsUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.RemoveCollectionSpotFavoriteUseCase
@@ -26,7 +26,7 @@ class FavoritesViewModel
     @Inject
     constructor(
         observeFavoritesUseCase: ObserveFavoritesUseCase,
-        observeCollectionSpotFavoriteSnapshotsUseCase: ObserveCollectionSpotFavoriteSnapshotsUseCase,
+        observeCollectionSpotFavoritesUseCase: ObserveCollectionSpotFavoritesUseCase,
         observeRegionalGuideFavoriteSnapshotsUseCase: ObserveRegionalGuideFavoriteSnapshotsUseCase,
         private val removeCollectionSpotFavoriteUseCase: RemoveCollectionSpotFavoriteUseCase,
         private val removeRegionalGuideFavoriteUseCase: RemoveRegionalGuideFavoriteUseCase,
@@ -40,24 +40,15 @@ class FavoritesViewModel
             combine(
                 selectedTab,
                 observeFavoritesUseCase(),
-                observeCollectionSpotFavoriteSnapshotsUseCase(),
+                observeCollectionSpotFavoritesUseCase(),
                 observeRegionalGuideFavoriteSnapshotsUseCase(),
-            ) { selectedTab, favorites, collectionSpotSnapshots, regionalGuideSnapshots ->
+            ) { selectedTab, favorites, collectionSpotFavorites, regionalGuideSnapshots ->
                 val itemGuideFavorites =
                     favorites
                         .filter { it.type == FavoriteTargetType.ITEM_GUIDE }
                         .mapNotNull { favorite -> itemGuideUiMapper.map(favorite) }
-                val collectionSpotFavoriteIds =
-                    favorites
-                        .filter { it.type == FavoriteTargetType.COLLECTION_SPOT }
-                val collectionSpotSnapshotsById =
-                    collectionSpotSnapshots.associateBy { snapshot -> snapshot.targetId }
-                val collectionSpotFavorites =
-                    collectionSpotFavoriteIds
-                        .mapNotNull { favorite ->
-                            collectionSpotSnapshotsById[favorite.targetId]
-                                ?.let { snapshot -> collectionSpotUiMapper.map(snapshot) }
-                        }
+                val collectionSpotFavoriteUiModels =
+                    collectionSpotFavorites.map { favorite -> collectionSpotUiMapper.map(favorite) }
                 val regionalGuideSnapshotsById =
                     regionalGuideSnapshots.associateBy { snapshot -> snapshot.targetId }
                 val regionalGuideFavorites =
@@ -71,7 +62,7 @@ class FavoritesViewModel
                     FavoritesUiState(
                         selectedTab = selectedTab,
                         itemGuideFavorites = itemGuideFavorites,
-                        collectionSpotFavorites = collectionSpotFavorites,
+                        collectionSpotFavorites = collectionSpotFavoriteUiModels,
                         regionalGuideFavorites = regionalGuideFavorites,
                     )
                 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/mapper/FavoriteCollectionSpotUiMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/mapper/FavoriteCollectionSpotUiMapper.kt
@@ -1,9 +1,8 @@
 package com.team.yeogibeoryeo.presentation.favorites.mapper
 
-import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavorite
 import com.team.yeogibeoryeo.domain.favorite.model.CollectionSpotFavoriteSnapshot
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
-import com.team.yeogibeoryeo.domain.favorite.usecase.GetCollectionSpotFavoriteSnapshotUseCase
 import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteCollectionSpotMapMoveRequest
 import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteUiModel
 import com.team.yeogibeoryeo.presentation.map.mapper.toDisplayName
@@ -11,22 +10,9 @@ import javax.inject.Inject
 
 class FavoriteCollectionSpotUiMapper
     @Inject
-    constructor(
-        private val getCollectionSpotFavoriteSnapshotUseCase: GetCollectionSpotFavoriteSnapshotUseCase,
-    ) {
-        suspend fun map(favorite: Favorite): FavoriteUiModel? {
-            if (favorite.type != FavoriteTargetType.COLLECTION_SPOT) return null
-
-            val snapshot = getCollectionSpotFavoriteSnapshotUseCase(favorite.targetId) ?: return null
-
-            return FavoriteUiModel(
-                type = FavoriteTargetType.COLLECTION_SPOT,
-                targetId = favorite.targetId,
-                title = snapshot.name,
-                subtitle = snapshot.toSubtitle(),
-                collectionSpotMapMoveRequest = snapshot.toMapMoveRequest(),
-            )
-        }
+    constructor() {
+        fun map(favorite: CollectionSpotFavorite): FavoriteUiModel =
+            map(favorite.snapshot)
 
         fun map(snapshot: CollectionSpotFavoriteSnapshot): FavoriteUiModel =
             FavoriteUiModel(

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesViewModelTest.kt
@@ -9,8 +9,7 @@ import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSn
 import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
 import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteRepository
 import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteSnapshotRepository
-import com.team.yeogibeoryeo.domain.favorite.usecase.GetCollectionSpotFavoriteSnapshotUseCase
-import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveCollectionSpotFavoriteSnapshotsUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveCollectionSpotFavoritesUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveRegionalGuideFavoriteSnapshotsUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.RemoveCollectionSpotFavoriteUseCase
@@ -486,8 +485,11 @@ class FavoritesViewModelTest {
     ): FavoritesViewModel =
         FavoritesViewModel(
             observeFavoritesUseCase = ObserveFavoritesUseCase(favoriteRepository),
-            observeCollectionSpotFavoriteSnapshotsUseCase =
-                ObserveCollectionSpotFavoriteSnapshotsUseCase(collectionSpotSnapshotRepository),
+            observeCollectionSpotFavoritesUseCase =
+                ObserveCollectionSpotFavoritesUseCase(
+                    favoriteRepository = favoriteRepository,
+                    snapshotRepository = collectionSpotSnapshotRepository,
+                ),
             observeRegionalGuideFavoriteSnapshotsUseCase =
                 ObserveRegionalGuideFavoriteSnapshotsUseCase(regionalGuideSnapshotRepository),
             removeCollectionSpotFavoriteUseCase =
@@ -507,10 +509,7 @@ class FavoritesViewModelTest {
                         ),
                 ),
             itemGuideUiMapper = FavoriteItemGuideUiMapper(GetDisposalItemGuideUseCase(itemRepository)),
-            collectionSpotUiMapper =
-                FavoriteCollectionSpotUiMapper(
-                    GetCollectionSpotFavoriteSnapshotUseCase(collectionSpotSnapshotRepository),
-                ),
+            collectionSpotUiMapper = FavoriteCollectionSpotUiMapper(),
             regionalGuideUiMapper = FavoriteRegionalGuideUiMapper(),
         )
 


### PR DESCRIPTION
## 작업 내용

- 수거 장소 즐겨찾기 목록 결합 로직을 `FavoritesViewModel`에서 domain UseCase로 이동했습니다.
- `CollectionSpotFavorite` domain model을 추가했습니다.
- `ObserveCollectionSpotFavoritesUseCase`를 추가했습니다.
  - 공통 `favorites` 목록과 `collection_spot_favorite_snapshots`를 `combine`
  - `FavoriteTargetType.COLLECTION_SPOT`만 필터링
  - `targetId` 기준으로 snapshot 매칭
  - `savedAtMillis DESC` 기준 정렬
  - snapshot이 없는 favorite 제외
  - common favorite 없이 snapshot만 남은 데이터 제외
- `FavoritesViewModel`은 결합된 수거 장소 즐겨찾기 목록을 받아 UI 모델로 변환하는 역할만 하도록 단순화했습니다.
- `FavoriteCollectionSpotUiMapper`에서 snapshot 조회 usecase 의존성을 제거했습니다.

## 변경 이유

기존에는 `FavoritesViewModel`이 수거 장소 즐겨찾기 목록을 만들기 위해 아래 정책을 직접 알고 있었습니다.

- `COLLECTION_SPOT` 타입 필터링
- `favorites`와 snapshot의 `targetId` 매칭
- `favorites.savedAtMillis DESC` 기준 순서 유지
- snapshot 누락 favorite 제외
- snapshot-only 데이터 제외

이 로직은 UI 상태 관리보다 “즐겨찾기 장소 목록을 어떤 기준으로 구성할지”에 가까운 비즈니스 규칙이라, domain 계층의 `ObserveCollectionSpotFavoritesUseCase`로 이동했습니다.

## 유지한 정책

- 공통 `favorites` 테이블 구조 변경 없음
- `collection_spot_favorite_snapshots` 테이블 구조 변경 없음
- Room migration 추가 없음
- 수거 장소 즐겨찾기 저장 / 삭제 로직 변경 없음
- 지도 BottomSheet 즐겨찾기 토글 동작 유지
- Favorites 장소 탭 목록 표시 동작 유지
- Favorites 장소 탭 즐겨찾기 해제 동작 유지
- 장소 목록 정렬은 `savedAtMillis DESC` 기준 유지
- snapshot이 없는 favorite은 목록에서 제외
- snapshot만 있고 common favorite이 없는 데이터는 목록에서 제외
- 좌표는 UI에 직접 노출하지 않음
- 품목 / 지역 즐겨찾기 흐름 유지

## 리뷰 시 확인하면 좋은 부분

- `ObserveCollectionSpotFavoritesUseCase`에서 결합 정책이 ViewModel에서 빠진 의도대로 잘 표현되어 있는지
- `savedAtMillis DESC` 정렬이 usecase에서 명시적으로 유지되는지
- snapshot 누락 favorite과 snapshot-only 데이터가 목록에서 제외되는지
- `FavoritesViewModel`이 수거 장소 favorite + snapshot 결합 정책을 더 이상 직접 알지 않는지
- `FavoriteCollectionSpotUiMapper`가 UI 모델 변환 책임만 가지도록 정리되었는지
- 기존 품목 / 장소 / 지역 탭 동작에 영향이 없어 보이는지

## 테스트

- [x] `./gradlew.bat :domain:test`
- [x] `./gradlew.bat :presentation:testDebugUnitTest`
- [x] `./gradlew.bat :presentation:compileDebugKotlin`
- [x] `./gradlew.bat :app:assembleDebug`
- [x] `git diff --check`

## 테스트 보강

- `ObserveCollectionSpotFavoritesUseCaseTest` 추가
  - `savedAtMillis DESC` 순서 유지
  - snapshot이 없는 favorite 제외
  - common favorite 없이 snapshot만 있는 데이터 제외
  - `COLLECTION_SPOT` 외 타입 제외
  - 결합 결과의 `targetId`, `savedAtMillis`, snapshot 값 검증
- `FavoritesViewModelTest`를 새 usecase 구조에 맞게 수정

## 실제 기기 검증

- [x] Favorites 장소 탭 목록 정상 표시
- [x] 장소 즐겨찾기 해제 후 목록 즉시 갱신
- [x] 지도 BottomSheet 즐겨찾기 토글 동작 유지
- [x] 품목 즐겨찾기 목록 / 해제 동작 유지
- [x] 지역 탭 동작 유지
- [x] 앱 사용 중 크래시 없음

## 관련 이슈

Related #119