### PR TITLE
[Refactor] 품목 로딩 UI 컴포넌트 정리

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailRoute.kt
@@ -1,11 +1,9 @@
 package com.team.yeogibeoryeo.presentation.search
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -16,7 +14,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -26,6 +23,7 @@ import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.favorites.components.FavoriteSnackbar
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchStatusDescription
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchStatusContent
+import com.team.yeogibeoryeo.presentation.search.components.ItemSearchLoadingContent
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchStatusTitle
 
 @Composable
@@ -65,14 +63,11 @@ fun ItemGuideDetailRoute(
     ) { innerPadding ->
         when (val state = uiState) {
             ItemGuideDetailUiState.Loading -> {
-                Box(
+                ItemSearchLoadingContent(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(innerPadding),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    CircularProgressIndicator()
-                }
+                )
             }
 
             is ItemGuideDetailUiState.Success -> {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -3,7 +3,6 @@ package com.team.yeogibeoryeo.presentation.search
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,7 +12,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -23,12 +21,9 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
@@ -36,6 +31,7 @@ import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.search.components.DisposalItemCard
 import com.team.yeogibeoryeo.presentation.search.components.EmptySearchResult
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchBar
+import com.team.yeogibeoryeo.presentation.search.components.ItemSearchLoadingContent
 import com.team.yeogibeoryeo.presentation.search.components.QuickCategoryGrid
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
 
@@ -144,18 +140,7 @@ fun ItemSearchScreen(
         ) {
             when {
                 uiState.isLoading -> {
-                    val loadingContentDescription = stringResource(R.string.loading_action)
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.semantics {
-                                contentDescription = loadingContentDescription
-                            },
-                            color = MaterialTheme.colorScheme.primary,
-                        )
-                    }
+                    ItemSearchLoadingContent(modifier = Modifier.fillMaxSize())
                 }
 
                 uiState.errorMessageResId != null -> {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchStatusContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchStatusContent.kt
@@ -1,12 +1,15 @@
 package com.team.yeogibeoryeo.presentation.search.components
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -14,6 +17,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -80,6 +85,25 @@ fun ItemSearchStatusDescription(
     )
 }
 
+@Composable
+fun ItemSearchLoadingContent(
+    modifier: Modifier = Modifier,
+) {
+    val loadingContentDescription = stringResource(R.string.loading_action)
+
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.semantics {
+                contentDescription = loadingContentDescription
+            },
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun ItemSearchStatusContentEmptyPreview() {
@@ -95,6 +119,16 @@ private fun ItemSearchStatusContentEmptyPreview() {
                     )
                 },
             )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ItemSearchLoadingContentPreview() {
+    YeogiBeoryeoTheme {
+        Surface {
+            ItemSearchLoadingContent()
         }
     }
 }


### PR DESCRIPTION
## 작업 내용

- 품목 검색/상세 로딩 표시를 `ItemSearchLoadingContent`로 정리했습니다.
- 품목 검색 로딩 상태에서 사용하던 접근성 설명을 품목 상세 로딩 상태에도 동일하게 적용했습니다.

## 변경 이유

품목 검색 화면과 품목 상세 화면이 같은 로딩 표현을 각각 직접 렌더링하고 있어, 품목 feature 내부에서만 재사용 가능한 작은 컴포넌트로 정리했습니다.

## 주요 변경 사항

- `ItemSearchStatusContent.kt`에 `ItemSearchLoadingContent` 추가
- `ItemSearchScreen` 로딩 분기에서 전용 컴포넌트 사용
- `ItemGuideDetailRoute` 로딩 분기에서 전용 컴포넌트 사용

## 확인 사항

- 지도/지역 가이드/즐겨찾기 상태 UI는 변경하지 않았습니다.
- empty/error UI 구조는 변경하지 않았습니다.
- `common` 모듈은 변경하지 않았습니다.

## 테스트

- [x] `./gradlew.bat :presentation:compileDebugKotlin`

## 관련 이슈

Related #141
