### PR TITLE
[Refactor] 즐겨찾기 스낵바 위치 정리

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/components/FavoriteSnackbar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/components/FavoriteSnackbar.kt
@@ -1,4 +1,4 @@
-package com.team.yeogibeoryeo.presentation.favorites.components
+package com.team.yeogibeoryeo.presentation.common.components
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailRoute.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.yeogibeoryeo.presentation.R
-import com.team.yeogibeoryeo.presentation.favorites.components.FavoriteSnackbar
+import com.team.yeogibeoryeo.presentation.common.components.FavoriteSnackbar
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchStatusDescription
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchStatusContent
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchLoadingContent


### PR DESCRIPTION
## 작업 내용

- `FavoriteSnackbar`를 `presentation.favorites.components`에서 `presentation.common.components`로 이동했습니다.
- 품목 상세 화면의 import 경로를 새 위치로 수정했습니다.
- 기존 preview는 이동한 파일에서 유지했습니다.

## 변경 이유

`FavoriteSnackbar`는 Favorites 탭 전용 UI라기보다 품목 상세, 지도 상세, 지역 가이드 등 즐겨찾기 추가/해제 피드백에 함께 쓰일 수 있는 UI입니다.

팀원 의견에 따라 바로 `common` 모듈로 올리기보다, 우선 presentation 내부 공통 컴포넌트 위치로 이동했습니다.

## 주요 변경 사항

- `FavoriteSnackbar.kt` 패키지 이동
- `ItemGuideDetailRoute` import 경로 수정

## 확인 사항

- snackbar one-shot event 처리 구조는 변경하지 않았습니다.
- 즐겨찾기 저장/해제 로직은 변경하지 않았습니다.
- snackbar 디자인은 변경하지 않았습니다.

## 테스트

- [x] `./gradlew.bat :presentation:compileDebugKotlin`

## 관련 이슈

Related #131
