### PR TITLE
[Refactor] 품목 초기 화면 전체 스크롤 구조 정리

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
@@ -1,0 +1,95 @@
+package com.team.yeogibeoryeo.presentation.search
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.search.components.ItemSearchBar
+import com.team.yeogibeoryeo.presentation.search.components.QuickCategoryGrid
+import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
+
+@Composable
+fun ItemSearchInitialContent(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onSearchClick: () -> Unit,
+    onQuickCategoryClick: (RepresentativeGuideCategory) -> Unit,
+    listState: LazyListState,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+
+    LazyColumn(
+        state = listState,
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(horizontal = spacing.xl)
+            .padding(top = spacing.xl),
+        contentPadding = PaddingValues(bottom = spacing.xl),
+        verticalArrangement = Arrangement.spacedBy(spacing.xl),
+    ) {
+        item {
+            ItemSearchHeader()
+        }
+
+        item {
+            ItemSearchBar(
+                keyword = query,
+                onKeywordChange = onQueryChange,
+                onSearchClick = onSearchClick,
+                placeholder = stringResource(R.string.item_search_query_label),
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+
+        item {
+            Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+                Text(
+                    text = stringResource(R.string.quick_categories),
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    ),
+                )
+                QuickCategoryGrid(onCategoryClick = onQuickCategoryClick)
+            }
+        }
+    }
+}
+
+@Composable
+fun ItemSearchHeader(
+    modifier: Modifier = Modifier,
+) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(spacing.xs),
+    ) {
+        Text(
+            text = stringResource(R.string.item_search_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = stringResource(R.string.item_search_description),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -32,7 +32,6 @@ import com.team.yeogibeoryeo.presentation.search.components.DisposalItemCard
 import com.team.yeogibeoryeo.presentation.search.components.EmptySearchResult
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchBar
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchLoadingContent
-import com.team.yeogibeoryeo.presentation.search.components.QuickCategoryGrid
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
 
 @Composable
@@ -102,43 +101,14 @@ fun ItemSearchScreen(
     val spacing = ItemSearchLayoutDefaults.spacing
 
     if (!uiState.hasSearched && !uiState.isLoading && uiState.errorMessageResId == null) {
-        LazyColumn(
-            state = categoryListState,
-            modifier = modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
-                .padding(horizontal = spacing.xl)
-                .padding(top = spacing.xl),
-            contentPadding = PaddingValues(bottom = spacing.xl),
-            verticalArrangement = Arrangement.spacedBy(spacing.xl),
-        ) {
-            item {
-                ItemSearchHeader()
-            }
-
-            item {
-                ItemSearchBar(
-                    keyword = uiState.query,
-                    onKeywordChange = onQueryChange,
-                    onSearchClick = onSearchClick,
-                    placeholder = stringResource(R.string.item_search_query_label),
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-
-            item {
-                Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
-                    Text(
-                        text = stringResource(R.string.quick_categories),
-                        style = MaterialTheme.typography.titleMedium.copy(
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface
-                        ),
-                    )
-                    QuickCategoryGrid(onCategoryClick = onQuickCategoryClick)
-                }
-            }
-        }
+        ItemSearchInitialContent(
+            query = uiState.query,
+            onQueryChange = onQueryChange,
+            onSearchClick = onSearchClick,
+            onQuickCategoryClick = onQuickCategoryClick,
+            listState = categoryListState,
+            modifier = modifier,
+        )
         return
     }
 
@@ -162,7 +132,6 @@ fun ItemSearchScreen(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        // 검색 결과 또는 제안 섹션
         Column(
             modifier = Modifier.weight(1f),
             verticalArrangement = Arrangement.spacedBy(spacing.md)
@@ -213,29 +182,5 @@ fun ItemSearchScreen(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun ItemSearchHeader(
-    modifier: Modifier = Modifier,
-) {
-    val spacing = ItemSearchLayoutDefaults.spacing
-
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(spacing.xs),
-    ) {
-        Text(
-            text = stringResource(R.string.item_search_title),
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-        Text(
-            text = stringResource(R.string.item_search_description),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -101,6 +101,47 @@ fun ItemSearchScreen(
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
 
+    if (!uiState.hasSearched && !uiState.isLoading && uiState.errorMessageResId == null) {
+        LazyColumn(
+            state = categoryListState,
+            modifier = modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(horizontal = spacing.xl)
+                .padding(top = spacing.xl),
+            contentPadding = PaddingValues(bottom = spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(spacing.xl),
+        ) {
+            item {
+                ItemSearchHeader()
+            }
+
+            item {
+                ItemSearchBar(
+                    keyword = uiState.query,
+                    onKeywordChange = onQueryChange,
+                    onSearchClick = onSearchClick,
+                    placeholder = stringResource(R.string.item_search_query_label),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+                    Text(
+                        text = stringResource(R.string.quick_categories),
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface
+                        ),
+                    )
+                    QuickCategoryGrid(onCategoryClick = onQuickCategoryClick)
+                }
+            }
+        }
+        return
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -109,19 +150,7 @@ fun ItemSearchScreen(
             .padding(top = spacing.xl),
         verticalArrangement = Arrangement.spacedBy(spacing.xl),
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
-            Text(
-                text = stringResource(R.string.item_search_title),
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = stringResource(R.string.item_search_description),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+        ItemSearchHeader()
 
         ItemSearchBar(
             keyword = uiState.query,
@@ -148,28 +177,6 @@ fun ItemSearchScreen(
                         title = stringResource(uiState.errorMessageResId),
                         description = stringResource(R.string.retry_later_message),
                     )
-                }
-
-                !uiState.hasSearched -> {
-                    LazyColumn(
-                        state = categoryListState,
-                        modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(bottom = spacing.xl),
-                        verticalArrangement = Arrangement.spacedBy(spacing.md),
-                    ) {
-                        item {
-                            Text(
-                                text = stringResource(R.string.quick_categories),
-                                style = MaterialTheme.typography.titleMedium.copy(
-                                    fontWeight = FontWeight.Bold,
-                                    color = MaterialTheme.colorScheme.onSurface
-                                ),
-                            )
-                        }
-                        item {
-                            QuickCategoryGrid(onCategoryClick = onQuickCategoryClick)
-                        }
-                    }
                 }
 
                 uiState.guides.isEmpty() -> {
@@ -206,5 +213,29 @@ fun ItemSearchScreen(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun ItemSearchHeader(
+    modifier: Modifier = Modifier,
+) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(spacing.xs),
+    ) {
+        Text(
+            text = stringResource(R.string.item_search_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = stringResource(R.string.item_search_description),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }


### PR DESCRIPTION
## 작업 내용

품목 탭 초기 화면에서 제목, 설명, 검색창, 분리배출 분류가 하나의 스크롤 흐름에 놓이도록 정리했습니다.

## 변경 이유

기존 구조는 상단 안내/검색 영역은 고정되고 분리배출 분류 영역만 남은 높이 안에서 스크롤되었습니다. 글자 크기 확대 상태에서는 분류 영역이 더 좁아져 화면 전체를 자연스럽게 탐색하기 어려웠습니다.

## 주요 변경 사항

- 검색 전 초기 화면을 전체 `LazyColumn` 기반 스크롤 구조로 변경
- 초기 화면 UI를 `ItemSearchInitialContent`로 분리
- 검색 결과, 로딩, 빈 결과, 오류 상태의 기존 구조 유지

## 확인 사항

리뷰 시 품목 초기 화면에서 상단 안내/검색창과 분리배출 분류가 함께 스크롤되는지 봐주시면 됩니다.

## 테스트

- [x] `./gradlew.bat :presentation:compileDebugKotlin`
- [x] `./gradlew.bat :app:installDebug`
- [x] 실기기 `SM_A315N` 실행 확인
- [x] 글자 크기 1.1 상태에서 품목 초기 화면 스크롤 확인

## 관련 이슈

Related #145
