### PR TITLE
feat: 지도 상세에서 지역 가이드 이동 이벤트 제공

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -45,6 +45,7 @@ import com.team.yeogibeoryeo.presentation.map.model.FavoriteSpotMapMoveRequest
 fun CollectionSpotMapScreen(
     favoriteSpotMoveRequest: FavoriteSpotMapMoveRequest? = null,
     onBottomBarVisibilityChanged: (Boolean) -> Unit = {},
+    onRegionalGuideClick: (String) -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: CollectionSpotMapViewModel = hiltViewModel(),
 ) {
@@ -113,6 +114,7 @@ fun CollectionSpotMapScreen(
         onSpotClick = viewModel::onSpotClick,
         onSpotFavoriteClick = viewModel::onSpotFavoriteClick,
         onBottomBarVisibilityChanged = onBottomBarVisibilityChanged,
+        onRegionalGuideClick = onRegionalGuideClick,
         modifier = modifier,
     )
 }
@@ -132,6 +134,7 @@ private fun CollectionSpotMapContent(
     onSpotClick: (CollectionSpot) -> Unit,
     onSpotFavoriteClick: (CollectionSpot) -> Unit,
     onBottomBarVisibilityChanged: (Boolean) -> Unit,
+    onRegionalGuideClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val isSpotSearchLoading = uiState.isLoading &&
@@ -342,6 +345,7 @@ private fun CollectionSpotMapContent(
                             spot = selectedSpot,
                             isNearbyLoading = uiState.isFavoriteSpotNearbyLoading,
                             onFavoriteClick = onSpotFavoriteClick,
+                            onRegionalGuideClick = onRegionalGuideClick,
                             onCloseClick = {
                                 mapUiMode = MapUiMode.ResultList
                                 sheetLevel = MapSheetLevel.Peek
@@ -428,6 +432,7 @@ private fun CollectionSpotMapContentPreview() {
                 onSpotClick = {},
                 onSpotFavoriteClick = {},
                 onBottomBarVisibilityChanged = {},
+                onRegionalGuideClick = {},
             )
         }
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -153,6 +154,7 @@ fun SpotDetailBottomSheetContent(
     spot: CollectionSpot,
     isNearbyLoading: Boolean = false,
     onFavoriteClick: (CollectionSpot) -> Unit,
+    onRegionalGuideClick: (String) -> Unit = {},
     onCloseClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -169,6 +171,17 @@ fun SpotDetailBottomSheetContent(
             onFavoriteClick = onFavoriteClick,
             modifier = Modifier.fillMaxWidth(),
         )
+
+        if (spot.address.isNotBlank()) {
+            FilledTonalButton(
+                onClick = { onRegionalGuideClick(spot.address) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp),
+            ) {
+                Text(text = "이 지역 배출 정보 보기")
+            }
+        }
 
         Row(
             modifier = Modifier


### PR DESCRIPTION
## 작업 내용

지도 장소 상세 BottomSheet에서 선택된 수거 장소의 주소를 지역별 배출 가이드 연결 작업에 사용할 수 있도록 callback 이벤트를 추가했습니다.

이번 PR에서는 실제 지역 가이드 화면으로 이동하는 navigation은 연결하지 않고, 지도 화면에서 선택된 장소의 `address`를 상위로 전달하는 이벤트까지만 제공합니다.

## 주요 변경 사항

- 수거 장소 상세 BottomSheet에 `이 지역 배출 정보 보기` 버튼 추가
- 선택된 수거 장소의 `address`가 비어 있지 않을 때만 버튼 표시
- 버튼 클릭 시 `onRegionalGuideClick(spot.address)` 호출
- `CollectionSpotMapScreen -> CollectionSpotMapContent -> SpotDetailBottomSheetContent`로 callback 전달
- 실제 `RegionalGuideRoute(initialAddress = address)` 연결은 정문님 작업 범위로 유지

## 화면

| 지도 장소 상세 BottomSheet |
| --- |
| <img width="360" alt="Screenshot_20260613_171422" src="https://github.com/user-attachments/assets/cef02b7f-0029-4cc8-99cc-414a670f8cae" /> |

## 작업 범위

이번 PR에서 처리한 범위:

`지도 상세 BottomSheet → 선택된 CollectionSpot.address → onRegionalGuideClick(address)`

후속/정문님 작업 범위:

`onRegionalGuideClick(address) → RegionalGuideRoute(initialAddress = address) → RegionalGuideViewModel.loadByAddress(address) → 주소 기반 지역별 배출 정보 조회`

## 유지한 정책

- 지도 검색 / 현재 위치 검색 / 현 지도 검색 로직은 변경하지 않았습니다.
- 지도 마커 / 카드 선택 / BottomSheet 동작은 유지했습니다.
- 즐겨찾기 추가 / 해제 로직은 변경하지 않았습니다.
- `RegionalGuideViewModel`, domain, data, `/info` 조회 로직은 수정하지 않았습니다.
- 주소가 없는 수거 장소는 지역 가이드 버튼을 표시하지 않습니다.

## 검증

실제 단말에서 확인했습니다.

- 장소 상세 BottomSheet 하단에 `이 지역 배출 정보 보기` 버튼 표시 확인
- 기존 지도 검색 동작 유지 확인
- 현재 위치 검색 / 현 지도 검색 동작 유지 확인
- 마커 선택 / 카드 선택 / BottomSheet 동작 유지 확인
- 즐겨찾기 토글 동작 유지 확인

Gradle 검증:

```bash
./gradlew.bat :presentation:testDebugUnitTest :presentation:compileDebugKotlin :app:assembleDebug --console=plain

```
BUILD SUCCESSFUL

## 리뷰 시 확인 부탁드릴 점

- onRegionalGuideClick(address) callback 전달 구조가 정문님 쪽 navigation 연결에 사용하기 적절한지
- 주소가 없는 장소에서 버튼을 숨기는 정책이 괜찮은지
- 실제 navigation 연결을 이번 PR에서 제외하고 이벤트 제공까지만 둔 범위가 적절한지

Related #120
