### PR TITLE
feat: 지도 장소 주소 기반 지역 가이드 연결

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
@@ -21,6 +21,11 @@ data class RegionalGuideRoute(
     val initialFavoriteTargetId: String? = null,
 )
 
+internal fun String.toRegionalGuideAddressRouteOrNull(): RegionalGuideRoute? =
+    trim()
+        .takeIf { address -> address.isNotBlank() }
+        ?.let { address -> RegionalGuideRoute(initialAddress = address) }
+
 @Serializable
 data object FavoritesRoute
 

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/BottomTabNavigation.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/BottomTabNavigation.kt
@@ -22,7 +22,7 @@ internal fun NavHostController.createBottomNavigationItems(
             iconResId = CommonR.drawable.ic_symbol_recycle,
             selected = currentBackStackEntry.isItemSearchSelected(),
             onClick = {
-                navigateBottomTabClearingFavoriteReentry(
+                navigateBottomTabClearingRegionalGuideReentry(
                     currentBackStackEntry = currentBackStackEntry,
                     route = ItemSearchRoute(),
                 )
@@ -34,9 +34,8 @@ internal fun NavHostController.createBottomNavigationItems(
             selected = currentDestination?.hasRoute<MapRoute>() == true,
             onClick = {
                 onMapTabSelected()
-                navigateBottomTabClearingFavoriteReentry(
+                navigateMapRoot(
                     currentBackStackEntry = currentBackStackEntry,
-                    route = MapRoute(),
                 )
             },
         ),
@@ -45,7 +44,7 @@ internal fun NavHostController.createBottomNavigationItems(
             iconResId = AppR.drawable.ic_navigation_guide,
             selected = currentBackStackEntry.isRegionalGuideSelected(),
             onClick = {
-                navigateBottomTabClearingFavoriteReentry(
+                navigateBottomTabClearingRegionalGuideReentry(
                     currentBackStackEntry = currentBackStackEntry,
                     route = RegionalGuideRoute(),
                 )
@@ -56,13 +55,9 @@ internal fun NavHostController.createBottomNavigationItems(
             iconResId = CommonR.drawable.ic_favorite,
             selected = currentBackStackEntry.isFavoritesSelected(),
             onClick = {
-                if (currentBackStackEntry.isFavoriteRegionalGuideSelected()) {
-                    popBackStack<FavoritesRoute>(inclusive = false)
-                } else {
-                    navigateFavoritesRoot(
-                        currentBackStackEntry = currentBackStackEntry,
-                    )
-                }
+                navigateFavoritesRootClearingRegionalGuideReentry(
+                    currentBackStackEntry = currentBackStackEntry,
+                )
             },
         ),
     )
@@ -73,28 +68,33 @@ private fun NavBackStackEntry?.isItemSearchSelected(): Boolean =
 
 private fun NavBackStackEntry?.isFavoritesSelected(): Boolean =
     this?.destination?.hasRoute<FavoritesRoute>() == true ||
-        isItemGuideDetailSource(ItemGuideDetailSource.FAVORITES) ||
-        isFavoriteRegionalGuideSelected()
+        isItemGuideDetailSource(ItemGuideDetailSource.FAVORITES)
 
 private fun NavBackStackEntry?.isRegionalGuideSelected(): Boolean =
-    this?.destination?.hasRoute<RegionalGuideRoute>() == true &&
-        !isFavoriteRegionalGuideSelected()
+    this?.destination?.hasRoute<RegionalGuideRoute>() == true
 
 private fun NavBackStackEntry?.isFavoriteRegionalGuideSelected(): Boolean =
     this != null &&
         destination.hasRoute<RegionalGuideRoute>() &&
         toRoute<RegionalGuideRoute>().isFavoriteReentryRoute()
 
+private fun NavBackStackEntry?.isMapRegionalGuideSelected(): Boolean =
+    this != null &&
+        destination.hasRoute<RegionalGuideRoute>() &&
+        toRoute<RegionalGuideRoute>().isMapReentryRoute()
+
 internal fun RegionalGuideRoute.isFavoriteReentryRoute(): Boolean =
     !initialFavoriteTargetId.isNullOrBlank()
 
-private inline fun <reified T : Any> NavHostController.navigateBottomTabClearingFavoriteReentry(
+internal fun RegionalGuideRoute.isMapReentryRoute(): Boolean =
+    initialFavoriteTargetId.isNullOrBlank() &&
+        !initialAddress.isNullOrBlank()
+
+private inline fun <reified T : Any> NavHostController.navigateBottomTabClearingRegionalGuideReentry(
     currentBackStackEntry: NavBackStackEntry?,
     route: T,
 ) {
-    if (currentBackStackEntry.isFavoriteRegionalGuideSelected()) {
-        popBackStack<FavoritesRoute>(inclusive = false)
-    }
+    popRegionalGuideReentryToSourceRoot(currentBackStackEntry)
 
     navigateBottomTab(route)
 }
@@ -120,6 +120,47 @@ private fun NavHostController.navigateFavoritesRoot(
                 launchSingleTop = true
                 restoreState = false
             }
+        }
+    }
+}
+
+private fun NavHostController.navigateMapRoot(
+    currentBackStackEntry: NavBackStackEntry?,
+) {
+    if (currentBackStackEntry.isMapRegionalGuideSelected()) {
+        popBackStack<MapRoute>(inclusive = false)
+        return
+    }
+
+    navigateBottomTabClearingRegionalGuideReentry(
+        currentBackStackEntry = currentBackStackEntry,
+        route = MapRoute(),
+    )
+}
+
+private fun NavHostController.navigateFavoritesRootClearingRegionalGuideReentry(
+    currentBackStackEntry: NavBackStackEntry?,
+) {
+    if (currentBackStackEntry.isFavoriteRegionalGuideSelected()) {
+        popBackStack<FavoritesRoute>(inclusive = false)
+        return
+    }
+
+    popRegionalGuideReentryToSourceRoot(currentBackStackEntry)
+    navigateFavoritesRoot(
+        currentBackStackEntry = currentBackStackEntry,
+    )
+}
+
+private fun NavHostController.popRegionalGuideReentryToSourceRoot(
+    currentBackStackEntry: NavBackStackEntry?,
+) {
+    when {
+        currentBackStackEntry.isFavoriteRegionalGuideSelected() -> {
+            popBackStack<FavoritesRoute>(inclusive = false)
+        }
+        currentBackStackEntry.isMapRegionalGuideSelected() -> {
+            popBackStack<MapRoute>(inclusive = false)
         }
     }
 }

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -93,6 +93,14 @@ fun YeogiBeoryeoNavHost(
                             isBottomBarVisible = isVisible
                         }
                     },
+                    onRegionalGuideClick = { address ->
+                        address.toRegionalGuideAddressRouteOrNull()
+                            ?.let { route ->
+                                navController.navigate(route) {
+                                    launchSingleTop = true
+                                }
+                            }
+                    },
                 )
             }
 

--- a/app/src/test/java/com/team/yeogibeoryeo/navigation/RegionalGuideRouteNavigationPolicyTest.kt
+++ b/app/src/test/java/com/team/yeogibeoryeo/navigation/RegionalGuideRouteNavigationPolicyTest.kt
@@ -30,11 +30,11 @@ class RegionalGuideRouteNavigationPolicyTest {
 
     @Test
     fun `spot address creates regional guide address route`() {
-        val address = " Seoul Yeongdeungpo-gu Mullae-dong (Mullae) "
+        val address = "  서울특별시 중구 남대문로 63 (남대문로2가, 한진빌딩)  "
 
         val route = address.toRegionalGuideAddressRouteOrNull()
 
-        assertEquals("Seoul Yeongdeungpo-gu Mullae-dong (Mullae)", route?.initialAddress)
+        assertEquals("서울특별시 중구 남대문로 63 (남대문로2가, 한진빌딩)", route?.initialAddress)
         assertFalse(route!!.isFavoriteReentryRoute())
         assertTrue(route.isMapReentryRoute())
     }
@@ -47,7 +47,7 @@ class RegionalGuideRouteNavigationPolicyTest {
     @Test
     fun `regional guide route with address and favorite target remains favorites reentry route`() {
         val route = RegionalGuideRoute(
-            initialAddress = "Seoul Yeongdeungpo-gu Mullae-dong",
+            initialAddress = "서울특별시 중구 남대문로 63 (남대문로2가, 한진빌딩)",
             initialFavoriteTargetId = "regional-guide-v1|4:Sido",
         )
 

--- a/app/src/test/java/com/team/yeogibeoryeo/navigation/RegionalGuideRouteNavigationPolicyTest.kt
+++ b/app/src/test/java/com/team/yeogibeoryeo/navigation/RegionalGuideRouteNavigationPolicyTest.kt
@@ -1,25 +1,57 @@
 package com.team.yeogibeoryeo.navigation
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class RegionalGuideRouteNavigationPolicyTest {
     @Test
     fun `regional guide route without favorite target is guide tab route`() {
-        assertFalse(RegionalGuideRoute().isFavoriteReentryRoute())
+        val route = RegionalGuideRoute()
+
+        assertFalse(route.isFavoriteReentryRoute())
+        assertFalse(route.isMapReentryRoute())
     }
 
     @Test
     fun `regional guide route with favorite target is favorites reentry route`() {
-        assertTrue(
-            RegionalGuideRoute(initialFavoriteTargetId = "regional-guide-v1|4:Sido")
-                .isFavoriteReentryRoute(),
-        )
+        val route = RegionalGuideRoute(initialFavoriteTargetId = "regional-guide-v1|4:Sido")
+
+        assertTrue(route.isFavoriteReentryRoute())
+        assertFalse(route.isMapReentryRoute())
     }
 
     @Test
     fun `blank favorite target is not favorites reentry route`() {
         assertFalse(RegionalGuideRoute(initialFavoriteTargetId = " ").isFavoriteReentryRoute())
+    }
+
+    @Test
+    fun `spot address creates regional guide address route`() {
+        val address = " Seoul Yeongdeungpo-gu Mullae-dong (Mullae) "
+
+        val route = address.toRegionalGuideAddressRouteOrNull()
+
+        assertEquals("Seoul Yeongdeungpo-gu Mullae-dong (Mullae)", route?.initialAddress)
+        assertFalse(route!!.isFavoriteReentryRoute())
+        assertTrue(route.isMapReentryRoute())
+    }
+
+    @Test
+    fun `blank spot address does not create regional guide address route`() {
+        assertNull(" ".toRegionalGuideAddressRouteOrNull())
+    }
+
+    @Test
+    fun `regional guide route with address and favorite target remains favorites reentry route`() {
+        val route = RegionalGuideRoute(
+            initialAddress = "Seoul Yeongdeungpo-gu Mullae-dong",
+            initialFavoriteTargetId = "regional-guide-v1|4:Sido",
+        )
+
+        assertTrue(route.isFavoriteReentryRoute())
+        assertFalse(route.isMapReentryRoute())
     }
 }


### PR DESCRIPTION
## 작업 내용

- #120에서 제공된 `onRegionalGuideClick(address)` callback을 App Navigation에 연결했습니다.
- 선택된 수거 장소의 `CollectionSpot.address`를 `RegionalGuideRoute(initialAddress = address)`로 전달합니다.
- blank 주소에서는 이동하지 않으며, 주소 기반 조회는 기존 `loadByAddress()` 흐름을 재사용합니다.
- 지역 가이드 화면의 하단 탭 선택과 지도/Favorites 복귀 정책을 정리했습니다.

## Navigation 정책

- 지역 가이드 화면에서는 진입 출처와 관계없이 하단 `안내` 탭을 선택 상태로 표시합니다.
- 시스템 뒤로가기 시 지도 또는 Favorites의 기존 화면으로 복귀합니다.
- 지역 가이드 화면에서 지도 탭을 선택하거나 다른 탭을 거쳐 지도 탭에 재진입하면, 이전 지역 가이드 상세가 아닌 지도 화면을 표시합니다.
- 기존 Favorites 루트 복귀와 품목·장소 즐겨찾기 Navigation 정책은 유지했습니다.

## 기존 흐름 유지

- `CollectionSpot.address`는 `/getSpot`의 `addrBase`를 사용하고, `addrDtl`은 `detailLocation`으로 분리된 기존 매핑을 유지합니다.
- #59의 주소 파싱 흐름과 #60의 `/info` 조회 key 정규화·후보 선택 구조를 재사용합니다.
- 진입 우선순위인 `initialFavoriteTargetId → initialAddress → initialKeyword`를 유지합니다.
- typed Navigation을 사용하며 수동 `Uri.encode()` / `Uri.decode()`는 추가하지 않았습니다.

## 테스트

- [x] `./gradlew :app:testDebugUnitTest`
- [x] `./gradlew :presentation:testDebugUnitTest`
- [x] `./gradlew :presentation:compileDebugKotlin`
- [x] `./gradlew :app:assembleDebug`
- [x] `git diff --check`

## 확인한 주요 케이스

- 지도 장소에서 `이 지역 배출 정보 보기` 클릭 시 지역 가이드 화면으로 이동
- 도로명·괄호가 포함된 주소가 깨지지 않고 전달되는 것 확인
- 전달된 주소가 `서울특별시 > 중구`로 파싱되어 `/info` 결과가 표시되는 것 확인
- 지역 가이드 화면에서 하단 `안내` 탭 선택 상태 확인
- 시스템 뒤로가기와 지도 탭 재진입 정책 확인
- 기존 품목·장소 즐겨찾기 Navigation 정책 유지

## 스크린샷

| 주소 기반 진입 | 지역 가이드 조회 결과 |
| --- | --- |
| 전달된 주소로 조회가 시작되고 하단 `안내` 탭이 선택된 상태 | 주소가 `서울특별시 > 중구`로 반영되어 조회 결과가 표시된 상태 |
| <img width="720" height="1520" alt="Screenshot_20260614_000040" src="https://github.com/user-attachments/assets/c0dc7d22-cf49-44f7-8c0e-c59d0b72e1a3" /> | <img width="720" height="1520" alt="Screenshot_20260614_000048" src="https://github.com/user-attachments/assets/f1121f7e-063b-4d02-9fb2-260483b16df3" /> |

## 알려진 제한 및 후속 작업

- 주소에서 추출한 법정동과 `/info` 응답의 행정동 단위가 다른 경우 후보 매칭에 실패할 수 있습니다.
  - 예: 하계동으로 파싱되지만 `/info` 후보는 하계1동, 하계2동으로 제공되는 경우
- 법정동 / 행정동 불일치 후보 매칭 보완은 #155에서 진행합니다.
- 주소 검색 API 연계와 동 단독 검색 보완은 별도 이슈에서 다룹니다.

## 관련 이슈

- Related #61
- Follow-up of #120