### PR TITLE
[Test] 품목 분류 그리드 경계값 테스트 보강

### DIFF
--- a/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridLabelLayoutTest.kt
+++ b/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridLabelLayoutTest.kt
@@ -1,0 +1,151 @@
+package com.team.yeogibeoryeo.presentation.search.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class QuickCategoryGridLabelLayoutTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun 발포합성수지_라벨은_일반_글자_크기_넓은_폭에서_한_줄로_표시된다() {
+        var lineCount: Int? = null
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDensity provides Density(density = 1f, fontScale = 1f)) {
+                MaterialTheme {
+                    val spec = quickCategoryGridMetricsSpec(maxWidth = 360.dp, fontScale = 1f)
+                    CompositionLocalProvider(
+                        LocalQuickCategoryGridMetrics provides spec.toMetrics(),
+                    ) {
+                        QuickCategoryItem(
+                            category = RepresentativeGuideCategory.STYROFOAM,
+                            name = RepresentativeGuideCategory.STYROFOAM.quickCategoryLabel,
+                            onClick = {},
+                            onLabelTextLayout = { lineCount = it.lineCount },
+                        )
+                    }
+                }
+            }
+        }
+
+        composeTestRule.waitUntil { lineCount != null }
+
+        assertEquals(1, lineCount)
+    }
+
+    @Test
+    fun 줄바꿈을_의도한_긴_라벨은_두_줄로_표시된다() {
+        var lineCount: Int? = null
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDensity provides Density(density = 1f, fontScale = 1f)) {
+                MaterialTheme {
+                    val spec = quickCategoryGridMetricsSpec(maxWidth = 360.dp, fontScale = 1f)
+                    CompositionLocalProvider(
+                        LocalQuickCategoryGridMetrics provides spec.toMetrics(),
+                    ) {
+                        QuickCategoryItem(
+                            category = RepresentativeGuideCategory.CONSTRUCTION_WASTE,
+                            name = RepresentativeGuideCategory.CONSTRUCTION_WASTE.quickCategoryLabel,
+                            onClick = {},
+                            onLabelTextLayout = { lineCount = it.lineCount },
+                        )
+                    }
+                }
+            }
+        }
+
+        composeTestRule.waitUntil { lineCount != null }
+
+        assertEquals(2, lineCount)
+    }
+
+    @Test
+    fun 불연성종량제폐기물_라벨은_폭과_글자_크기_경계값에서_두_줄_이하로_표시된다() {
+        val cases =
+            listOf(
+                LabelLineCountCase(maxWidthDp = 299, fontScale = 1.0f),
+                LabelLineCountCase(maxWidthDp = 300, fontScale = 1.0f),
+                LabelLineCountCase(maxWidthDp = 335, fontScale = 1.0f),
+                LabelLineCountCase(maxWidthDp = 336, fontScale = 1.0f),
+                LabelLineCountCase(maxWidthDp = 351, fontScale = 1.0f),
+                LabelLineCountCase(maxWidthDp = 352, fontScale = 1.0f),
+                LabelLineCountCase(maxWidthDp = 359, fontScale = 1.0f),
+                LabelLineCountCase(maxWidthDp = 360, fontScale = 1.0f),
+                LabelLineCountCase(maxWidthDp = 299, fontScale = 1.3f),
+                LabelLineCountCase(maxWidthDp = 300, fontScale = 1.3f),
+                LabelLineCountCase(maxWidthDp = 351, fontScale = 1.3f),
+                LabelLineCountCase(maxWidthDp = 352, fontScale = 1.3f),
+            )
+        val lineCounts = mutableMapOf<LabelLineCountCase, Int>()
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                Column {
+                    cases.forEach { case ->
+                        CompositionLocalProvider(
+                            LocalDensity provides Density(density = 1f, fontScale = case.fontScale),
+                        ) {
+                            val spec = quickCategoryGridMetricsSpec(
+                                maxWidth = case.maxWidthDp.dp,
+                                fontScale = case.fontScale,
+                            )
+                            CompositionLocalProvider(
+                                LocalQuickCategoryGridMetrics provides spec.toMetrics(),
+                            ) {
+                                QuickCategoryItem(
+                                    category = RepresentativeGuideCategory.NON_COMBUSTIBLE,
+                                    name = RepresentativeGuideCategory.NON_COMBUSTIBLE.quickCategoryLabel,
+                                    onClick = {},
+                                    onLabelTextLayout = { lineCounts[case] = it.lineCount },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        composeTestRule.waitUntil { cases.all { it in lineCounts } }
+
+        cases.forEach { case ->
+            val lineCount = lineCounts.getValue(case)
+            assertTrue(
+                "case=$case expected lineCount <= 2 but was $lineCount",
+                lineCount <= 2,
+            )
+        }
+    }
+
+    @Composable
+    private fun QuickCategoryGridMetricsSpec.toMetrics(): QuickCategoryGridMetrics =
+        QuickCategoryGridMetrics(
+            columnCount = columnCount,
+            cellSize = cellSize,
+            tileSize = tileSize,
+            iconSize = iconSize,
+            verticalSpace = verticalSpace,
+            labelSpacing = labelSpacing,
+            labelTextStyle = when (labelTextStyleType) {
+                QuickCategoryGridLabelTextStyleType.BodyLarge -> MaterialTheme.typography.bodyLarge
+                QuickCategoryGridLabelTextStyleType.LabelLarge -> MaterialTheme.typography.labelLarge
+            },
+        )
+
+    private data class LabelLineCountCase(
+        val maxWidthDp: Int,
+        val fontScale: Float,
+    )
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -122,10 +123,11 @@ private fun QuickCategoryRow(
 }
 
 @Composable
-private fun QuickCategoryItem(
+internal fun QuickCategoryItem(
     category: RepresentativeGuideCategory,
     name: String,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    onLabelTextLayout: (TextLayoutResult) -> Unit = {},
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
     val size = ItemSearchLayoutDefaults.size
@@ -172,6 +174,7 @@ private fun QuickCategoryItem(
                 color = MaterialTheme.colorScheme.onBackground,
             ),
             minLines = 2,
+            onTextLayout = onLabelTextLayout,
             textAlign = TextAlign.Center,
         )
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridMetrics.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridMetrics.kt
@@ -13,9 +13,32 @@ import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 internal fun quickCategoryGridMetrics(
     maxWidth: Dp,
 ): QuickCategoryGridMetrics {
+    val fontScale = LocalDensity.current.fontScale
+    val spec = quickCategoryGridMetricsSpec(
+        maxWidth = maxWidth,
+        fontScale = fontScale,
+    )
+
+    return QuickCategoryGridMetrics(
+        columnCount = spec.columnCount,
+        cellSize = spec.cellSize,
+        tileSize = spec.tileSize,
+        iconSize = spec.iconSize,
+        verticalSpace = spec.verticalSpace,
+        labelSpacing = spec.labelSpacing,
+        labelTextStyle = when (spec.labelTextStyleType) {
+            QuickCategoryGridLabelTextStyleType.BodyLarge -> MaterialTheme.typography.bodyLarge
+            QuickCategoryGridLabelTextStyleType.LabelLarge -> MaterialTheme.typography.labelLarge
+        },
+    )
+}
+
+internal fun quickCategoryGridMetricsSpec(
+    maxWidth: Dp,
+    fontScale: Float,
+): QuickCategoryGridMetricsSpec {
     val spacing = ItemSearchLayoutDefaults.spacing
     val size = ItemSearchLayoutDefaults.size
-    val fontScale = LocalDensity.current.fontScale
     val useLargeFontLayout = fontScale >= QuickCategoryGridBreakpoints.LargeFontScale
     val useFourColumnCompactVisuals =
         !useLargeFontLayout &&
@@ -27,24 +50,24 @@ internal fun quickCategoryGridMetrics(
     val useExpandedWidePhoneVisuals =
         !useLargeFontLayout &&
             maxWidth >= QuickCategoryGridBreakpoints.ExpandedWidePhoneContentWidth
-    val useRoomyPhoneVisuals =
+    val useLargePhoneVisuals =
         !useLargeFontLayout &&
-            maxWidth >= QuickCategoryGridBreakpoints.RoomyPhoneContentWidth
+            maxWidth >= QuickCategoryGridBreakpoints.LargePhoneContentWidth
     val useNarrowVisuals = maxWidth < QuickCategoryGridBreakpoints.NarrowContentWidth
     val useNarrowLargeFontLayout =
         useLargeFontLayout &&
             maxWidth < QuickCategoryGridBreakpoints.NarrowContentWidth
-    val useRoomyLargeFontLayout =
+    val useWideLargeFontLayout =
         useLargeFontLayout &&
-            maxWidth >= QuickCategoryGridBreakpoints.RoomyLargeFontContentWidth
+            maxWidth >= QuickCategoryGridBreakpoints.WideLargeFontContentWidth
 
     val cellSize =
         when {
             useNarrowLargeFontLayout -> QuickCategoryGridDefaults.NarrowLargeFontCellSize
-            useRoomyLargeFontLayout -> QuickCategoryGridDefaults.RoomyLargeFontCellSize
+            useWideLargeFontLayout -> QuickCategoryGridDefaults.WideLargeFontCellSize
             useLargeFontLayout -> QuickCategoryGridDefaults.LargeFontCellSize
             useExpandedWidePhoneVisuals -> QuickCategoryGridDefaults.ExpandedWidePhoneCellSize
-            useRoomyPhoneVisuals -> QuickCategoryGridDefaults.RoomyPhoneCellSize
+            useLargePhoneVisuals -> QuickCategoryGridDefaults.LargePhoneCellSize
             useWidePhoneVisuals -> QuickCategoryGridDefaults.WidePhoneCellSize
             useFourColumnCompactVisuals -> QuickCategoryGridDefaults.CompactCellSize
             useNarrowVisuals -> QuickCategoryGridDefaults.NarrowCellSize
@@ -54,7 +77,7 @@ internal fun quickCategoryGridMetrics(
         when {
             useLargeFontLayout -> QuickCategoryGridDefaults.LargeFontTileSize
             useExpandedWidePhoneVisuals -> QuickCategoryGridDefaults.WidePhoneTileSize
-            useRoomyPhoneVisuals -> QuickCategoryGridDefaults.WidePhoneTileSize
+            useLargePhoneVisuals -> QuickCategoryGridDefaults.WidePhoneTileSize
             useWidePhoneVisuals -> QuickCategoryGridDefaults.WidePhoneTileSize
             useFourColumnCompactVisuals -> QuickCategoryGridDefaults.CompactTileSize
             useNarrowVisuals -> QuickCategoryGridDefaults.NarrowTileSize
@@ -64,7 +87,7 @@ internal fun quickCategoryGridMetrics(
         when {
             useLargeFontLayout -> QuickCategoryGridDefaults.LargeFontIconSize
             useExpandedWidePhoneVisuals -> QuickCategoryGridDefaults.WidePhoneIconSize
-            useRoomyPhoneVisuals -> QuickCategoryGridDefaults.WidePhoneIconSize
+            useLargePhoneVisuals -> QuickCategoryGridDefaults.WidePhoneIconSize
             useWidePhoneVisuals -> QuickCategoryGridDefaults.WidePhoneIconSize
             useFourColumnCompactVisuals -> QuickCategoryGridDefaults.CompactIconSize
             useNarrowVisuals -> QuickCategoryGridDefaults.NarrowIconSize
@@ -93,20 +116,16 @@ internal fun quickCategoryGridMetrics(
             .toInt()
             .coerceIn(1, maxColumnCount)
 
-    return QuickCategoryGridMetrics(
+    return QuickCategoryGridMetricsSpec(
         columnCount = columnCount,
         cellSize = cellSize,
         tileSize = tileSize,
         iconSize = iconSize,
         verticalSpace = verticalSpace,
         labelSpacing = labelSpacing,
-        labelTextStyle = when {
-            useLargeFontLayout -> MaterialTheme.typography.bodyLarge
-            useExpandedWidePhoneVisuals -> MaterialTheme.typography.bodyLarge
-            useRoomyPhoneVisuals -> MaterialTheme.typography.bodyLarge
-            useWidePhoneVisuals -> MaterialTheme.typography.bodyLarge
-            useFourColumnCompactVisuals -> MaterialTheme.typography.labelLarge
-            else -> MaterialTheme.typography.bodyLarge
+        labelTextStyleType = when {
+            useFourColumnCompactVisuals -> QuickCategoryGridLabelTextStyleType.LabelLarge
+            else -> QuickCategoryGridLabelTextStyleType.BodyLarge
         },
     )
 }
@@ -121,6 +140,21 @@ internal data class QuickCategoryGridMetrics(
     val labelTextStyle: TextStyle,
 )
 
+internal data class QuickCategoryGridMetricsSpec(
+    val columnCount: Int,
+    val cellSize: Dp,
+    val tileSize: Dp,
+    val iconSize: Dp,
+    val verticalSpace: Dp,
+    val labelSpacing: Dp,
+    val labelTextStyleType: QuickCategoryGridLabelTextStyleType,
+)
+
+internal enum class QuickCategoryGridLabelTextStyleType {
+    BodyLarge,
+    LabelLarge,
+}
+
 internal val LocalQuickCategoryGridMetrics = compositionLocalOf<QuickCategoryGridMetrics> {
     error("QuickCategoryGridMetrics is not provided.")
 }
@@ -130,7 +164,7 @@ private object QuickCategoryGridDefaults {
     const val NarrowLargeFontMaxColumnCount = 2
     const val LargeFontMaxColumnCount = 3
     val NarrowLargeFontCellSize = 128.dp
-    val RoomyLargeFontCellSize = 112.dp
+    val WideLargeFontCellSize = 112.dp
     val NarrowCellSize = 80.dp
     val NarrowTileSize = 72.dp
     val NarrowIconSize = 36.dp
@@ -138,7 +172,7 @@ private object QuickCategoryGridDefaults {
     val CompactTileSize = 56.dp
     val CompactIconSize = 28.dp
     val WidePhoneCellSize = 84.dp
-    val RoomyPhoneCellSize = 88.dp
+    val LargePhoneCellSize = 88.dp
     val ExpandedWidePhoneCellSize = 90.dp
     val WidePhoneTileSize = 64.dp
     val WidePhoneIconSize = 32.dp
@@ -151,8 +185,8 @@ private object QuickCategoryGridBreakpoints {
     val NarrowContentWidth = 300.dp
     val FourColumnContentWidth = 336.dp
     val WidePhoneContentWidth = 336.dp
-    val RoomyPhoneContentWidth = 352.dp
+    val LargePhoneContentWidth = 352.dp
     val ExpandedWidePhoneContentWidth = 360.dp
-    val RoomyLargeFontContentWidth = 352.dp
+    val WideLargeFontContentWidth = 352.dp
     const val LargeFontScale = 1.3f
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridMetricsTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridMetricsTest.kt
@@ -1,0 +1,128 @@
+package com.team.yeogibeoryeo.presentation.search.components
+
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class QuickCategoryGridMetricsTest {
+    @Test
+    fun `일반 글자 크기에서는 300dp 미만만 좁은 폭 기준을 적용한다`() {
+        val belowNarrow = quickCategoryGridMetricsSpec(
+            maxWidth = 299.dp,
+            fontScale = 1.0f,
+        )
+        val narrow = quickCategoryGridMetricsSpec(
+            maxWidth = 300.dp,
+            fontScale = 1.0f,
+        )
+
+        assertEquals(3, belowNarrow.columnCount)
+        assertEquals(80.dp, belowNarrow.cellSize)
+        assertEquals(72.dp, belowNarrow.tileSize)
+        assertEquals(36.dp, belowNarrow.iconSize)
+
+        assertEquals(3, narrow.columnCount)
+        assertEquals(80.dp, narrow.cellSize)
+        assertEquals(56.dp, narrow.tileSize)
+        assertEquals(28.dp, narrow.iconSize)
+        assertEquals(QuickCategoryGridLabelTextStyleType.LabelLarge, narrow.labelTextStyleType)
+    }
+
+    @Test
+    fun `일반 글자 크기에서는 336dp부터 4열 wide phone 기준을 적용한다`() {
+        val compact = quickCategoryGridMetricsSpec(
+            maxWidth = 335.dp,
+            fontScale = 1.0f,
+        )
+        val wide = quickCategoryGridMetricsSpec(
+            maxWidth = 336.dp,
+            fontScale = 1.0f,
+        )
+
+        assertEquals(4, compact.columnCount)
+        assertEquals(80.dp, compact.cellSize)
+        assertEquals(QuickCategoryGridLabelTextStyleType.LabelLarge, compact.labelTextStyleType)
+
+        assertEquals(4, wide.columnCount)
+        assertEquals(84.dp, wide.cellSize)
+        assertEquals(64.dp, wide.tileSize)
+        assertEquals(32.dp, wide.iconSize)
+        assertEquals(QuickCategoryGridLabelTextStyleType.BodyLarge, wide.labelTextStyleType)
+    }
+
+    @Test
+    fun `일반 글자 크기에서는 352dp와 360dp에서 넓은 폭 시각 기준을 단계적으로 키운다`() {
+        val wide = quickCategoryGridMetricsSpec(
+            maxWidth = 351.dp,
+            fontScale = 1.0f,
+        )
+        val largePhone = quickCategoryGridMetricsSpec(
+            maxWidth = 352.dp,
+            fontScale = 1.0f,
+        )
+        val expanded = quickCategoryGridMetricsSpec(
+            maxWidth = 360.dp,
+            fontScale = 1.0f,
+        )
+
+        assertEquals(4, wide.columnCount)
+        assertEquals(84.dp, wide.cellSize)
+
+        assertEquals(4, largePhone.columnCount)
+        assertEquals(88.dp, largePhone.cellSize)
+
+        assertEquals(4, expanded.columnCount)
+        assertEquals(90.dp, expanded.cellSize)
+    }
+
+    @Test
+    fun `큰 글자 크기에서는 font scale 1_3부터 최대 3열로 제한한다`() {
+        val normalFont = quickCategoryGridMetricsSpec(
+            maxWidth = 320.dp,
+            fontScale = 1.29f,
+        )
+        val largeFont = quickCategoryGridMetricsSpec(
+            maxWidth = 320.dp,
+            fontScale = 1.3f,
+        )
+
+        assertEquals(4, normalFont.columnCount)
+        assertEquals(80.dp, normalFont.cellSize)
+
+        assertEquals(3, largeFont.columnCount)
+        assertEquals(96.dp, largeFont.cellSize)
+        assertEquals(72.dp, largeFont.tileSize)
+        assertEquals(36.dp, largeFont.iconSize)
+    }
+
+    @Test
+    fun `큰 글자 크기의 좁은 폭은 최대 2열로 제한한다`() {
+        val narrowLargeFont = quickCategoryGridMetricsSpec(
+            maxWidth = 299.dp,
+            fontScale = 1.3f,
+        )
+
+        assertEquals(2, narrowLargeFont.columnCount)
+        assertEquals(128.dp, narrowLargeFont.cellSize)
+        assertEquals(72.dp, narrowLargeFont.tileSize)
+        assertEquals(36.dp, narrowLargeFont.iconSize)
+    }
+
+    @Test
+    fun `큰 글자 크기에서는 352dp부터 넓은 폭 cell 기준을 적용한다`() {
+        val largeFont = quickCategoryGridMetricsSpec(
+            maxWidth = 351.dp,
+            fontScale = 1.3f,
+        )
+        val wideLargeFont = quickCategoryGridMetricsSpec(
+            maxWidth = 352.dp,
+            fontScale = 1.3f,
+        )
+
+        assertEquals(3, largeFont.columnCount)
+        assertEquals(96.dp, largeFont.cellSize)
+
+        assertEquals(3, wideLargeFont.columnCount)
+        assertEquals(112.dp, wideLargeFont.cellSize)
+    }
+}


### PR DESCRIPTION
## 관련 이슈

Related #154

## 작업 내용

품목 분류 그리드의 폭/font scale 경계값 계산과 주요 라벨 줄 수를 테스트로 보강했습니다.

## 변경 이유

#149 리뷰에서 그리드 열 수 계산이 핵심 정책이므로 폭과 font scale 경계값 테스트를 보강하면 좋겠다는 의견이 있었습니다.

기존 계산은 Compose 환경값과 함께 사용되어 순수 unit test로 확인하기 어려웠고, 라벨 줄 수는 실제 Compose Text 레이아웃 결과를 봐야 해서 계산 테스트와 UI 레이아웃 테스트를 분리했습니다.

## 주요 변경 사항

- `QuickCategoryGridMetrics` 계산부를 테스트 가능한 spec 계산으로 분리
- 폭 경계값과 font scale 경계값별 column count, cell/tile/icon size, label style 기준 테스트 추가
- 실제 코드의 대표 라벨을 사용해 Compose Text line count 테스트 추가
- `발포합성수지`, `공사장 생활폐기물`, `불연성종량제폐기물` 라벨 줄 수 확인

## 테스트

- `./gradlew.bat :presentation:testDebugUnitTest --tests com.team.yeogibeoryeo.presentation.search.components.QuickCategoryGridMetricsTest`
- `./gradlew.bat :presentation:connectedDebugAndroidTest "-Pandroid.testInstrumentationRunnerArguments.class=com.team.yeogibeoryeo.presentation.search.components.QuickCategoryGridLabelLayoutTest"`
