### PR TITLE
[Fix] 한글 줄바꿈 텍스트 접근성 읽기 보정

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">YeogiBeoryeo</string>
+    <string name="app_name">여기버려</string>
 </resources>

--- a/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreenTest.kt
+++ b/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreenTest.kt
@@ -1,9 +1,11 @@
 package com.team.yeogibeoryeo.presentation.search
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasImeAction
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -84,32 +86,30 @@ class ItemSearchScreenTest {
     }
 
     @Test
-    fun 결과_카드는_모든_배출방법을_보여준다() {
+    fun 결과_카드는_대표_배출방법만_보여준다() {
+        val primaryInstruction = DisposalInstruction(method = "재활용폐기물")
+        val secondaryInstruction = DisposalInstruction(method = "대형폐기물")
+        val guide =
+            DisposalItemGuide(
+                id = "cast-iron-pot",
+                name = "무쇠 주물냄비",
+                category = DisposalCategory.METAL,
+                subCategory = null,
+                instructions = listOf(primaryInstruction, secondaryInstruction),
+                steps = emptyList(),
+                cautions = emptyList(),
+                tip = null,
+                isRecyclable = true,
+                relatedSpotTypes = emptyList(),
+            )
+
         composeTestRule.setContent {
             MaterialTheme {
                 ItemSearchScreen(
                     uiState =
                         ItemSearchUiState(
                             hasSearched = true,
-                            guides =
-                                listOf(
-                                    DisposalItemGuide(
-                                        id = "cast-iron-pot",
-                                        name = "무쇠 주물냄비",
-                                        category = DisposalCategory.METAL,
-                                        subCategory = null,
-                                        instructions =
-                                            listOf(
-                                                DisposalInstruction(method = "재활용폐기물"),
-                                                DisposalInstruction(method = "대형폐기물"),
-                                            ),
-                                        steps = emptyList(),
-                                        cautions = emptyList(),
-                                        tip = null,
-                                        isRecyclable = true,
-                                        relatedSpotTypes = emptyList(),
-                                    ),
-                                ),
+                            guides = listOf(guide),
                         ),
                     onQueryChange = {},
                     onSearchClick = {},
@@ -119,8 +119,8 @@ class ItemSearchScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("재활용폐기물").assertIsDisplayed()
-        composeTestRule.onNodeWithText("대형폐기물").assertIsDisplayed()
+        composeTestRule.onNodeWithText(primaryInstruction.method).assertIsDisplayed()
+        composeTestRule.onAllNodesWithText(secondaryInstruction.method).assertCountEquals(0)
     }
 
     @Test
@@ -238,7 +238,7 @@ class ItemSearchScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("플라스틱")
+        composeTestRule.onNodeWithText(RepresentativeGuideCategory.PLASTIC.displayName)
             .performScrollTo()
             .performClick()
 

--- a/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/SearchComponentsTest.kt
+++ b/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/SearchComponentsTest.kt
@@ -130,8 +130,9 @@ class SearchComponentsTest {
             }
         }
 
-        composeTestRule.onNodeWithText("1. 비\u200B웁\u200B니\u200B다\u200B.").assertIsDisplayed()
-        composeTestRule.onNodeWithText("2. 헹\u200B굽\u200B니\u200B다\u200B.").assertIsDisplayed()
+        composeTestRule.onNodeWithText("1. 비웁니다.").assertIsDisplayed()
+        composeTestRule.onNodeWithText("2. 헹굽니다.").assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("1. 비\u200B웁\u200B니\u200B다\u200B.").assertCountEquals(0)
     }
 
     @Test
@@ -196,9 +197,26 @@ class SearchComponentsTest {
         }
 
         composeTestRule.onNodeWithText("종이").assertIsDisplayed()
-        composeTestRule.onNodeWithText("비닐").performClick()
+        composeTestRule.onNodeWithText("비닐류").performClick()
 
         assertEquals(RepresentativeGuideCategory.VINYL, clickedCategory)
+    }
+
+    @Test
+    fun 퀵_카테고리_라벨은_접근성_텍스트로_zero_width_space_없는_원문을_제공한다() {
+        composeTestRule.setContent {
+            MaterialTheme {
+                QuickCategoryGrid(
+                    categories = listOf(RepresentativeGuideCategory.NON_COMBUSTIBLE),
+                    onCategoryClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("불연성종량제 폐기물").assertIsDisplayed()
+        composeTestRule
+            .onAllNodesWithText("불\u200B연\u200B성\u200B종\u200B량\u200B제\u200B 폐\u200B기\u200B물\u200B")
+            .assertCountEquals(0)
     }
 
     private fun sampleGuide(

--- a/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/components/KoreanLineBreakSemanticsTest.kt
+++ b/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/components/KoreanLineBreakSemanticsTest.kt
@@ -1,0 +1,49 @@
+package com.team.yeogibeoryeo.presentation.search.components
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
+import org.junit.Rule
+import org.junit.Test
+
+class KoreanLineBreakSemanticsTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun section_text_semantics_uses_original_text_without_zero_width_space() {
+        composeTestRule.setContent {
+            MaterialTheme {
+                SectionCard(
+                    title = "배출 절차",
+                    lines = listOf("비웁니다."),
+                    numbered = true,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("1. 비웁니다.").assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("1. 비\u200B웁\u200B니\u200B다\u200B.").assertCountEquals(0)
+    }
+
+    @Test
+    fun quick_category_semantics_uses_original_label_without_zero_width_space() {
+        composeTestRule.setContent {
+            MaterialTheme {
+                QuickCategoryGrid(
+                    categories = listOf(RepresentativeGuideCategory.NON_COMBUSTIBLE),
+                    onCategoryClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("불연성종량제 폐기물").assertIsDisplayed()
+        composeTestRule
+            .onAllNodesWithText("불\u200B연\u200B성\u200B종\u200B량\u200B제\u200B 폐\u200B기\u200B물\u200B")
+            .assertCountEquals(0)
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/text/KoreanText.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/text/KoreanText.kt
@@ -1,7 +1,40 @@
 package com.team.yeogibeoryeo.presentation.common.text
 
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.text
+import androidx.compose.ui.text.AnnotatedString
+
 private const val ZERO_WIDTH_SPACE = "\u200B"
 private val koreanSyllable = Regex("([가-힣])")
+private val materialAbbreviationReadings =
+    mapOf(
+        "EPP" to "이피피",
+        "EPS" to "이피에스",
+        "EPE" to "이피이",
+        "EPR" to "이피알",
+        "PP" to "피피",
+        "PE" to "피이",
+        "PS" to "피에스",
+    )
+private val materialAbbreviation = Regex(
+    pattern = materialAbbreviationReadings.keys.joinToString(
+        separator = "|",
+        prefix = "(?<![A-Za-z])(",
+        postfix = ")(?![A-Za-z])",
+    ),
+    option = RegexOption.IGNORE_CASE,
+)
 
 fun String.withKoreanLineBreakOpportunities(): String =
     replace(koreanSyllable, "$1$ZERO_WIDTH_SPACE")
+
+fun String.toTalkBackReadableText(): String =
+    materialAbbreviation.replace(this) { match ->
+        materialAbbreviationReadings.getValue(match.value.uppercase())
+    }
+
+fun Modifier.koreanLineBreakSemantics(text: String): Modifier =
+    semantics {
+        this.text = AnnotatedString(text.toTalkBackReadableText())
+    }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/text/KoreanText.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/text/KoreanText.kt
@@ -34,7 +34,7 @@ fun String.toTalkBackReadableText(): String =
         materialAbbreviationReadings.getValue(match.value.uppercase())
     }
 
-fun Modifier.koreanLineBreakSemantics(text: String): Modifier =
+fun Modifier.koreanLineBreakSemantics(originalText: String): Modifier =
     semantics {
-        this.text = AnnotatedString(text.toTalkBackReadableText())
+        text = AnnotatedString(originalText.toTalkBackReadableText())
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
@@ -31,6 +31,7 @@ import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.domain.item.model.DisposalSubCategory
 import com.team.yeogibeoryeo.common.R as CommonR
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
 import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
 import com.team.yeogibeoryeo.presentation.search.components.DisposalGuideMetadataChips
 import com.team.yeogibeoryeo.presentation.search.components.SectionCard
@@ -167,6 +168,7 @@ fun ItemGuideDetailScreen(
             ) {
                 Text(
                     text = guide.name.withKoreanLineBreakOpportunities(),
+                    modifier = Modifier.koreanLineBreakSemantics(guide.name),
                     style = textStyles.title.copy(
                         fontWeight = FontWeight.ExtraBold,
                         color = MaterialTheme.colorScheme.onSurface

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
 import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchBar
 import com.team.yeogibeoryeo.presentation.search.components.QuickCategoryGrid
@@ -66,9 +67,10 @@ fun ItemSearchInitialContent(
 
             item {
                 Column(verticalArrangement = Arrangement.spacedBy(metrics.sectionVerticalSpace)) {
+                    val quickCategoriesTitle = stringResource(R.string.quick_categories)
                     Text(
-                        text = stringResource(R.string.quick_categories)
-                            .withKoreanLineBreakOpportunities(),
+                        text = quickCategoriesTitle.withKoreanLineBreakOpportunities(),
+                        modifier = Modifier.koreanLineBreakSemantics(quickCategoriesTitle),
                         style = MaterialTheme.typography.titleLarge.copy(
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.onSurface

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -29,6 +29,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
 import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
 import com.team.yeogibeoryeo.presentation.search.components.DisposalItemCard
 import com.team.yeogibeoryeo.presentation.search.components.EmptySearchResult
@@ -164,11 +165,13 @@ fun ItemSearchScreen(
                     }
 
                     else -> {
+                        val searchResultCountText = stringResource(
+                            R.string.search_results_count,
+                            uiState.guides.size
+                        )
                         Text(
-                            text = stringResource(
-                                R.string.search_results_count,
-                                uiState.guides.size
-                            ).withKoreanLineBreakOpportunities(),
+                            text = searchResultCountText.withKoreanLineBreakOpportunities(),
+                            modifier = Modifier.koreanLineBreakSemantics(searchResultCountText),
                             style = MaterialTheme.typography.titleLarge.copy(
                                 fontWeight = FontWeight.Bold,
                                 color = MaterialTheme.colorScheme.onSurface

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalCategoryChip.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalCategoryChip.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
+import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
 import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 
@@ -44,6 +45,7 @@ internal fun MetadataChip(
     ) {
         Text(
             text = text.withKoreanLineBreakOpportunities(),
+            modifier = Modifier.koreanLineBreakSemantics(text),
             style = MaterialTheme.typography.labelLarge,
             color = contentColor,
         )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalInstructionCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalInstructionCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import com.team.yeogibeoryeo.domain.item.model.DisposalInstruction
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
 import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 import com.team.yeogibeoryeo.presentation.search.itemGuideDetailTextStyles
@@ -52,6 +53,7 @@ fun DisposalInstructionCard(
                 Column(verticalArrangement = Arrangement.spacedBy(spacing.xxs)) {
                     Text(
                         text = instruction.method.withKoreanLineBreakOpportunities(),
+                        modifier = Modifier.koreanLineBreakSemantics(instruction.method),
                         style = textStyles.emphasizedBody.copy(
                             fontWeight = FontWeight.Medium,
                         ),
@@ -59,6 +61,7 @@ fun DisposalInstructionCard(
                     instruction.tip?.let {
                         Text(
                             text = it.withKoreanLineBreakOpportunities(),
+                            modifier = Modifier.koreanLineBreakSemantics(it),
                             style = textStyles.supportingBody.copy(
                                 color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.84f),
                             ),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.common.R as CommonR
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
 import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 
@@ -140,7 +141,9 @@ private fun BoxScope.FavoriteIndicator() {
 private fun ColumnScope.DisposalItemTitle(text: String) {
     Text(
         text = text.withKoreanLineBreakOpportunities(),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .koreanLineBreakSemantics(text),
         style = MaterialTheme.typography.titleMedium.copy(
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,
@@ -154,6 +157,7 @@ private fun ColumnScope.DisposalItemTitle(text: String) {
 private fun ColumnScope.DisposalItemDescription(text: String) {
     Text(
         text = text.withKoreanLineBreakOpportunities(),
+        modifier = Modifier.koreanLineBreakSemantics(text),
         style = MaterialTheme.typography.bodyMedium.copy(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         ),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemGuideSectionCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemGuideSectionCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
+import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
 import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 import com.team.yeogibeoryeo.presentation.search.itemGuideDetailTextStyles
@@ -58,7 +59,7 @@ internal fun ItemGuideSectionTitle(
 
     Text(
         text = text.withKoreanLineBreakOpportunities(),
-        modifier = modifier,
+        modifier = modifier.koreanLineBreakSemantics(text),
         style = textStyles.sectionTitle.copy(
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchStatusContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchStatusContent.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.team.yeogibeoryeo.common.design.theme.YeogiBeoryeoTheme
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
 import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 
@@ -64,7 +65,7 @@ fun ItemSearchStatusTitle(
 ) {
     Text(
         text = text.withKoreanLineBreakOpportunities(),
-        modifier = modifier,
+        modifier = modifier.koreanLineBreakSemantics(text),
         style = MaterialTheme.typography.titleMedium,
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.onSurface,
@@ -79,7 +80,7 @@ fun ItemSearchStatusDescription(
 ) {
     Text(
         text = text.withKoreanLineBreakOpportunities(),
-        modifier = modifier,
+        modifier = modifier.koreanLineBreakSemantics(text),
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         textAlign = TextAlign.Center,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
 import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
@@ -166,7 +167,9 @@ private fun QuickCategoryItem(
         }
         Text(
             text = name.withKoreanLineBreakOpportunities(),
-            modifier = Modifier.width(metrics.cellSize),
+            modifier = Modifier
+                .width(metrics.cellSize)
+                .koreanLineBreakSemantics(name),
             style = metrics.labelTextStyle.copy(
                 fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.onBackground,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SectionCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SectionCard.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import com.team.yeogibeoryeo.domain.item.model.DisposalGuideSectionRow
+import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
 import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 import com.team.yeogibeoryeo.presentation.search.itemGuideDetailTextStyles
@@ -71,6 +72,7 @@ private fun SectionLines(
             val text = if (numbered) "${index + 1}. $line" else line
             Text(
                 text = text.withKoreanLineBreakOpportunities(),
+                modifier = Modifier.koreanLineBreakSemantics(text),
                 style = textStyles.body.copy(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 ),
@@ -94,7 +96,7 @@ private fun SectionRow(
     ) {
         Text(
             text = label.withKoreanLineBreakOpportunities(),
-            modifier = labelModifier,
+            modifier = labelModifier.koreanLineBreakSemantics(label),
             style = textStyles.body.copy(
                 color = MaterialTheme.colorScheme.onSurface,
                 fontWeight = FontWeight.SemiBold,
@@ -102,7 +104,9 @@ private fun SectionRow(
         )
         Text(
             text = value.withKoreanLineBreakOpportunities(),
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .koreanLineBreakSemantics(value),
             style = textStyles.body.copy(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             ),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SubGuideSection.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SubGuideSection.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import com.team.yeogibeoryeo.domain.item.model.DisposalSubGuide
+import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
 import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 import com.team.yeogibeoryeo.presentation.search.itemGuideDetailTextStyles
@@ -45,6 +46,7 @@ private fun SubGuideItem(
     Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
         Text(
             text = name.withKoreanLineBreakOpportunities(),
+            modifier = Modifier.koreanLineBreakSemantics(name),
             style = textStyles.subGuideTitle.copy(
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface,
@@ -52,6 +54,7 @@ private fun SubGuideItem(
         )
         Text(
             text = summary.withKoreanLineBreakOpportunities(),
+            modifier = Modifier.koreanLineBreakSemantics(summary),
             style = textStyles.body.copy(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             ),

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/common/text/KoreanTextTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/common/text/KoreanTextTest.kt
@@ -20,4 +20,16 @@ class KoreanTextTest {
 
         assertEquals("PET 500ml", result)
     }
+
+    @Test
+    fun `발포합성수지 소재 약어는 TalkBack 읽기용 한글 발음으로 변환한다`() {
+        val result =
+            "발포합성수지는 PP, PE, PS 등의 합성수지이며 EPP, EPS, EPE 등은 EPR 대상품목입니다."
+                .toTalkBackReadableText()
+
+        assertEquals(
+            "발포합성수지는 피피, 피이, 피에스 등의 합성수지이며 이피피, 이피에스, 이피이 등은 이피알 대상품목입니다.",
+            result,
+        )
+    }
 }


### PR DESCRIPTION
## 작업 내용

- 한글 줄바꿈 유틸을 적용한 텍스트의 TalkBack 읽기값을 원문 기준으로 보정했습니다.
- 발포합성수지 상세 설명에서 소재 약어가 자연스럽게 읽히도록 접근성 읽기용 텍스트를 보정했습니다.
- 앱 라벨이 TalkBack에서 한국어 앱명으로 읽히도록 `여기버려`로 수정했습니다.
- 접근성 읽기값과 zero-width space 영향 확인을 테스트로 보강했습니다.

## 변경 이유

`withKoreanLineBreakOpportunities()`는 화면 줄바꿈을 위해 한글 음절 뒤에 zero-width space를 삽입합니다. 실기기 TalkBack QA에서 zero-width space가 포함된 문자열이 부자연스럽게 읽히는 것을 확인해, 화면 표시용 문자열과 접근성 읽기용 문자열을 분리했습니다.

QA 중 앱 라벨이 로마자(`YeogiBeoryeo`)로 설정되어 TalkBack에서 한국어 앱명처럼 읽히지 않는 문제도 확인해 함께 수정했습니다.

## 주요 변경 사항

- `Modifier.koreanLineBreakSemantics()`에서 TalkBack용 원문 텍스트 제공
- `EPP`, `EPS`, `EPE`, `EPR`, `PP`, `PE`, `PS` 소재 약어의 접근성 읽기값 보정
- 품목 초기 화면, 검색 결과, 상세 화면, 섹션 카드 등 한글 줄바꿈 유틸 적용 위치에 semantics 적용
- Compose UI test와 unit test로 zero-width space 미노출 및 소재 약어 읽기값 검증

## 확인 사항

- 화면에 보이는 텍스트와 데이터 원문은 유지했습니다.
- 접근성 읽기용 semantics만 보정했습니다.
- 현재 품목 화면에는 사용자가 본문 텍스트를 직접 선택/복사하는 UI가 없어, 텍스트 복사 UX는 별도 사용자 조작 표면이 없는 것으로 확인했습니다.

## 테스트

- `./gradlew :presentation:testDebugUnitTest`
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :presentation:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.team.yeogibeoryeo.presentation.search.components.KoreanLineBreakSemanticsTest`
- 실기기 TalkBack QA
<TalkBack의 소리가 포함된 동영상입니다.>

https://github.com/user-attachments/assets/ab4a1a89-98fa-4031-ab94-15f499bba0ef

## 관련 이슈

Related #153
