### PR TITLE
fix: 지역 가이드 검색 실행 시 키보드와 포커스 정리

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
@@ -25,7 +25,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -86,6 +89,7 @@ fun RegionalGuideRoute(
     )
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun RegionalGuideScreen(
     uiState: RegionalGuideUiState,
@@ -106,6 +110,8 @@ fun RegionalGuideScreen(
     modifier: Modifier = Modifier,
 ) {
     var isRegionSelectorExpanded by rememberSaveable { mutableStateOf(false) }
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
     val ambiguousState = uiState as? RegionalGuideUiState.Ambiguous
     val guideCandidatesState = uiState as? RegionalGuideUiState.GuideCandidates
     val hasSearchCandidates = ambiguousState != null || guideCandidatesState != null
@@ -126,6 +132,11 @@ fun RegionalGuideScreen(
         if (uiState is RegionalGuideUiState.Loading) {
             isRegionSelectorExpanded = false
         }
+    }
+
+    fun clearSearchFocus() {
+        focusManager.clearFocus()
+        keyboardController?.hide()
     }
 
     Column(
@@ -160,6 +171,7 @@ fun RegionalGuideScreen(
                 keyword = searchKeyword,
                 onKeywordChange = onSearchKeywordChange,
                 onSearchClick = { submittedKeyword ->
+                    clearSearchFocus()
                     isRegionSelectorExpanded = false
                     onRegionSelectorDropdownDismissed()
                     onSearchClick(submittedKeyword)
@@ -170,6 +182,7 @@ fun RegionalGuideScreen(
                             RegionalGuideAmbiguousResult(
                                 candidates = ambiguousState.candidates,
                                 onCandidateClick = { candidate ->
+                                    clearSearchFocus()
                                     isRegionSelectorExpanded = false
                                     onRegionSelectorDropdownDismissed()
                                     onCandidateClick(candidate)
@@ -181,6 +194,7 @@ fun RegionalGuideScreen(
                             RegionalGuideCandidateResult(
                                 candidates = guideCandidatesState.candidates,
                                 onCandidateClick = { candidate ->
+                                    clearSearchFocus()
                                     isRegionSelectorExpanded = false
                                     onRegionSelectorDropdownDismissed()
                                     onGuideCandidateClick(candidate)


### PR DESCRIPTION
## 작업 내용

지역 가이드 검색창에서 IME 검색, 화면 검색 버튼, 검색 후보 선택으로 조회를 실행할 때 검색창 focus를 해제하고 키보드를 닫도록 처리했습니다.

키보드와 focus 처리는 Composable 계층에서만 담당하며, ViewModel과 domain/data 계층은 변경하지 않았습니다.

## 기존 흐름 유지

- 검색어 입력 중 자동 후보 추천에서는 키보드와 focus를 유지합니다.
- 직접 검색, 후보 선택, 지역 선택형 조회 흐름을 유지했습니다.
- 주소 기반 `loadByAddress()`와 Favorites 지역 가이드 재진입 흐름은 변경하지 않았습니다.
- 검색 결과 상태를 기다리지 않고 검색 실행 시점에 키보드와 focus를 정리합니다.

## 테스트 및 검증

- [x] `./gradlew :presentation:testDebugUnitTest`
- [x] `./gradlew :presentation:compileDebugKotlin`
- [x] `./gradlew :app:assembleDebug`
- [x] `git diff --check`

## 수동 확인

- [x] IME 검색 실행 후 키보드 닫힘
- [x] 화면 검색 버튼 실행 후 키보드 닫힘
- [x] 검색 성공 상태에서 키보드 닫힘
- [x] 검색 결과 없음 상태에서 키보드 닫힘
- [x] 다중 후보 상태에서 키보드 닫힘
- [x] 자동 후보 추천 중 키보드 유지
- [x] 검색창 재선택 후 정상적인 재입력
- [ ] 실제 Error 상태
  - 코드상 검색 결과와 무관하게 검색 실행 시점에 동일한 키보드 처리 경로를 사용합니다.

## 📸 스크린샷

| 변경 전 | 변경 후 |
| --- | --- |
| 검색 실행 후에도 키보드와 검색창 focus가 유지되는 상태 | 검색 실행 후 키보드가 닫히고 focus가 해제된 상태 |
| <img width="720" height="1520" alt="Image" src="https://github.com/user-attachments/assets/701ab747-5d48-4180-a27f-b209aef3217d" /> | <img width="720" height="1520" alt="Image" src="https://github.com/user-attachments/assets/8b66d9b8-8f13-4c1a-a912-dac2b984241e" /> |

## 관련 이슈

- Related #151