### PR TITLE
fix: 관리구역 기준 후보 식별 및 표시 보완

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/favorite/repository/RegionalGuideFavoriteRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/favorite/repository/RegionalGuideFavoriteRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.team.yeogibeoryeo.data.favorite.local.FavoriteDatabase
 import com.team.yeogibeoryeo.data.favorite.mapper.toEntity
 import com.team.yeogibeoryeo.domain.favorite.model.Favorite
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteKey
 import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
 import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteRepository
 import javax.inject.Inject
@@ -24,10 +25,17 @@ class RegionalGuideFavoriteRepositoryImpl
                         targetId = snapshot.targetId,
                         savedAtMillis = System.currentTimeMillis(),
                     )
+                val compatibleTargetIds = snapshot.compatibleTargetIds
 
-                if (favoriteDao.isFavorite(favorite.type.name, favorite.targetId)) {
-                    favoriteDao.deleteFavorite(favorite.type.name, favorite.targetId)
-                    snapshotDao.deleteSnapshot(snapshot.targetId)
+                if (
+                    compatibleTargetIds.any { targetId ->
+                        favoriteDao.isFavorite(favorite.type.name, targetId)
+                    }
+                ) {
+                    compatibleTargetIds.forEach { targetId ->
+                        favoriteDao.deleteFavorite(favorite.type.name, targetId)
+                        snapshotDao.deleteSnapshot(targetId)
+                    }
                     false
                 } else {
                     favoriteDao.upsertFavorite(favorite.toEntity())
@@ -38,11 +46,19 @@ class RegionalGuideFavoriteRepositoryImpl
 
         override suspend fun removeFavorite(targetId: String) {
             database.withTransaction {
-                database.favoriteDao().deleteFavorite(
-                    type = FavoriteTargetType.REGIONAL_GUIDE.name,
-                    targetId = targetId,
-                )
-                database.regionalGuideFavoriteSnapshotDao().deleteSnapshot(targetId)
+                compatibleTargetIdsOf(targetId).forEach { compatibleTargetId ->
+                    database.favoriteDao().deleteFavorite(
+                        type = FavoriteTargetType.REGIONAL_GUIDE.name,
+                        targetId = compatibleTargetId,
+                    )
+                    database.regionalGuideFavoriteSnapshotDao().deleteSnapshot(compatibleTargetId)
+                }
             }
+        }
+
+        private fun compatibleTargetIdsOf(targetId: String): List<String> {
+            val key = RegionalGuideFavoriteKey.decodeOrNull(targetId) ?: return listOf(targetId)
+
+            return listOf(targetId, key.copy(managementZoneName = null).encodeLegacy()).distinct()
         }
     }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/RegionalGuideFavoriteKey.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/RegionalGuideFavoriteKey.kt
@@ -7,6 +7,7 @@ data class RegionalGuideFavoriteKey(
     val sigungu: String?,
     val eupmyeondong: String?,
     val targetRegionName: String?,
+    val managementZoneName: String? = null,
 ) {
     fun toRegion(): Region =
         Region(
@@ -23,21 +24,38 @@ data class RegionalGuideFavoriteKey(
             appendEncoded(sigungu)
             appendEncoded(eupmyeondong)
             appendEncoded(targetRegionName)
+            appendEncoded(managementZoneName)
+        }
+
+    fun encodeLegacy(): String =
+        buildString {
+            append(LEGACY_VERSION)
+            append(FIELD_DELIMITER)
+            appendEncoded(sido)
+            appendEncoded(sigungu)
+            appendEncoded(eupmyeondong)
+            appendEncoded(targetRegionName)
         }
 
     companion object {
-        private const val VERSION = "regional-guide-v1"
+        private const val VERSION = "regional-guide-v2"
+        private const val LEGACY_VERSION = "regional-guide-v1"
         private const val FIELD_DELIMITER = '|'
         private const val NULL_LENGTH = -1
 
         fun decodeOrNull(value: String): RegionalGuideFavoriteKey? {
-            if (!value.startsWith("$VERSION$FIELD_DELIMITER")) return null
+            val version = value.substringBefore(FIELD_DELIMITER)
+            val fieldCount = when (version) {
+                VERSION -> KEY_FIELD_COUNT
+                LEGACY_VERSION -> LEGACY_KEY_FIELD_COUNT
+                else -> return null
+            }
 
             val payload = value.substringAfter(FIELD_DELIMITER)
             val fields = mutableListOf<String?>()
             var cursor = 0
 
-            repeat(KEY_FIELD_COUNT) {
+            repeat(fieldCount) {
                 val delimiterIndex = payload.indexOf(':', startIndex = cursor)
                 if (delimiterIndex == -1) return null
 
@@ -66,11 +84,13 @@ data class RegionalGuideFavoriteKey(
                 sigungu = fields[1],
                 eupmyeondong = fields[2],
                 targetRegionName = fields[3],
+                managementZoneName = fields.getOrNull(4),
             )
                 .takeIf { key -> !key.sido.isNullOrBlank() || !key.sigungu.isNullOrBlank() }
         }
 
-        private const val KEY_FIELD_COUNT = 4
+        private const val LEGACY_KEY_FIELD_COUNT = 4
+        private const val KEY_FIELD_COUNT = 5
 
         private fun StringBuilder.appendEncoded(value: String?) {
             val normalizedValue = value?.trim()?.takeIf { it.isNotBlank() }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/RegionalGuideFavoriteSnapshot.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/favorite/model/RegionalGuideFavoriteSnapshot.kt
@@ -11,6 +11,14 @@ data class RegionalGuideFavoriteSnapshot(
 ) {
     val key: RegionalGuideFavoriteKey?
         get() = RegionalGuideFavoriteKey.decodeOrNull(targetId)
+
+    val legacyTargetId: String?
+        get() = key
+            ?.copy(managementZoneName = null)
+            ?.encodeLegacy()
+
+    val compatibleTargetIds: List<String>
+        get() = listOfNotNull(targetId, legacyTargetId).distinct()
 }
 
 fun RegionalDisposalGuide.toFavoriteSnapshot(): RegionalGuideFavoriteSnapshot {
@@ -20,6 +28,7 @@ fun RegionalDisposalGuide.toFavoriteSnapshot(): RegionalGuideFavoriteSnapshot {
             sigungu = region.sigungu,
             eupmyeondong = region.eupmyeondong,
             targetRegionName = targetRegionName,
+            managementZoneName = managementZoneName,
         )
 
     return RegionalGuideFavoriteSnapshot(

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/GetRegionalDisposalGuideUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/GetRegionalDisposalGuideUseCase.kt
@@ -14,7 +14,8 @@ class GetRegionalDisposalGuideUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(
         region: Region,
-        preferredTargetRegionName: String? = null
+        preferredTargetRegionName: String? = null,
+        preferredManagementZoneName: String? = null,
     ): RegionalGuideLookupResult {
         val query = normalizeRegionalGuideQueryUseCase(region)
             ?: return RegionalGuideLookupResult.NotFound
@@ -30,7 +31,8 @@ class GetRegionalDisposalGuideUseCase @Inject constructor(
         return selectRegionalGuideCandidateUseCase(
             candidates = candidates,
             query = query,
-            preferredTargetRegionName = preferredTargetRegionName
+            preferredTargetRegionName = preferredTargetRegionName,
+            preferredManagementZoneName = preferredManagementZoneName,
         )
     }
 

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
@@ -12,55 +12,45 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
         candidates: List<RegionalDisposalGuide>,
         query: RegionalGuideQuery,
         preferredTargetRegionName: String? = null,
+        preferredManagementZoneName: String? = null,
     ): RegionalGuideLookupResult {
         if (candidates.isEmpty()) return RegionalGuideLookupResult.NotFound
 
         val filteredCandidates = candidates
             .filterBySido(query.displayRegion.sido)
             .filterBySigungu(query.sigunguQuery)
+            .mergeDuplicateCandidateRows()
 
         if (filteredCandidates.isEmpty()) {
             return RegionalGuideLookupResult.CandidateNotFound
         }
 
+        if (!preferredTargetRegionName.isNullOrBlank() || !preferredManagementZoneName.isNullOrBlank()) {
+            return filteredCandidates
+                .filterByPreferredCandidate(
+                    preferredTargetRegionName = preferredTargetRegionName,
+                    preferredManagementZoneName = preferredManagementZoneName
+                )
+                .toSingleSuccessOrCandidates(query.displayRegion)
+                ?: RegionalGuideLookupResult.CandidateNotFound
+        }
+
         if (filteredCandidates.size == 1) {
-            return RegionalGuideLookupResult.Success(
-                guide = filteredCandidates.first().withDisplayRegion(query.displayRegion)
-            )
+            return filteredCandidates.toSingleSuccessOrCandidates(query.displayRegion)
+                ?: RegionalGuideLookupResult.CandidateNotFound
         }
 
-        preferredTargetRegionName
-            ?.trim()
-            ?.takeIf { targetRegionName -> targetRegionName.isNotBlank() }
-            ?.let { targetRegionName ->
-                val preferredGuide = filteredCandidates.firstOrNull { guide ->
-                    guide.targetRegionName?.trim() == targetRegionName
-                }
+        filteredCandidates.selectOverallCandidates(query.sigunguQuery)
+            .toSingleSuccessOrCandidates(query.displayRegion)
+            ?.let { result -> return result }
 
-                return if (preferredGuide != null) {
-                    RegionalGuideLookupResult.Success(
-                        guide = preferredGuide.withDisplayRegion(query.displayRegion)
-                    )
-                } else {
-                    RegionalGuideLookupResult.CandidateNotFound
-                }
-            }
-
-        filteredCandidates.selectSingleOverallCandidate(query.sigunguQuery)?.let { guide ->
-            return RegionalGuideLookupResult.Success(
-                guide = guide.withDisplayRegion(query.displayRegion)
-            )
-        }
-
-        val selectedGuide = selectByTargetRegion(
+        selectByTargetRegion(
             candidates = filteredCandidates,
             requestedRegion = query.displayRegion,
             sigunguQuery = query.sigunguQuery
-        ) ?: return filteredCandidates.toCandidateResultOrNotFound(query.displayRegion)
+        )?.let { result -> return result }
 
-        return RegionalGuideLookupResult.Success(
-            guide = selectedGuide.withDisplayRegion(query.displayRegion)
-        )
+        return filteredCandidates.toCandidateResultOrNotFound(query.displayRegion)
     }
 
     private fun List<RegionalDisposalGuide>.filterBySido(
@@ -83,26 +73,48 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
         candidates: List<RegionalDisposalGuide>,
         requestedRegion: Region,
         sigunguQuery: String
-    ): RegionalDisposalGuide? {
+    ): RegionalGuideLookupResult? {
         val eupmyeondong = requestedRegion.eupmyeondong?.trim()
 
         if (!eupmyeondong.isNullOrBlank()) {
-            return candidates.firstOrNull { guide ->
-                guide.targetRegionName.matchesEupmyeondong(eupmyeondong)
-            } ?: candidates.firstOrNull { guide ->
-                guide.targetRegionName.isSejongDongArea() &&
-                    eupmyeondong in SEJONG_DONG_AREA_NAMES
-            } ?: candidates.firstOrNull { guide ->
-                guide.targetRegionName.isOverallTarget(sigunguQuery)
-            }
+            candidates
+                .filterByRequestedEupmyeondong(eupmyeondong)
+                .toSingleSuccessOrCandidates(requestedRegion)
+                ?.let { result -> return result }
+
+            candidates
+                .filter { guide ->
+                    guide.targetRegionName.isSejongDongArea() &&
+                        eupmyeondong in SEJONG_DONG_AREA_NAMES
+                }
+                .toSingleSuccessOrCandidates(requestedRegion)
+                ?.let { result -> return result }
+
+            return candidates
+                .selectOverallCandidates(sigunguQuery)
+                .toSingleSuccessOrCandidates(requestedRegion)
         }
 
         return null
     }
 
-    private fun List<RegionalDisposalGuide>.selectSingleOverallCandidate(
+    private fun List<RegionalDisposalGuide>.filterByRequestedEupmyeondong(
+        eupmyeondong: String
+    ): List<RegionalDisposalGuide> {
+        val targetRegionMatches = filter { guide ->
+            guide.targetRegionName.matchesEupmyeondong(eupmyeondong)
+        }
+        val managementZoneMatches = filter { guide ->
+            guide.managementZoneName.isExactRegionName(eupmyeondong)
+        }
+
+        return (targetRegionMatches + managementZoneMatches)
+            .mergeDuplicateCandidateRows()
+    }
+
+    private fun List<RegionalDisposalGuide>.selectOverallCandidates(
         sigunguQuery: String
-    ): RegionalDisposalGuide? {
+    ): List<RegionalDisposalGuide> {
         val targetRegionNames = map { guide ->
             guide.targetRegionName
                 ?.trim()
@@ -113,9 +125,9 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
             targetRegionNames.size == 1 &&
             targetRegionNames.single().isOverallTarget(sigunguQuery)
         ) {
-            firstOrNull()
+            this
         } else {
-            null
+            emptyList()
         }
     }
 
@@ -130,6 +142,62 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
             guides = map { guide -> guide.withDisplayRegion(displayRegion) }
         )
     }
+
+    private fun List<RegionalDisposalGuide>.toSingleSuccessOrCandidates(
+        displayRegion: Region
+    ): RegionalGuideLookupResult? {
+        return when (size) {
+            0 -> null
+            1 -> RegionalGuideLookupResult.Success(
+                guide = first().withDisplayRegion(displayRegion)
+            )
+            else -> RegionalGuideLookupResult.Candidates(
+                guides = map { guide -> guide.withDisplayRegion(displayRegion) }
+            )
+        }
+    }
+
+    private fun List<RegionalDisposalGuide>.filterByPreferredCandidate(
+        preferredTargetRegionName: String?,
+        preferredManagementZoneName: String?
+    ): List<RegionalDisposalGuide> {
+        val targetRegionName = preferredTargetRegionName.normalizeRegionName()
+        val managementZoneName = preferredManagementZoneName.normalizeRegionName()
+
+        return filter { guide ->
+            val targetMatches = targetRegionName == null ||
+                guide.targetRegionName.normalizeRegionName() == targetRegionName
+            val managementMatches = managementZoneName == null ||
+                guide.managementZoneName.normalizeRegionName() == managementZoneName
+
+            targetMatches && managementMatches
+        }
+    }
+
+    private fun List<RegionalDisposalGuide>.mergeDuplicateCandidateRows(): List<RegionalDisposalGuide> =
+        groupBy { guide -> guide.toCandidateKey() }
+            .values
+            .map { guides ->
+                val firstGuide = guides.first()
+                firstGuide.copy(
+                    schedules = guides
+                        .flatMap { guide -> guide.schedules }
+                        .distinct()
+                )
+            }
+
+    private fun RegionalDisposalGuide.toCandidateKey(): CandidateKey =
+        CandidateKey(
+            sido = region.sido.normalizeRegionName(),
+            sigungu = region.sigungu.normalizeRegionName(),
+            managementZoneName = managementZoneName.normalizeRegionName(),
+            targetRegionName = targetRegionName.normalizeRegionName(),
+            disposalPlaceType = disposalPlaceType.normalizeRegionName(),
+            disposalPlaceDescription = disposalPlaceDescription.normalizeRegionName(),
+            uncollectedDays = uncollectedDays.normalizeRegionName(),
+            departmentName = departmentName.normalizeRegionName(),
+            departmentPhoneNumber = departmentPhoneNumber.normalizeRegionName(),
+        )
 
     private fun String?.matchesEupmyeondong(
         eupmyeondong: String
@@ -148,6 +216,16 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
             .map { token -> token.trim().removeAdministrativeSuffix() }
             .any { token -> token == normalizedEupmyeondong }
     }
+
+    private fun String?.isExactRegionName(
+        regionName: String
+    ): Boolean =
+        normalizeRegionName() == regionName.normalizeRegionName()
+
+    private fun String?.normalizeRegionName(): String? =
+        this
+            ?.trim()
+            ?.takeIf { value -> value.isNotBlank() }
 
     private fun String.removeAdministrativeSuffix(): String =
         removeSuffix(EUP)
@@ -182,6 +260,18 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
 
     private fun String?.isSejongDongArea(): Boolean =
         this?.trim() == SEJONG_DONG_AREA
+
+    private data class CandidateKey(
+        val sido: String?,
+        val sigungu: String?,
+        val managementZoneName: String?,
+        val targetRegionName: String?,
+        val disposalPlaceType: String?,
+        val disposalPlaceDescription: String?,
+        val uncollectedDays: String?,
+        val departmentName: String?,
+        val departmentPhoneNumber: String?,
+    )
 
     private companion object {
         const val SEJONG_SIGUNGU_QUERY = "없음"

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/model/RegionalGuideFavoriteKeyTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/favorite/model/RegionalGuideFavoriteKeyTest.kt
@@ -7,13 +7,14 @@ import org.junit.Test
 
 class RegionalGuideFavoriteKeyTest {
     @Test
-    fun `encode and decode preserves region and target region`() {
+    fun `encode and decode preserves region target region and management zone`() {
         val key =
             RegionalGuideFavoriteKey(
                 sido = "인천광역시",
                 sigungu = "중구",
                 eupmyeondong = "신흥동",
                 targetRegionName = "신흥동+율목동",
+                managementZoneName = "중구 관리구역",
             )
 
         assertEquals(key, RegionalGuideFavoriteKey.decodeOrNull(key.encode()))
@@ -31,6 +32,62 @@ class RegionalGuideFavoriteKeyTest {
         val otherZone = baseRegion.copy(targetRegionName = "신포동+연안동")
 
         assertNotEquals(baseRegion.encode(), otherZone.encode())
+    }
+
+    @Test
+    fun `management zone separates same target region candidates`() {
+        val baseRegion =
+            RegionalGuideFavoriteKey(
+                sido = "대전광역시",
+                sigungu = "유성구",
+                eupmyeondong = "반석동",
+                targetRegionName = "반석동 일부지역",
+                managementZoneName = "노은2동",
+            )
+        val otherManagementZone = baseRegion.copy(managementZoneName = "노은3동")
+
+        assertNotEquals(baseRegion.encode(), otherManagementZone.encode())
+    }
+
+    @Test
+    fun `legacy key without management zone can still be decoded`() {
+        val legacyKey = "regional-guide-v1|5:대전광역시3:유성구3:반석동8:반석동 일부지역"
+
+        val decodedKey = RegionalGuideFavoriteKey.decodeOrNull(legacyKey)
+
+        assertEquals(
+            RegionalGuideFavoriteKey(
+                sido = "대전광역시",
+                sigungu = "유성구",
+                eupmyeondong = "반석동",
+                targetRegionName = "반석동 일부지역",
+                managementZoneName = null,
+            ),
+            decodedKey
+        )
+    }
+
+    @Test
+    fun `encodeLegacy omits management zone for compatible favorite lookup`() {
+        val key =
+            RegionalGuideFavoriteKey(
+                sido = "Sido",
+                sigungu = "Sigungu",
+                eupmyeondong = "Dong",
+                targetRegionName = "Target",
+                managementZoneName = "Management",
+            )
+
+        assertEquals(
+            RegionalGuideFavoriteKey(
+                sido = "Sido",
+                sigungu = "Sigungu",
+                eupmyeondong = "Dong",
+                targetRegionName = "Target",
+                managementZoneName = null,
+            ),
+            RegionalGuideFavoriteKey.decodeOrNull(key.encodeLegacy())
+        )
     }
 
     @Test

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
@@ -4,6 +4,8 @@ import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideLookupResult
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideQuery
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteSchedule
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -207,6 +209,221 @@ class SelectRegionalGuideCandidateUseCaseTest {
     }
 
     @Test
+    fun `동일 대상지역명이어도 관리구역명이 다르면 첫 후보를 임의 선택하지 않고 후보 목록을 반환한다`() {
+        val result = useCase(
+            candidates = listOf(
+                guide(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    managementZoneName = "노은2동",
+                    targetRegionName = "반석동 일부지역"
+                ),
+                guide(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    managementZoneName = "노은3동",
+                    targetRegionName = "반석동 일부지역"
+                )
+            ),
+            query = query(
+                displayRegion = Region(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    eupmyeondong = "반석동"
+                ),
+                sigunguQuery = "유성구"
+            )
+        )
+
+        val candidates = (result as RegionalGuideLookupResult.Candidates).guides
+
+        assertEquals(2, candidates.size)
+        assertEquals("노은2동", candidates[0].managementZoneName)
+        assertEquals("노은3동", candidates[1].managementZoneName)
+    }
+
+    @Test
+    fun `관리구역명이 선택 읍면동과 정확히 일치하면 직접 매칭 후보로 선택한다`() {
+        val result = useCase(
+            candidates = listOf(
+                guide(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    managementZoneName = "온천1동",
+                    targetRegionName = "봉명동 호텔주변"
+                ),
+                guide(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    managementZoneName = "온천2동",
+                    targetRegionName = "장대동+죽동"
+                )
+            ),
+            query = query(
+                displayRegion = Region(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    eupmyeondong = "온천1동"
+                ),
+                sigunguQuery = "유성구"
+            )
+        )
+
+        val guide = (result as RegionalGuideLookupResult.Success).guide
+
+        assertEquals("온천1동", guide.managementZoneName)
+        assertEquals("봉명동 호텔주변", guide.targetRegionName)
+    }
+
+    @Test
+    fun `관리구역명으로 직접 매칭되는 후보가 여러 개면 후보 목록을 반환한다`() {
+        val result = useCase(
+            candidates = listOf(
+                guide(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    managementZoneName = "온천1동",
+                    targetRegionName = "봉명동 호텔주변"
+                ),
+                guide(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    managementZoneName = "온천1동",
+                    targetRegionName = "구암동+덕명동+복용동+봉명동"
+                )
+            ),
+            query = query(
+                displayRegion = Region(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    eupmyeondong = "온천1동"
+                ),
+                sigunguQuery = "유성구"
+            )
+        )
+
+        val candidates = (result as RegionalGuideLookupResult.Candidates).guides
+
+        assertEquals(2, candidates.size)
+        assertEquals("봉명동 호텔주변", candidates[0].targetRegionName)
+        assertEquals("구암동+덕명동+복용동+봉명동", candidates[1].targetRegionName)
+    }
+
+    @Test
+    fun `대상지역명과 관리구역명 기준에서 서로 다른 후보가 잡히면 후보 목록을 반환한다`() {
+        val result = useCase(
+            candidates = listOf(
+                guide(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    managementZoneName = "관리구역A",
+                    targetRegionName = "온천1동"
+                ),
+                guide(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    managementZoneName = "온천1동",
+                    targetRegionName = "별도 대상지역"
+                )
+            ),
+            query = query(
+                displayRegion = Region(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    eupmyeondong = "온천1동"
+                ),
+                sigunguQuery = "유성구"
+            )
+        )
+
+        val candidates = (result as RegionalGuideLookupResult.Candidates).guides
+
+        assertEquals(2, candidates.size)
+        assertEquals("관리구역A", candidates[0].managementZoneName)
+        assertEquals("온천1동", candidates[1].managementZoneName)
+    }
+
+    @Test
+    fun `완전 중복 후보는 하나의 후보로 정리하고 상세 일정은 유지한다`() {
+        val firstSchedule = RegionalWasteSchedule(
+            wasteType = RegionalWasteType.GENERAL,
+            disposalDays = "월"
+        )
+        val secondSchedule = RegionalWasteSchedule(
+            wasteType = RegionalWasteType.FOOD,
+            disposalDays = "화"
+        )
+
+        val result = useCase(
+            candidates = listOf(
+                guide(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    managementZoneName = "노은2동",
+                    targetRegionName = "반석동 일부지역",
+                    schedules = listOf(firstSchedule)
+                ),
+                guide(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    managementZoneName = "노은2동",
+                    targetRegionName = "반석동 일부지역",
+                    schedules = listOf(secondSchedule)
+                )
+            ),
+            query = query(
+                displayRegion = Region(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    eupmyeondong = "반석동"
+                ),
+                sigunguQuery = "유성구"
+            )
+        )
+
+        val guide = (result as RegionalGuideLookupResult.Success).guide
+
+        assertEquals("노은2동", guide.managementZoneName)
+        assertEquals(listOf(firstSchedule, secondSchedule), guide.schedules)
+    }
+
+    @Test
+    fun `same candidate names with different detail fields remain separate candidates`() {
+        val result = useCase(
+            candidates = listOf(
+                guide(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    managementZoneName = "노은2동",
+                    targetRegionName = "반석동 일부지역",
+                    disposalPlaceDescription = "A구역"
+                ),
+                guide(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    managementZoneName = "노은2동",
+                    targetRegionName = "반석동 일부지역",
+                    disposalPlaceDescription = "B구역"
+                )
+            ),
+            query = query(
+                displayRegion = Region(
+                    sido = "대전광역시",
+                    sigungu = "유성구",
+                    eupmyeondong = "반석동"
+                ),
+                sigunguQuery = "유성구"
+            )
+        )
+
+        val candidates = (result as RegionalGuideLookupResult.Candidates).guides
+
+        assertEquals(2, candidates.size)
+        assertEquals("A구역", candidates[0].disposalPlaceDescription)
+        assertEquals("B구역", candidates[1].disposalPlaceDescription)
+    }
+
+    @Test
     fun `읍면동 없이 복수 후보가 있으면 전체 적용 후보가 있어도 후보 목록을 반환한다`() {
         val result = useCase(
             candidates = listOf(
@@ -345,14 +562,27 @@ class SelectRegionalGuideCandidateUseCaseTest {
     private fun guide(
         sido: String?,
         sigungu: String?,
-        targetRegionName: String?
+        targetRegionName: String?,
+        managementZoneName: String? = null,
+        schedules: List<RegionalWasteSchedule> = emptyList(),
+        disposalPlaceType: String? = null,
+        disposalPlaceDescription: String? = null,
+        uncollectedDays: String? = null,
+        departmentName: String? = null,
+        departmentPhoneNumber: String? = null,
     ): RegionalDisposalGuide =
         RegionalDisposalGuide(
             region = Region(
                 sido = sido,
                 sigungu = sigungu
             ),
+            managementZoneName = managementZoneName,
             targetRegionName = targetRegionName,
-            schedules = emptyList()
+            disposalPlaceType = disposalPlaceType,
+            disposalPlaceDescription = disposalPlaceDescription,
+            schedules = schedules,
+            uncollectedDays = uncollectedDays,
+            departmentName = departmentName,
+            departmentPhoneNumber = departmentPhoneNumber,
         )
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -222,7 +223,7 @@ class RegionalGuideViewModel @Inject constructor(
 
         val snapshot = candidate.toFavoriteSnapshot()
         currentRegionalGuideFavoriteSnapshot = snapshot
-        observeRegionalGuideFavoriteState(snapshot.targetId)
+        observeRegionalGuideFavoriteState(snapshot)
 
         _uiState.value = RegionalGuideUiState.Success(
             query = query,
@@ -375,7 +376,8 @@ class RegionalGuideViewModel @Inject constructor(
                 loadRegionalGuide(
                     query = snapshot.displayText(),
                     region = regionalGuideRegion,
-                    preferredTargetRegionName = snapshot.targetRegionName
+                    preferredTargetRegionName = snapshot.targetRegionName,
+                    preferredManagementZoneName = snapshot.managementZoneName,
                 )
             } catch (e: CancellationException) {
                 throw e
@@ -517,17 +519,29 @@ class RegionalGuideViewModel @Inject constructor(
         }
     }
 
-    private fun observeRegionalGuideFavoriteState(targetId: String) {
+    private fun observeRegionalGuideFavoriteState(snapshot: RegionalGuideFavoriteSnapshot) {
         favoriteStateJob?.cancel()
         favoriteStateJob = viewModelScope.launch {
-            observeFavoriteUseCase(
-                type = FavoriteTargetType.REGIONAL_GUIDE,
-                targetId = targetId,
-            ).collect { isFavorite ->
+            val favoriteStateFlows = snapshot.compatibleTargetIds.map { targetId ->
+                observeFavoriteUseCase(
+                    type = FavoriteTargetType.REGIONAL_GUIDE,
+                    targetId = targetId,
+                )
+            }
+            val favoriteStateFlow =
+                when (favoriteStateFlows.size) {
+                    0 -> return@launch
+                    1 -> favoriteStateFlows.single()
+                    else -> combine(favoriteStateFlows) { favoriteStates ->
+                        favoriteStates.any { isFavorite -> isFavorite }
+                    }
+                }
+
+            favoriteStateFlow.collect { isFavorite ->
                 _uiState.update { state ->
                     if (
                         state is RegionalGuideUiState.Success &&
-                        currentRegionalGuideFavoriteSnapshot?.targetId == targetId
+                        currentRegionalGuideFavoriteSnapshot?.targetId == snapshot.targetId
                     ) {
                         state.copy(isFavorite = isFavorite)
                     } else {
@@ -591,11 +605,13 @@ class RegionalGuideViewModel @Inject constructor(
     private suspend fun loadRegionalGuide(
         query: String,
         region: Region,
-        preferredTargetRegionName: String? = null
+        preferredTargetRegionName: String? = null,
+        preferredManagementZoneName: String? = null,
     ) {
         val result = getRegionalDisposalGuideUseCase(
             region = region,
-            preferredTargetRegionName = preferredTargetRegionName
+            preferredTargetRegionName = preferredTargetRegionName,
+            preferredManagementZoneName = preferredManagementZoneName,
         )
 
         _uiState.value = result.toUiState(query)
@@ -608,7 +624,7 @@ class RegionalGuideViewModel @Inject constructor(
             is RegionalGuideLookupResult.Success -> {
                 val snapshot = guide.toFavoriteSnapshot()
                 currentRegionalGuideFavoriteSnapshot = snapshot
-                observeRegionalGuideFavoriteState(snapshot.targetId)
+                observeRegionalGuideFavoriteState(snapshot)
 
                 RegionalGuideUiState.Success(
                     query = query,
@@ -689,6 +705,7 @@ class RegionalGuideViewModel @Inject constructor(
                 sigungu = region.sigungu,
                 eupmyeondong = region.eupmyeondong,
                 targetRegionName = guide.targetRegionName,
+                managementZoneName = guide.managementZoneName,
             ).encode(),
             region = region,
             targetRegionName = guide.targetRegionName,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
@@ -7,8 +7,20 @@ data class RegionalGuideCandidateUiModel(
     val eupmyeondong: String?
 ) {
     val displayText: String =
-        guide.targetRegionName
-            ?.takeIf { targetRegionName -> targetRegionName.isNotBlank() }
-            ?: guide.managementZoneName
-            ?: guide.regionName
+        listOfNotNull(
+            guide.managementZoneName.takeIfNotBlank(),
+            guide.targetRegionName.takeIfNotBlank()
+        )
+            .distinct()
+            .joinToString(CANDIDATE_LABEL_SEPARATOR)
+            .ifBlank { guide.regionName }
+
+    private fun String?.takeIfNotBlank(): String? =
+        this
+            ?.trim()
+            ?.takeIf { value -> value.isNotBlank() }
+
+    private companion object {
+        const val CANDIDATE_LABEL_SEPARATOR = " / "
+    }
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModelTest.kt
@@ -2,6 +2,7 @@ package com.team.yeogibeoryeo.presentation.regionalguide
 
 import com.team.yeogibeoryeo.domain.favorite.model.Favorite
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteKey
 import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
 import com.team.yeogibeoryeo.domain.favorite.model.toFavoriteSnapshot
 import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
@@ -822,6 +823,116 @@ class RegionalGuideViewModelTest {
         assertEquals(true, state.isFavorite)
     }
 
+    @Test
+    fun `favorite target id restores candidate with same target region and different management zone`() = runTest {
+        val region = Region(sido = "대전광역시", sigungu = "유성구", eupmyeondong = "반석동")
+        val firstGuide =
+            RegionalDisposalGuide(
+                region = region,
+                targetRegionName = "반석동 일부지역",
+                managementZoneName = "노은2동",
+                schedules = emptyList(),
+            )
+        val savedGuide =
+            RegionalDisposalGuide(
+                region = region,
+                targetRegionName = "반석동 일부지역",
+                managementZoneName = "노은3동",
+                schedules = emptyList(),
+            )
+        val snapshot = savedGuide.toFavoriteSnapshot()
+        val favoriteRepository =
+            FakeFavoriteRepository(
+                initialFavorites =
+                    listOf(
+                        Favorite(
+                            type = FavoriteTargetType.REGIONAL_GUIDE,
+                            targetId = snapshot.targetId,
+                            savedAtMillis = 1L,
+                        ),
+                    ),
+            )
+        val viewModel =
+            createViewModel(
+                regionalGuideRepository =
+                    FakeRegionalDisposalGuideRepository(candidates = listOf(firstGuide, savedGuide)),
+                favoriteRepository = favoriteRepository,
+                regionalGuideSnapshotRepository =
+                    FakeRegionalGuideFavoriteSnapshotRepository(snapshots = listOf(snapshot)),
+            )
+        advanceUntilIdle()
+
+        viewModel.loadByFavoriteTargetId(snapshot.targetId)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value as RegionalGuideUiState.Success
+        assertEquals("반석동 일부지역", state.guide.targetRegionName)
+        assertEquals("노은3동", state.guide.managementZoneName)
+        assertEquals(true, state.isFavorite)
+    }
+
+    @Test
+    fun `legacy regional guide favorite key is observed and removed with current snapshot`() = runTest {
+        val region = Region(sido = "Sido", sigungu = "Sigungu", eupmyeondong = "Dong")
+        val guide =
+            RegionalDisposalGuide(
+                region = region,
+                targetRegionName = "Target",
+                managementZoneName = "Management",
+                schedules = emptyList(),
+            )
+        val currentSnapshot = guide.toFavoriteSnapshot()
+        val legacyTargetId =
+            RegionalGuideFavoriteKey(
+                sido = region.sido,
+                sigungu = region.sigungu,
+                eupmyeondong = region.eupmyeondong,
+                targetRegionName = guide.targetRegionName,
+            ).encodeLegacy()
+        val legacySnapshot = currentSnapshot.copy(targetId = legacyTargetId, managementZoneName = null)
+        val favoriteRepository =
+            FakeFavoriteRepository(
+                initialFavorites =
+                    listOf(
+                        Favorite(
+                            type = FavoriteTargetType.REGIONAL_GUIDE,
+                            targetId = legacyTargetId,
+                            savedAtMillis = 1L,
+                        ),
+                    ),
+            )
+        val snapshotRepository =
+            FakeRegionalGuideFavoriteSnapshotRepository(snapshots = listOf(legacySnapshot))
+        val viewModel =
+            createViewModel(
+                regionRepository = FakeRegionRepository(resolvedRegion = region),
+                regionalGuideRepository = FakeRegionalDisposalGuideRepository(candidates = listOf(guide)),
+                favoriteRepository = favoriteRepository,
+                regionalGuideSnapshotRepository = snapshotRepository,
+                regionalGuideFavoriteRepository =
+                    FakeRegionalGuideFavoriteRepository(
+                        favoriteRepository = favoriteRepository,
+                        snapshotRepository = snapshotRepository,
+                    ),
+            )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("Sigungu")
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        assertEquals(true, (viewModel.uiState.value as RegionalGuideUiState.Success).isFavorite)
+
+        viewModel.onFavoriteClick()
+        advanceUntilIdle()
+
+        assertEquals(false, (viewModel.uiState.value as RegionalGuideUiState.Success).isFavorite)
+        assertEquals(false, favoriteRepository.isFavorite(FavoriteTargetType.REGIONAL_GUIDE, legacyTargetId))
+        assertEquals(false, favoriteRepository.isFavorite(FavoriteTargetType.REGIONAL_GUIDE, currentSnapshot.targetId))
+        assertNull(snapshotRepository.getSnapshot(legacyTargetId))
+        assertNull(snapshotRepository.getSnapshot(currentSnapshot.targetId))
+    }
+
     private fun createViewModel(
         regionRepository: RegionRepository = FakeRegionRepository(),
         regionOptionsRepository: RegionOptionsRepository = FakeRegionOptionsRepository(),
@@ -1059,10 +1170,17 @@ class RegionalGuideViewModelTest {
                     targetId = snapshot.targetId,
                     savedAtMillis = 1L,
                 )
+            val compatibleTargetIds = snapshot.compatibleTargetIds
 
-            return if (favoriteRepository.isFavorite(favorite.type, favorite.targetId)) {
-                favoriteRepository.removeFavorite(favorite.type, favorite.targetId)
-                snapshotRepository.deleteSnapshot(snapshot.targetId)
+            return if (
+                compatibleTargetIds.any { targetId ->
+                    favoriteRepository.isFavorite(favorite.type, targetId)
+                }
+            ) {
+                compatibleTargetIds.forEach { targetId ->
+                    favoriteRepository.removeFavorite(favorite.type, targetId)
+                    snapshotRepository.deleteSnapshot(targetId)
+                }
                 false
             } else {
                 favoriteRepository.addFavorite(favorite)
@@ -1072,8 +1190,17 @@ class RegionalGuideViewModelTest {
         }
 
         override suspend fun removeFavorite(targetId: String) {
-            favoriteRepository.removeFavorite(FavoriteTargetType.REGIONAL_GUIDE, targetId)
-            snapshotRepository.deleteSnapshot(targetId)
+            val key = RegionalGuideFavoriteKey.decodeOrNull(targetId)
+            val compatibleTargetIds =
+                listOfNotNull(
+                    targetId,
+                    key?.copy(managementZoneName = null)?.encodeLegacy()
+                ).distinct()
+
+            compatibleTargetIds.forEach { compatibleTargetId ->
+                favoriteRepository.removeFavorite(FavoriteTargetType.REGIONAL_GUIDE, compatibleTargetId)
+                snapshotRepository.deleteSnapshot(compatibleTargetId)
+            }
         }
     }
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModelTest.kt
@@ -1,0 +1,79 @@
+package com.team.yeogibeoryeo.presentation.regionalguide.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RegionalGuideCandidateUiModelTest {
+
+    @Test
+    fun `관리구역명과 대상지역명이 다르면 두 값을 함께 표시한다`() {
+        val candidate = candidate(
+            managementZoneName = "노은2동",
+            targetRegionName = "반석동 일부지역"
+        )
+
+        assertEquals("노은2동 / 반석동 일부지역", candidate.displayText)
+    }
+
+    @Test
+    fun `관리구역명과 대상지역명이 같으면 한 번만 표시한다`() {
+        val candidate = candidate(
+            managementZoneName = "문전수거 지역",
+            targetRegionName = "문전수거 지역"
+        )
+
+        assertEquals("문전수거 지역", candidate.displayText)
+    }
+
+    @Test
+    fun `관리구역명만 있으면 관리구역명을 표시한다`() {
+        val candidate = candidate(
+            managementZoneName = "온천1동",
+            targetRegionName = null
+        )
+
+        assertEquals("온천1동", candidate.displayText)
+    }
+
+    @Test
+    fun `대상지역명만 있으면 대상지역명을 표시한다`() {
+        val candidate = candidate(
+            managementZoneName = null,
+            targetRegionName = "반석동 일부지역"
+        )
+
+        assertEquals("반석동 일부지역", candidate.displayText)
+    }
+
+    @Test
+    fun `관리구역명과 대상지역명이 모두 비어 있으면 지역명을 표시한다`() {
+        val candidate = candidate(
+            regionName = "대전광역시 유성구",
+            managementZoneName = " ",
+            targetRegionName = ""
+        )
+
+        assertEquals("대전광역시 유성구", candidate.displayText)
+    }
+
+    private fun candidate(
+        regionName: String = "대전광역시 유성구",
+        managementZoneName: String?,
+        targetRegionName: String?
+    ): RegionalGuideCandidateUiModel =
+        RegionalGuideCandidateUiModel(
+            guide = RegionalGuideUiModel(
+                regionName = regionName,
+                managementZoneName = managementZoneName,
+                targetRegionName = targetRegionName,
+                disposalPlaceType = null,
+                disposalPlaceDescription = null,
+                schedules = emptyList(),
+                uncollectedDays = null,
+                departmentInfo = null
+            ),
+            sido = "대전광역시",
+            sigungu = "유성구",
+            eupmyeondong = null
+        )
+}


### PR DESCRIPTION
## 작업 내용

- `/info` 후보의 `managementZoneName`과 `targetRegionName`을 함께 사용하도록 후보 식별과 선택 흐름을 보완했습니다.
- 동일 대상지역명이라도 관리구역명이 다르면 서로 다른 후보로 유지합니다.
- 복수 직접 매칭 후보가 남으면 첫 번째 후보를 임의 선택하지 않고 후보 목록으로 반환합니다.
- 후보 목록에 관리구역명과 대상지역명을 함께 표시합니다.
- Favorites key에 `managementZoneName`을 포함하고, 기존 v1 key의 즐겨찾기 상태 및 토글 호환을 유지했습니다.

## 변경 이유

같은 `targetRegionName`을 가진 서로 다른 관리구역 후보가 존재할 수 있습니다.

예:

- `노은2동 / 반석동 일부지역`
- `노은3동 / 반석동 일부지역`

기존에는 두 후보가 모두 `반석동 일부지역`처럼 보여 사용자가 구분하기 어려웠고, Favorites 재진입에서도 동일 대상지역명 후보를 안정적으로 구분하기 어려웠습니다.

## 주요 변경 사항

- 시도, 시군구, 관리구역명, 대상지역명과 상세 안내를 기준으로 후보 중복 제거 정책 보완
- 같은 후보 row로 판단되는 경우에만 `schedules` 병합
- 관리구역명과 대상지역명이 다르면 후보 표시 문자열에 함께 노출
- 선택한 읍면동이 `managementZoneName`과 정확히 일치하면 직접 매칭 후보로 인정
- v2 지역 가이드 Favorites key에 `managementZoneName` 포함
- 기존 v1 Favorites key decode 및 현재 화면의 즐겨찾기 상태·토글 호환 유지

## 유지한 흐름

- 직접 검색 / 자동 추천 후보 선택 / 선택형 UI 조회
- 주소 기반 `loadByAddress()` 진입
- #151에서 반영한 검색 실행 시 focus 및 키보드 정리
- 네트워크 실패, 결과 없음, `CandidateNotFound` 처리

## 이번 PR에서 제외한 범위

- #155 법정동·행정동 매칭 파일 적용
- 강릉시 사천면과 같은 직접 매칭 실패 사례의 시군구 후보 fallback
- 선택형 UI 옵션 재구성 또는 사전 제외
- 시군구 전체 단위 데이터의 읍면동 selector 정책 변경
- #159 검색창 입력값과 실제 조회 상태 분리

## 테스트

- [x] `./gradlew :domain:test`
- [x] `./gradlew :data:testDebugUnitTest`
- [x] `./gradlew :presentation:testDebugUnitTest`
- [x] `./gradlew :presentation:compileDebugKotlin`
- [x] `./gradlew :app:assembleDebug`
- [x] `git diff --check`

## 관련 이슈

- Related #158