### PR TITLE
[Refactor] 품목 한글 줄바꿈 Text 래퍼 분리

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/text/KoreanText.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/text/KoreanText.kt
@@ -1,9 +1,16 @@
 package com.team.yeogibeoryeo.presentation.common.text
 
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.text
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 
 private const val ZERO_WIDTH_SPACE = "\u200B"
 private val koreanSyllable = Regex("([가-힣])")
@@ -38,3 +45,26 @@ fun Modifier.koreanLineBreakSemantics(originalText: String): Modifier =
     semantics {
         text = AnnotatedString(originalText.toTalkBackReadableText())
     }
+
+@Composable
+fun KoreanLineBreakText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    style: TextStyle = TextStyle.Default,
+    fontWeight: FontWeight? = null,
+    textAlign: TextAlign? = null,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text.withKoreanLineBreakOpportunities(),
+        modifier = modifier.koreanLineBreakSemantics(text),
+        color = color,
+        style = style,
+        fontWeight = fontWeight,
+        textAlign = textAlign,
+        overflow = overflow,
+        maxLines = maxLines,
+    )
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -31,8 +30,7 @@ import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.domain.item.model.DisposalSubCategory
 import com.team.yeogibeoryeo.common.R as CommonR
 import com.team.yeogibeoryeo.presentation.R
-import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
-import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
+import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
 import com.team.yeogibeoryeo.presentation.search.components.DisposalGuideMetadataChips
 import com.team.yeogibeoryeo.presentation.search.components.SectionCard
 import com.team.yeogibeoryeo.presentation.search.components.SubGuideSection
@@ -166,9 +164,8 @@ fun ItemGuideDetailScreen(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(spacing.sm),
             ) {
-                Text(
-                    text = guide.name.withKoreanLineBreakOpportunities(),
-                    modifier = Modifier.koreanLineBreakSemantics(guide.name),
+                KoreanLineBreakText(
+                    text = guide.name,
                     style = textStyles.title.copy(
                         fontWeight = FontWeight.ExtraBold,
                         color = MaterialTheme.colorScheme.onSurface

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
@@ -17,8 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import com.team.yeogibeoryeo.presentation.R
-import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
-import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
+import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchBar
 import com.team.yeogibeoryeo.presentation.search.components.QuickCategoryGrid
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
@@ -68,9 +67,8 @@ fun ItemSearchInitialContent(
             item {
                 Column(verticalArrangement = Arrangement.spacedBy(metrics.sectionVerticalSpace)) {
                     val quickCategoriesTitle = stringResource(R.string.quick_categories)
-                    Text(
-                        text = quickCategoriesTitle.withKoreanLineBreakOpportunities(),
-                        modifier = Modifier.koreanLineBreakSemantics(quickCategoriesTitle),
+                    KoreanLineBreakText(
+                        text = quickCategoriesTitle,
                         style = MaterialTheme.typography.titleLarge.copy(
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.onSurface

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -29,8 +29,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.presentation.R
-import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
-import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
+import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
 import com.team.yeogibeoryeo.presentation.search.components.DisposalItemCard
 import com.team.yeogibeoryeo.presentation.search.components.EmptySearchResult
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchBar
@@ -169,9 +168,8 @@ fun ItemSearchScreen(
                             R.string.search_results_count,
                             uiState.guides.size
                         )
-                        Text(
-                            text = searchResultCountText.withKoreanLineBreakOpportunities(),
-                            modifier = Modifier.koreanLineBreakSemantics(searchResultCountText),
+                        KoreanLineBreakText(
+                            text = searchResultCountText,
                             style = MaterialTheme.typography.titleLarge.copy(
                                 fontWeight = FontWeight.Bold,
                                 color = MaterialTheme.colorScheme.onSurface

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalCategoryChip.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalCategoryChip.kt
@@ -4,13 +4,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
-import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
-import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
+import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 
 @Composable
@@ -43,9 +41,8 @@ internal fun MetadataChip(
                 )
                 .padding(horizontal = spacing.sm, vertical = spacing.xs),
     ) {
-        Text(
-            text = text.withKoreanLineBreakOpportunities(),
-            modifier = Modifier.koreanLineBreakSemantics(text),
+        KoreanLineBreakText(
+            text = text,
             style = MaterialTheme.typography.labelLarge,
             color = contentColor,
         )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalInstructionCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalInstructionCard.kt
@@ -14,8 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import com.team.yeogibeoryeo.domain.item.model.DisposalInstruction
 import com.team.yeogibeoryeo.presentation.R
-import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
-import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
+import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 import com.team.yeogibeoryeo.presentation.search.itemGuideDetailTextStyles
 
@@ -51,17 +50,15 @@ fun DisposalInstructionCard(
             )
             instructions.forEach { instruction ->
                 Column(verticalArrangement = Arrangement.spacedBy(spacing.xxs)) {
-                    Text(
-                        text = instruction.method.withKoreanLineBreakOpportunities(),
-                        modifier = Modifier.koreanLineBreakSemantics(instruction.method),
+                    KoreanLineBreakText(
+                        text = instruction.method,
                         style = textStyles.emphasizedBody.copy(
                             fontWeight = FontWeight.Medium,
                         ),
                     )
                     instruction.tip?.let {
-                        Text(
-                            text = it.withKoreanLineBreakOpportunities(),
-                            modifier = Modifier.koreanLineBreakSemantics(it),
+                        KoreanLineBreakText(
+                            text = it,
                             style = textStyles.supportingBody.copy(
                                 color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.84f),
                             ),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,8 +29,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.common.R as CommonR
 import com.team.yeogibeoryeo.presentation.R
-import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
-import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
+import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 
 @Composable
@@ -139,11 +137,10 @@ private fun BoxScope.FavoriteIndicator() {
 
 @Composable
 private fun ColumnScope.DisposalItemTitle(text: String) {
-    Text(
-        text = text.withKoreanLineBreakOpportunities(),
+    KoreanLineBreakText(
+        text = text,
         modifier = Modifier
-            .fillMaxWidth()
-            .koreanLineBreakSemantics(text),
+            .fillMaxWidth(),
         style = MaterialTheme.typography.titleMedium.copy(
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,
@@ -155,9 +152,8 @@ private fun ColumnScope.DisposalItemTitle(text: String) {
 
 @Composable
 private fun ColumnScope.DisposalItemDescription(text: String) {
-    Text(
-        text = text.withKoreanLineBreakOpportunities(),
-        modifier = Modifier.koreanLineBreakSemantics(text),
+    KoreanLineBreakText(
+        text = text,
         style = MaterialTheme.typography.bodyMedium.copy(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         ),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemGuideSectionCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemGuideSectionCard.kt
@@ -9,13 +9,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
-import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
-import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
+import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 import com.team.yeogibeoryeo.presentation.search.itemGuideDetailTextStyles
 
@@ -57,9 +55,9 @@ internal fun ItemGuideSectionTitle(
 ) {
     val textStyles = itemGuideDetailTextStyles()
 
-    Text(
-        text = text.withKoreanLineBreakOpportunities(),
-        modifier = modifier.koreanLineBreakSemantics(text),
+    KoreanLineBreakText(
+        text = text,
+        modifier = modifier,
         style = textStyles.sectionTitle.copy(
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchStatusContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemSearchStatusContent.kt
@@ -24,8 +24,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.team.yeogibeoryeo.common.design.theme.YeogiBeoryeoTheme
 import com.team.yeogibeoryeo.presentation.R
-import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
-import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
+import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 
 @Composable
@@ -63,9 +62,9 @@ fun ItemSearchStatusTitle(
     text: String,
     modifier: Modifier = Modifier,
 ) {
-    Text(
-        text = text.withKoreanLineBreakOpportunities(),
-        modifier = modifier.koreanLineBreakSemantics(text),
+    KoreanLineBreakText(
+        text = text,
+        modifier = modifier,
         style = MaterialTheme.typography.titleMedium,
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.onSurface,
@@ -78,9 +77,9 @@ fun ItemSearchStatusDescription(
     text: String,
     modifier: Modifier = Modifier,
 ) {
-    Text(
-        text = text.withKoreanLineBreakOpportunities(),
-        modifier = modifier.koreanLineBreakSemantics(text),
+    KoreanLineBreakText(
+        text = text,
+        modifier = modifier,
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         textAlign = TextAlign.Center,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SectionCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SectionCard.kt
@@ -6,13 +6,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import com.team.yeogibeoryeo.domain.item.model.DisposalGuideSectionRow
-import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
-import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
+import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 import com.team.yeogibeoryeo.presentation.search.itemGuideDetailTextStyles
 
@@ -70,9 +68,8 @@ private fun SectionLines(
     Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
         lines.forEachIndexed { index, line ->
             val text = if (numbered) "${index + 1}. $line" else line
-            Text(
-                text = text.withKoreanLineBreakOpportunities(),
-                modifier = Modifier.koreanLineBreakSemantics(text),
+            KoreanLineBreakText(
+                text = text,
                 style = textStyles.body.copy(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 ),
@@ -94,19 +91,18 @@ private fun SectionRow(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(spacing.sm),
     ) {
-        Text(
-            text = label.withKoreanLineBreakOpportunities(),
-            modifier = labelModifier.koreanLineBreakSemantics(label),
+        KoreanLineBreakText(
+            text = label,
+            modifier = labelModifier,
             style = textStyles.body.copy(
                 color = MaterialTheme.colorScheme.onSurface,
                 fontWeight = FontWeight.SemiBold,
             ),
         )
-        Text(
-            text = value.withKoreanLineBreakOpportunities(),
+        KoreanLineBreakText(
+            text = value,
             modifier = Modifier
-                .weight(1f)
-                .koreanLineBreakSemantics(value),
+                .weight(1f),
             style = textStyles.body.copy(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             ),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SubGuideSection.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/SubGuideSection.kt
@@ -3,13 +3,11 @@ package com.team.yeogibeoryeo.presentation.search.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import com.team.yeogibeoryeo.domain.item.model.DisposalSubGuide
-import com.team.yeogibeoryeo.presentation.common.text.koreanLineBreakSemantics
-import com.team.yeogibeoryeo.presentation.common.text.withKoreanLineBreakOpportunities
+import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 import com.team.yeogibeoryeo.presentation.search.itemGuideDetailTextStyles
 
@@ -44,17 +42,15 @@ private fun SubGuideItem(
     val textStyles = itemGuideDetailTextStyles()
 
     Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
-        Text(
-            text = name.withKoreanLineBreakOpportunities(),
-            modifier = Modifier.koreanLineBreakSemantics(name),
+        KoreanLineBreakText(
+            text = name,
             style = textStyles.subGuideTitle.copy(
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface,
             ),
         )
-        Text(
-            text = summary.withKoreanLineBreakOpportunities(),
-            modifier = Modifier.koreanLineBreakSemantics(summary),
+        KoreanLineBreakText(
+            text = summary,
             style = textStyles.body.copy(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             ),


### PR DESCRIPTION
## 작업 내용

- `KoreanLineBreakText`를 추가해 한글 줄바꿈 표시 텍스트와 접근성 원문 semantics 처리를 한 곳으로 묶었습니다.
- 품목 검색/상세 화면의 단순 텍스트 호출부를 `KoreanLineBreakText` 사용으로 정리했습니다.
- `QuickCategoryGrid` 라벨은 `minLines`, `onTextLayout` 테스트 훅이 있어 기존 처리를 유지했습니다.

## 변경 이유

기존에는 `withKoreanLineBreakOpportunities()`와 `koreanLineBreakSemantics(originalText)` 조합을 호출부마다 함께 맞춰야 했습니다. 표시용 문자열과 TalkBack용 원문을 따로 전달해야 해서, 이후 표시용 문자열이 semantics에 잘못 전달될 여지가 있었습니다.

이번 변경은 호출부가 원문만 넘기도록 만들어, 화면 줄바꿈과 접근성 읽기값 분리 의도를 컴포넌트 계약으로 드러내기 위한 정리입니다.

## 주요 변경 사항

- `presentation.common.text.KoreanLineBreakText` 추가
- 품목 검색 초기 화면, 검색 결과, 상세 제목, 상태 UI, 상세 섹션/행 텍스트에 래퍼 적용
- 배출방법 카드, 결과 카드, 카테고리 chip, sub guide 텍스트에 래퍼 적용

## 확인 사항

- 화면 표시용 zero-width space 삽입과 TalkBack용 원문 semantics 동작은 기존 유틸을 그대로 사용합니다.
- 품목 화면 외 지도/지역 가이드/즐겨찾기 화면은 변경하지 않았습니다.
- 한글 줄바꿈 알고리즘과 소재 약어 읽기값 정책은 변경하지 않았습니다.

## 테스트

- `./gradlew :presentation:compileDebugKotlin :presentation:testDebugUnitTest`
- `./gradlew :app:compileDebugKotlin`

## 관련 이슈

Related #162
