### PR TITLE
[Refactor] 품목 asset JSON 필수 필드 파싱 정리

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/item/local/ItemCategoryLocalDataSource.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/item/local/ItemCategoryLocalDataSource.kt
@@ -7,6 +7,8 @@ import com.team.yeogibeoryeo.domain.item.model.DisposalGuideSectionRow
 import com.team.yeogibeoryeo.domain.item.model.DisposalSubGuide
 import com.team.yeogibeoryeo.domain.item.model.RelatedSpotType
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -79,8 +81,8 @@ constructor(
                                 ?.map { subGuide ->
                                     val subGuideObject = subGuide.jsonObject
                                     DisposalSubGuide(
-                                        name = subGuideObject["name"]!!.jsonPrimitive.content,
-                                        summary = subGuideObject["summary"]!!.jsonPrimitive.content,
+                                        name = subGuideObject.requiredString("name"),
+                                        summary = subGuideObject.requiredString("summary"),
                                     )
                                 }.orEmpty(),
                         sections =
@@ -89,7 +91,7 @@ constructor(
                                 ?.map { section ->
                                     val sectionObject = section.jsonObject
                                     DisposalGuideSection(
-                                        title = sectionObject["title"]!!.jsonPrimitive.content,
+                                        title = sectionObject.requiredString("title"),
                                         lines = sectionObject.stringList("lines"),
                                         rows =
                                             sectionObject["rows"]
@@ -97,8 +99,8 @@ constructor(
                                                 ?.map { row ->
                                                     val rowObject = row.jsonObject
                                                     DisposalGuideSectionRow(
-                                                        label = rowObject["label"]!!.jsonPrimitive.content,
-                                                        value = rowObject["value"]!!.jsonPrimitive.content,
+                                                        label = rowObject.requiredString("label"),
+                                                        value = rowObject.requiredString("value"),
                                                     )
                                                 }.orEmpty(),
                                     )
@@ -115,10 +117,9 @@ constructor(
         array.map { element ->
             val obj = element.jsonObject
             WasteDictionaryItem(
-                name = obj["name"]!!.jsonPrimitive.content,
+                name = obj.requiredString("name"),
                 categoryPaths =
-                    obj["categoryPaths"]!!
-                        .jsonArray
+                    obj.requiredArray("categoryPaths")
                         .map { path ->
                             path.jsonArray.map { it.jsonPrimitive.content }
                         },
@@ -130,7 +131,16 @@ constructor(
         }
     }
 
-    private fun kotlinx.serialization.json.JsonObject.stringList(key: String): List<String> =
+    private fun JsonObject.requiredString(key: String): String =
+        requireNotNull(this[key]) { "필수 JSON key가 누락되었습니다: $key" }
+            .jsonPrimitive
+            .content
+
+    private fun JsonObject.requiredArray(key: String): JsonArray =
+        requireNotNull(this[key]) { "필수 JSON key가 누락되었습니다: $key" }
+            .jsonArray
+
+    private fun JsonObject.stringList(key: String): List<String> =
         this[key]
             ?.jsonArray
             ?.map { it.jsonPrimitive.content }


### PR DESCRIPTION
## 작업 내용

- `ItemCategoryLocalDataSource`의 필수 JSON key 접근을 helper로 정리했습니다.
- `obj["name"]!!`처럼 직접 접근하던 필드를 `requiredString(...)`, `requiredArray(...)`로 변경했습니다.
- 필수 key가 누락되면 한국어 오류 메시지로 누락 key를 확인할 수 있게 했습니다.

## 변경 이유

품목 asset JSON schema가 깨졌을 때 기존 `!!` 접근은 `NullPointerException`만 발생해 어떤 필드가 누락됐는지 바로 알기 어려웠습니다.

이번 변경은 큰 parser를 새로 만들지 않고 data layer 내부 helper만 추가해, 실패 원인을 더 빨리 확인할 수 있게 하는 정리입니다.

## 주요 변경 사항

- `JsonObject.requiredString(key)` 추가
- `JsonObject.requiredArray(key)` 추가
- `subGuides`, `sections`, `rows`, `item_disposal_guides`의 필수 key 접근 정리

## 확인 사항

- JSON schema 구조는 변경하지 않았습니다.
- domain model과 품목 UI는 변경하지 않았습니다.
- schema key는 domain/common으로 올리지 않고 data layer 내부 문자열로 유지했습니다.

## 테스트

- `./gradlew :data:testDebugUnitTest`
- `./gradlew :app:compileDebugKotlin`

## 관련 이슈

Related #164
