### PR TITLE
[Setting] release PR Android CI 중복 실행 줄이기

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - develop
-      - main
     paths:
       - '.github/workflows/android-ci.yml'
       - 'app/**'


### PR DESCRIPTION
## 관련 이슈
Related #176

## 작업 내용
- main 대상 `pull_request` 트리거에서 Android CI 실행을 제외했습니다.
- `develop` 대상 PR CI와 `develop/main` push CI는 유지했습니다.

## 변경 이유
release PR에서 PR 단계와 main merge push 단계의 Android CI가 연속 실행되어 대기 시간이 길어지고 있었습니다.
main push CI는 유지하므로 최종 main 반영 검증은 계속 수행됩니다.

## 테스트
- workflow trigger 조건 변경만 있어 별도 Gradle 테스트는 실행하지 않았습니다.
