### PR TITLE
[Release] develop 변경사항 main 반영

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - develop
-      - main
     paths:
       - '.github/workflows/android-ci.yml'
       - 'app/**'


### PR DESCRIPTION
## 관련 이슈
Closes #176

## 작업 내용
- develop에 반영된 release PR Android CI 중복 실행 방지 설정을 main에 반영합니다.

## 변경 이유
main 대상 release PR에서는 Android CI를 중복 실행하지 않고, merge 후 main push CI에서 최종 검증하도록 흐름을 정리했습니다.

## 확인 사항
- develop과 main 차이는 `.github/workflows/android-ci.yml` 변경 1건입니다.
- main push CI는 유지되어 merge 후 최종 검증이 실행됩니다.

## 테스트
- #177 Android CI 통과를 확인했습니다.
- 이번 release PR에서 Android CI가 실행되지 않는지 확인 예정입니다.
