### PR TITLE
[Refactor] 지도 수거 장소 타입 매핑 및 필터 chip 분리

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/mapper/SpotTypeMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/mapper/SpotTypeMapper.kt
@@ -18,6 +18,10 @@ object SpotTypeMapper {
                 CollectionSpotType.MEDICINE_DROP_BOX
             }
 
+            targetText.containsAny(batteryKeywords) -> {
+                CollectionSpotType.BATTERY_BIN
+            }
+
             targetText.containsAny(fluorescentLampKeywords) -> {
                 CollectionSpotType.FLUORESCENT_LAMP_BIN
             }
@@ -32,10 +36,6 @@ object SpotTypeMapper {
 
             targetText.containsAny(wasteCookingOilKeywords) -> {
                 CollectionSpotType.WASTE_COOKING_OIL_BIN
-            }
-
-            targetText.containsAny(batteryKeywords) -> {
-                CollectionSpotType.BATTERY_BIN
             }
 
             targetText.containsAny(phoneKeywords) -> {
@@ -64,7 +64,9 @@ object SpotTypeMapper {
         "폐의약품 수거함",
         "폐의약품수거함",
         "의약품 수거함",
+        "의약품수거함",
         "약국 폐의약품 수거함",
+        "약국 폐의약품수거함",
     )
 
     private val fluorescentLampKeywords = listOf(
@@ -129,11 +131,16 @@ object SpotTypeMapper {
 
     private val smallEWasteKeywords = listOf(
         "중소형 수거함",
+        "중소형수거함",
         "중소형 폐가전수거함",
+        "중소형폐가전수거함",
         "중소형 폐가전 수거함",
         "소형가전 수거함",
+        "소형가전수거함",
         "소형전기전자제품 수거함",
+        "소형전기전자제품수거함",
         "폐가전 수거함",
+        "폐가전수거함",
     )
 
     private fun String.containsAny(keywords: List<String>): Boolean {

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/mapper/SpotTypeMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/mapper/SpotTypeMapper.kt
@@ -14,23 +14,43 @@ object SpotTypeMapper {
         ).joinToString(separator = " ").trim()
 
         return when {
-            targetText.contains("건전지") -> {
+            targetText.containsAny(medicineKeywords) -> {
+                CollectionSpotType.MEDICINE_DROP_BOX
+            }
+
+            targetText.containsAny(fluorescentLampKeywords) -> {
+                CollectionSpotType.FLUORESCENT_LAMP_BIN
+            }
+
+            targetText.containsAny(clothingKeywords) -> {
+                CollectionSpotType.CLOTHING_BIN
+            }
+
+            targetText.containsAny(icePackKeywords) -> {
+                CollectionSpotType.ICE_PACK_BIN
+            }
+
+            targetText.containsAny(wasteCookingOilKeywords) -> {
+                CollectionSpotType.WASTE_COOKING_OIL_BIN
+            }
+
+            targetText.containsAny(batteryKeywords) -> {
                 CollectionSpotType.BATTERY_BIN
             }
 
-            targetText.contains("휴대폰") -> {
+            targetText.containsAny(phoneKeywords) -> {
                 CollectionSpotType.PHONE_DROP_OFF
             }
 
-            targetText.contains("재활용센터") || targetText.contains("재활용 센터") -> {
+            targetText.containsAny(recyclingCenterKeywords) -> {
                 CollectionSpotType.RECYCLING_CENTER
             }
 
-            targetText.contains("종량제") || targetText.contains("봉투") -> {
+            targetText.containsAny(standardBagKeywords) -> {
                 CollectionSpotType.STANDARD_BAG_STORE
             }
 
-            targetText.contains("중소형") || targetText.contains("수거함") -> {
+            targetText.containsAny(smallEWasteKeywords) -> {
                 CollectionSpotType.SMALL_E_WASTE_BIN
             }
 
@@ -38,5 +58,85 @@ object SpotTypeMapper {
                 CollectionSpotType.OTHER
             }
         }
+    }
+
+    private val medicineKeywords = listOf(
+        "폐의약품 수거함",
+        "폐의약품수거함",
+        "의약품 수거함",
+        "약국 폐의약품 수거함",
+    )
+
+    private val fluorescentLampKeywords = listOf(
+        "폐형광등 수거함",
+        "폐형광등수거함",
+        "형광등 수거함",
+        "형광등수거함",
+    )
+
+    private val clothingKeywords = listOf(
+        "의류 수거함",
+        "의류수거함",
+    )
+
+    private val icePackKeywords = listOf(
+        "아이스팩 수거함",
+    )
+
+    private val wasteCookingOilKeywords = listOf(
+        "폐식용유 수거함",
+        "폐식용유수거함",
+        "폐식용유 배출함",
+        "식물성 식용유 수거함",
+    )
+
+    private val batteryKeywords = listOf(
+        "폐건전지 수거함",
+        "건전지 수거함",
+        "전지 수거함",
+        "폐전지 수거함",
+        "전지수거함",
+        "건전지",
+        "폐전지",
+    )
+
+    private val phoneKeywords = listOf(
+        "폐휴대폰 배출처",
+        "폐휴대폰",
+        "휴대폰 수거함",
+        "휴대폰 배출함",
+    )
+
+    private val recyclingCenterKeywords = listOf(
+        "재활용센터",
+        "재활용 센터",
+        "재활용정거장",
+        "재활용동네마당",
+        "재활용 동네마당",
+        "재활용도움센터",
+        "클린하우스",
+        "클린 하우스",
+        "재활용품 분리배출함",
+        "재활용품 분리수거함",
+        "재활용품 공동배출장소",
+        "재활용품 분리배출장소",
+    )
+
+    private val standardBagKeywords = listOf(
+        "종량제",
+        "봉투",
+    )
+
+    private val smallEWasteKeywords = listOf(
+        "중소형 수거함",
+        "중소형 폐가전수거함",
+        "중소형 폐가전 수거함",
+        "소형가전 수거함",
+        "소형전기전자제품 수거함",
+        "폐가전 수거함",
+    )
+
+    private fun String.containsAny(keywords: List<String>): Boolean {
+        return keywords.any(::contains)
     }
 }

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/mapper/SpotTypeMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/mapper/SpotTypeMapperTest.kt
@@ -88,6 +88,16 @@ class SpotTypeMapperTest {
     }
 
     @Test
+    fun `의약품수거함이면 MEDICINE_DROP_BOX를 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "의약품수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.MEDICINE_DROP_BOX, result)
+    }
+
+    @Test
     fun `폐형광등 수거함이면 FLUORESCENT_LAMP_BIN을 반환한다`() {
         val result = SpotTypeMapper.mapToType(
             spotName = "폐형광등 수거함",
@@ -138,9 +148,39 @@ class SpotTypeMapperTest {
     }
 
     @Test
+    fun `소형가전수거함이면 SMALL_E_WASTE_BIN을 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "소형가전수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.SMALL_E_WASTE_BIN, result)
+    }
+
+    @Test
+    fun `소형전기전자제품수거함이면 SMALL_E_WASTE_BIN을 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "소형전기전자제품수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.SMALL_E_WASTE_BIN, result)
+    }
+
+    @Test
     fun `폐가전 수거함이면 SMALL_E_WASTE_BIN을 반환한다`() {
         val result = SpotTypeMapper.mapToType(
             spotName = "폐가전 수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.SMALL_E_WASTE_BIN, result)
+    }
+
+    @Test
+    fun `폐가전수거함이면 SMALL_E_WASTE_BIN을 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "폐가전수거함",
             detailAddress = null,
         )
 
@@ -162,6 +202,26 @@ class SpotTypeMapperTest {
     fun `폐전지 수거함이면 BATTERY_BIN을 반환한다`() {
         val result = SpotTypeMapper.mapToType(
             spotName = "폐전지 수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.BATTERY_BIN, result)
+    }
+
+    @Test
+    fun `폐건전지와 폐형광등 복합 수거함은 현재 chip 정책상 BATTERY_BIN을 우선 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "폐건전지, 폐형광등 수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.BATTERY_BIN, result)
+    }
+
+    @Test
+    fun `폐형광등 전지수거함 복합 응답은 현재 chip 정책상 BATTERY_BIN을 우선 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "폐형광등,전지수거함",
             detailAddress = null,
         )
 

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/mapper/SpotTypeMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/mapper/SpotTypeMapperTest.kt
@@ -2,6 +2,7 @@ package com.team.yeogibeoryeo.data.spot.mapper
 
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 class SpotTypeMapperTest {
@@ -74,5 +75,136 @@ class SpotTypeMapperTest {
         )
 
         assertEquals(CollectionSpotType.BATTERY_BIN, result)
+    }
+
+    @Test
+    fun `폐의약품수거함이면 MEDICINE_DROP_BOX를 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "폐의약품수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.MEDICINE_DROP_BOX, result)
+    }
+
+    @Test
+    fun `폐형광등 수거함이면 FLUORESCENT_LAMP_BIN을 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "폐형광등 수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.FLUORESCENT_LAMP_BIN, result)
+    }
+
+    @Test
+    fun `의류 수거함이면 CLOTHING_BIN을 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "의류 수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.CLOTHING_BIN, result)
+    }
+
+    @Test
+    fun `아이스팩 수거함이면 ICE_PACK_BIN을 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "아이스팩 수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.ICE_PACK_BIN, result)
+    }
+
+    @Test
+    fun `폐식용유 수거함이면 WASTE_COOKING_OIL_BIN을 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "폐식용유 수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.WASTE_COOKING_OIL_BIN, result)
+    }
+
+    @Test
+    fun `소형가전 수거함이면 SMALL_E_WASTE_BIN을 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "소형가전 수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.SMALL_E_WASTE_BIN, result)
+    }
+
+    @Test
+    fun `폐가전 수거함이면 SMALL_E_WASTE_BIN을 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "폐가전 수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.SMALL_E_WASTE_BIN, result)
+    }
+
+    @Test
+    fun `수거함 단어만으로는 SMALL_E_WASTE_BIN을 반환하지 않는다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "마을 공용 수거함",
+            detailAddress = null,
+        )
+
+        assertNotEquals(CollectionSpotType.SMALL_E_WASTE_BIN, result)
+        assertEquals(CollectionSpotType.OTHER, result)
+    }
+
+    @Test
+    fun `폐전지 수거함이면 BATTERY_BIN을 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "폐전지 수거함",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.BATTERY_BIN, result)
+    }
+
+    @Test
+    fun `재활용정거장이면 RECYCLING_CENTER를 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "재활용정거장",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.RECYCLING_CENTER, result)
+    }
+
+    @Test
+    fun `재활용동네마당이면 RECYCLING_CENTER를 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "재활용동네마당",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.RECYCLING_CENTER, result)
+    }
+
+    @Test
+    fun `재활용도움센터이면 RECYCLING_CENTER를 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "재활용도움센터",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.RECYCLING_CENTER, result)
+    }
+
+    @Test
+    fun `클린하우스이면 RECYCLING_CENTER를 반환한다`() {
+        val result = SpotTypeMapper.mapToType(
+            spotName = "클린하우스",
+            detailAddress = null,
+        )
+
+        assertEquals(CollectionSpotType.RECYCLING_CENTER, result)
     }
 }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/CollectionSpotType.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/CollectionSpotType.kt
@@ -6,5 +6,10 @@ enum class CollectionSpotType {
     PHONE_DROP_OFF,       // 폐휴대폰
     RECYCLING_CENTER,      // 재활용센터
     STANDARD_BAG_STORE,    // 종량제봉투 판매소
+    MEDICINE_DROP_BOX,     // 폐의약품
+    FLUORESCENT_LAMP_BIN,  // 폐형광등
+    CLOTHING_BIN,          // 의류수거함
+    ICE_PACK_BIN,          // 아이스팩
+    WASTE_COOKING_OIL_BIN, // 폐식용유
     OTHER                 // 기타
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSpotFilterChipPolicy.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSpotFilterChipPolicy.kt
@@ -1,0 +1,14 @@
+package com.team.yeogibeoryeo.presentation.map.components
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+
+object MapSpotFilterChipPolicy {
+    val visibleTypes: List<CollectionSpotType> = listOf(
+        CollectionSpotType.SMALL_E_WASTE_BIN,
+        CollectionSpotType.BATTERY_BIN,
+        CollectionSpotType.PHONE_DROP_OFF,
+        CollectionSpotType.RECYCLING_CENTER,
+        CollectionSpotType.STANDARD_BAG_STORE,
+        CollectionSpotType.OTHER,
+    )
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
@@ -54,6 +54,7 @@ fun SpotBottomSheetContent(
 
         if (hasSearched && !isLoading && !hasNoticeOrError) {
             SpotFilterChipRow(
+                types = MapSpotFilterChipPolicy.visibleTypes,
                 selectedTypes = selectedTypes,
                 onTypeClick = onTypeClick,
                 modifier = Modifier.padding(top = 4.dp),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotFilterChipRow.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotFilterChipRow.kt
@@ -18,6 +18,7 @@ import com.team.yeogibeoryeo.presentation.map.mapper.toDisplayName
 
 @Composable
 fun SpotFilterChipRow(
+    types: List<CollectionSpotType>,
     selectedTypes: Set<CollectionSpotType>,
     onTypeClick: (CollectionSpotType) -> Unit,
     modifier: Modifier = Modifier,
@@ -28,7 +29,7 @@ fun SpotFilterChipRow(
             .padding(horizontal = 16.dp, vertical = 4.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        CollectionSpotType.entries.forEach { type ->
+        types.forEach { type ->
             FilterChip(
                 selected = type in selectedTypes,
                 onClick = {
@@ -48,6 +49,7 @@ private fun SpotFilterChipRowPreview() {
     MaterialTheme {
         Surface {
             SpotFilterChipRow(
+                types = MapSpotFilterChipPolicy.visibleTypes,
                 selectedTypes = emptySet(),
                 onTypeClick = {},
             )
@@ -61,6 +63,7 @@ private fun SpotFilterChipRowSelectedPreview() {
     MaterialTheme {
         Surface {
             SpotFilterChipRow(
+                types = MapSpotFilterChipPolicy.visibleTypes,
                 selectedTypes = setOf(
                     CollectionSpotType.BATTERY_BIN,
                     CollectionSpotType.RECYCLING_CENTER,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/mapper/CollectionSpotTypeUiMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/mapper/CollectionSpotTypeUiMapper.kt
@@ -9,5 +9,10 @@ fun CollectionSpotType.toDisplayName(): String =
         CollectionSpotType.PHONE_DROP_OFF -> "폐휴대폰"
         CollectionSpotType.RECYCLING_CENTER -> "재활용센터"
         CollectionSpotType.STANDARD_BAG_STORE -> "종량제봉투"
+        CollectionSpotType.MEDICINE_DROP_BOX -> "폐의약품"
+        CollectionSpotType.FLUORESCENT_LAMP_BIN -> "폐형광등"
+        CollectionSpotType.CLOTHING_BIN -> "의류수거함"
+        CollectionSpotType.ICE_PACK_BIN -> "아이스팩"
+        CollectionSpotType.WASTE_COOKING_OIL_BIN -> "폐식용유"
         CollectionSpotType.OTHER -> "기타"
     }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/components/MapSpotFilterChipPolicyTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/components/MapSpotFilterChipPolicyTest.kt
@@ -1,0 +1,41 @@
+package com.team.yeogibeoryeo.presentation.map.components
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MapSpotFilterChipPolicyTest {
+
+    @Test
+    fun `지도 chip 노출 목록은 CollectionSpotType entries 전체를 그대로 사용하지 않는다`() {
+        assertNotEquals(
+            CollectionSpotType.entries.toList(),
+            MapSpotFilterChipPolicy.visibleTypes,
+        )
+    }
+
+    @Test
+    fun `신규 내부 타입은 지도 chip에 자동 노출되지 않는다`() {
+        val visibleTypes = MapSpotFilterChipPolicy.visibleTypes
+
+        assertFalse(CollectionSpotType.MEDICINE_DROP_BOX in visibleTypes)
+        assertFalse(CollectionSpotType.FLUORESCENT_LAMP_BIN in visibleTypes)
+        assertFalse(CollectionSpotType.CLOTHING_BIN in visibleTypes)
+        assertFalse(CollectionSpotType.ICE_PACK_BIN in visibleTypes)
+        assertFalse(CollectionSpotType.WASTE_COOKING_OIL_BIN in visibleTypes)
+    }
+
+    @Test
+    fun `기존 주요 지도 chip 타입은 계속 노출된다`() {
+        val visibleTypes = MapSpotFilterChipPolicy.visibleTypes
+
+        assertTrue(CollectionSpotType.SMALL_E_WASTE_BIN in visibleTypes)
+        assertTrue(CollectionSpotType.BATTERY_BIN in visibleTypes)
+        assertTrue(CollectionSpotType.PHONE_DROP_OFF in visibleTypes)
+        assertTrue(CollectionSpotType.RECYCLING_CENTER in visibleTypes)
+        assertTrue(CollectionSpotType.STANDARD_BAG_STORE in visibleTypes)
+        assertTrue(CollectionSpotType.OTHER in visibleTypes)
+    }
+}


### PR DESCRIPTION
## 작업 내용

Refs #171

지도 수거 장소 타입 매핑 기준을 정비하고, 내부 분류 타입과 지도 filter chip 노출 정책을 분리했습니다.

기존에는 장소명 또는 상세 위치에 `수거함` 단어가 포함되면 `SMALL_E_WASTE_BIN`으로 분류되어 폐의약품/폐형광등/의류/아이스팩/폐식용유 수거함까지 중소형 수거함으로 묶일 수 있었습니다.

이번 작업에서는 `수거함` 단어만으로 `SMALL_E_WASTE_BIN`에 매핑하는 로직을 제거하고, 신규 내부 타입과 chip 노출 정책을 분리했습니다.

## 주요 변경 사항

| 구분 | 내용 |
| --- | --- |
| 타입 추가 | `MEDICINE_DROP_BOX`, `FLUORESCENT_LAMP_BIN`, `CLOTHING_BIN`, `ICE_PACK_BIN`, `WASTE_COOKING_OIL_BIN` 추가 |
| 매핑 기준 정비 | `수거함` 단어 기반 `SMALL_E_WASTE_BIN` 매핑 제거 |
| 소형가전/폐가전 매핑 | `중소형`, `소형가전`, `폐가전` 성격이 명확한 키워드만 `SMALL_E_WASTE_BIN`으로 분류 |
| 키워드 보강 | 폐건전지, 폐전지, 폐휴대폰, 재활용정거장, 재활용동네마당, 재활용도움센터, 클린하우스 등 매핑 보강 |
| UI 표시명 | 신규 타입 표시명 추가 |
| chip 정책 분리 | `MapSpotFilterChipPolicy.visibleTypes` 추가 |
| chip 렌더링 | `SpotFilterChipRow`가 `CollectionSpotType.entries`를 직접 순회하지 않도록 변경 |
| 테스트 | `SpotTypeMapperTest`, `MapSpotFilterChipPolicyTest` 보강 |

## 신규 내부 타입

| 타입 | 표시명 | 비고 |
| --- | --- | --- |
| `MEDICINE_DROP_BOX` | 폐의약품 | 지도 chip 자동 노출 안 함 |
| `FLUORESCENT_LAMP_BIN` | 폐형광등 | 지도 chip 자동 노출 안 함 |
| `CLOTHING_BIN` | 의류수거함 | 지도 chip 자동 노출 안 함 |
| `ICE_PACK_BIN` | 아이스팩 | 지도 chip 자동 노출 안 함 |
| `WASTE_COOKING_OIL_BIN` | 폐식용유 | 지도 chip 자동 노출 안 함 |

## 지도 filter chip 정책

| 항목 | 변경 전 | 변경 후 |
| --- | --- | --- |
| chip 노출 기준 | `CollectionSpotType.entries` 직접 순회 | `MapSpotFilterChipPolicy.visibleTypes` 기준 |
| 신규 타입 추가 시 | 모든 타입이 chip에 자동 노출될 수 있음 | 정책에 명시한 타입만 chip 노출 |
| UI 책임 | chip row가 enum 전체를 알고 렌더링 | chip row는 전달받은 타입 목록만 렌더링 |

현재 지도에 노출되는 chip 타입은 기존 주요 타입을 유지했습니다.

- `SMALL_E_WASTE_BIN`
- `BATTERY_BIN`
- `PHONE_DROP_OFF`
- `RECYCLING_CENTER`
- `STANDARD_BAG_STORE`
- `OTHER`

## 검증

| 항목 | 결과 |
| --- | --- |
| `폐의약품수거함`이 `MEDICINE_DROP_BOX`로 분류되는지 확인 | 확인 |
| `폐형광등 수거함`이 `FLUORESCENT_LAMP_BIN`으로 분류되는지 확인 | 확인 |
| `의류 수거함`이 `CLOTHING_BIN`으로 분류되는지 확인 | 확인 |
| `아이스팩 수거함`이 `ICE_PACK_BIN`으로 분류되는지 확인 | 확인 |
| `폐식용유 수거함`이 `WASTE_COOKING_OIL_BIN`으로 분류되는지 확인 | 확인 |
| `수거함` 단어만으로 `SMALL_E_WASTE_BIN`에 매핑되지 않는지 확인 | 확인 |
| 소형가전/폐가전 관련 장소만 `SMALL_E_WASTE_BIN`으로 분류되는지 확인 | 확인 |
| 폐건전지/폐전지 관련 장소가 `BATTERY_BIN`으로 분류되는지 확인 | 확인 |
| 폐휴대폰 관련 장소가 `PHONE_DROP_OFF`로 분류되는지 확인 | 확인 |
| 재활용정거장/재활용동네마당/재활용도움센터/클린하우스가 `RECYCLING_CENTER`로 분류되는지 확인 | 확인 |
| 신규 내부 타입이 지도 chip에 자동 노출되지 않는지 확인 | 확인 |
| 기존 지도 검색 / 필터 / 마커 / BottomSheet 동작 유지 | 확인 |
| 기존 즐겨찾기 토글 동작 유지 | 확인 |

## 테스트

```bash
./gradlew.bat :data:testDebugUnitTest --tests com.team.yeogibeoryeo.data.spot.mapper.SpotTypeMapperTest
./gradlew.bat :presentation:testDebugUnitTest --tests com.team.yeogibeoryeo.presentation.map.components.MapSpotFilterChipPolicyTest
./gradlew.bat :domain:test
./gradlew.bat :data:testDebugUnitTest
./gradlew.bat :presentation:testDebugUnitTest
./gradlew.bat :presentation:compileDebugKotlin
./gradlew.bat :app:assembleDebug
git diff --check
```
## 참고
- git diff --check는 공백 오류 없이 통과했습니다.
- Windows 환경에서 일부 파일의 LF will be replaced by CRLF 줄바꿈 경고만 있었습니다.
- 이번 PR에서는 #169 품목 상세 CTA 연결은 진행하지 않았습니다.
- /getSpot API 구조, 지도 검색 UX, 즐겨찾기 저장 구조는 변경하지 않았습니다.