### PR TITLE
feat: 품목 홈 지역 가이드 요약 배너 추가

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
@@ -19,7 +19,13 @@ data class RegionalGuideRoute(
     val initialKeyword: String? = null,
     val initialAddress: String? = null,
     val initialFavoriteTargetId: String? = null,
+    val entrySource: RegionalGuideEntrySource? = null,
 )
+
+@Serializable
+enum class RegionalGuideEntrySource {
+    FAVORITES,
+}
 
 internal fun String.toRegionalGuideAddressRouteOrNull(): RegionalGuideRoute? =
     trim()

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/BottomTabNavigation.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/BottomTabNavigation.kt
@@ -22,10 +22,7 @@ internal fun NavHostController.createBottomNavigationItems(
             iconResId = CommonR.drawable.ic_symbol_recycle,
             selected = currentBackStackEntry.isItemSearchSelected(),
             onClick = {
-                navigateBottomTabClearingRegionalGuideReentry(
-                    currentBackStackEntry = currentBackStackEntry,
-                    route = ItemSearchRoute(),
-                )
+                navigateItemSearchRoot(currentBackStackEntry)
             },
         ),
         BottomNavigationItem(
@@ -44,10 +41,7 @@ internal fun NavHostController.createBottomNavigationItems(
             iconResId = AppR.drawable.ic_navigation_guide,
             selected = currentBackStackEntry.isRegionalGuideSelected(),
             onClick = {
-                navigateBottomTabClearingRegionalGuideReentry(
-                    currentBackStackEntry = currentBackStackEntry,
-                    route = RegionalGuideRoute(),
-                )
+                navigateRegionalGuideRoot(currentBackStackEntry)
             },
         ),
         BottomNavigationItem(
@@ -84,7 +78,8 @@ private fun NavBackStackEntry?.isMapRegionalGuideSelected(): Boolean =
         toRoute<RegionalGuideRoute>().isMapReentryRoute()
 
 internal fun RegionalGuideRoute.isFavoriteReentryRoute(): Boolean =
-    !initialFavoriteTargetId.isNullOrBlank()
+    !initialFavoriteTargetId.isNullOrBlank() &&
+        entrySource == RegionalGuideEntrySource.FAVORITES
 
 internal fun RegionalGuideRoute.isMapReentryRoute(): Boolean =
     initialFavoriteTargetId.isNullOrBlank() &&
@@ -103,6 +98,52 @@ private fun NavBackStackEntry?.isItemGuideDetailSource(source: ItemGuideDetailSo
     this != null &&
         destination.hasRoute<ItemGuideDetailRoute>() &&
         toRoute<ItemGuideDetailRoute>().source == source
+
+private fun NavHostController.navigateItemSearchRoot(
+    currentBackStackEntry: NavBackStackEntry?,
+) {
+    when {
+        currentBackStackEntry?.destination?.hasRoute<ItemSearchRoute>() == true -> return
+        currentBackStackEntry.isItemGuideDetailSource(ItemGuideDetailSource.SEARCH) -> {
+            if (!popBackStack<ItemSearchRoute>(inclusive = false)) {
+                navigateItemSearchTab()
+            }
+        }
+        else -> {
+            popRegionalGuideReentryToSourceRoot(currentBackStackEntry)
+            navigateItemSearchTab()
+        }
+    }
+}
+
+private fun NavHostController.navigateRegionalGuideRoot(
+    currentBackStackEntry: NavBackStackEntry?,
+) {
+    val currentRoute = currentBackStackEntry
+        ?.takeIf { entry -> entry.destination.hasRoute<RegionalGuideRoute>() }
+        ?.toRoute<RegionalGuideRoute>()
+
+    if (currentRoute == RegionalGuideRoute()) return
+
+    popRegionalGuideReentryToSourceRoot(currentBackStackEntry)
+    navigate(RegionalGuideRoute()) {
+        popUpTo(graph.findStartDestination().id) {
+            saveState = true
+        }
+        launchSingleTop = true
+        restoreState = false
+    }
+}
+
+private fun NavHostController.navigateItemSearchTab() {
+    navigate(ItemSearchRoute()) {
+        popUpTo(graph.findStartDestination().id) {
+            saveState = true
+        }
+        launchSingleTop = true
+        restoreState = false
+    }
+}
 
 private fun NavHostController.navigateFavoritesRoot(
     currentBackStackEntry: NavBackStackEntry?,
@@ -129,6 +170,17 @@ private fun NavHostController.navigateMapRoot(
 ) {
     if (currentBackStackEntry.isMapRegionalGuideSelected()) {
         popBackStack<MapRoute>(inclusive = false)
+        return
+    }
+
+    if (currentBackStackEntry.isRegionalGuideSelected()) {
+        navigate(MapRoute()) {
+            popUpTo(graph.findStartDestination().id) {
+                saveState = true
+            }
+            launchSingleTop = true
+            restoreState = false
+        }
         return
     }
 

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -134,7 +134,10 @@ fun YeogiBeoryeoNavHost(
                     },
                     onRegionalGuideClick = { targetId ->
                         navController.navigate(
-                            RegionalGuideRoute(initialFavoriteTargetId = targetId),
+                            RegionalGuideRoute(
+                                initialFavoriteTargetId = targetId,
+                                entrySource = RegionalGuideEntrySource.FAVORITES,
+                            ),
                         )
                     },
                 )
@@ -149,6 +152,13 @@ fun YeogiBeoryeoNavHost(
                             ItemGuideDetailRoute(
                                 guideId = guide.id,
                                 source = ItemGuideDetailSource.SEARCH,
+                            ),
+                        )
+                    },
+                    onRegionalGuideSummaryClick = { targetId ->
+                        navController.navigate(
+                            RegionalGuideRoute(
+                                initialFavoriteTargetId = targetId,
                             ),
                         )
                     },

--- a/app/src/test/java/com/team/yeogibeoryeo/navigation/RegionalGuideRouteNavigationPolicyTest.kt
+++ b/app/src/test/java/com/team/yeogibeoryeo/navigation/RegionalGuideRouteNavigationPolicyTest.kt
@@ -16,10 +16,10 @@ class RegionalGuideRouteNavigationPolicyTest {
     }
 
     @Test
-    fun `regional guide route with favorite target is favorites reentry route`() {
+    fun `regional guide route with favorite target and no source is guide tab route`() {
         val route = RegionalGuideRoute(initialFavoriteTargetId = "regional-guide-v1|4:Sido")
 
-        assertTrue(route.isFavoriteReentryRoute())
+        assertFalse(route.isFavoriteReentryRoute())
         assertFalse(route.isMapReentryRoute())
     }
 
@@ -29,12 +29,31 @@ class RegionalGuideRouteNavigationPolicyTest {
     }
 
     @Test
+    fun `regional guide route from home summary remains guide tab route`() {
+        val route = RegionalGuideRoute(initialFavoriteTargetId = "regional-guide-v2|4:Sido")
+
+        assertFalse(route.isFavoriteReentryRoute())
+        assertFalse(route.isMapReentryRoute())
+    }
+
+    @Test
+    fun `regional guide route from favorites remains favorites reentry route`() {
+        val route = RegionalGuideRoute(
+            initialFavoriteTargetId = "regional-guide-v2|4:Sido",
+            entrySource = RegionalGuideEntrySource.FAVORITES,
+        )
+
+        assertTrue(route.isFavoriteReentryRoute())
+        assertFalse(route.isMapReentryRoute())
+    }
+
+    @Test
     fun `spot address creates regional guide address route`() {
-        val address = "  서울특별시 중구 남대문로 63 (남대문로2가, 한진빌딩)  "
+        val address = "  서울특별시 중구 퇴계로 63 (남창동, 삼익패션타운)  "
 
         val route = address.toRegionalGuideAddressRouteOrNull()
 
-        assertEquals("서울특별시 중구 남대문로 63 (남대문로2가, 한진빌딩)", route?.initialAddress)
+        assertEquals("서울특별시 중구 퇴계로 63 (남창동, 삼익패션타운)", route?.initialAddress)
         assertFalse(route!!.isFavoriteReentryRoute())
         assertTrue(route.isMapReentryRoute())
     }
@@ -45,13 +64,13 @@ class RegionalGuideRouteNavigationPolicyTest {
     }
 
     @Test
-    fun `regional guide route with address and favorite target remains favorites reentry route`() {
+    fun `regional guide route with address and favorite target requires favorites source for favorites reentry`() {
         val route = RegionalGuideRoute(
-            initialAddress = "서울특별시 중구 남대문로 63 (남대문로2가, 한진빌딩)",
+            initialAddress = "서울특별시 중구 퇴계로 63 (남창동, 삼익패션타운)",
             initialFavoriteTargetId = "regional-guide-v1|4:Sido",
         )
 
-        assertTrue(route.isFavoriteReentryRoute())
+        assertFalse(route.isFavoriteReentryRoute())
         assertFalse(route.isMapReentryRoute())
     }
 }

--- a/common/src/main/res/drawable/ic_symbol_info.xml
+++ b/common/src/main/res/drawable/ic_symbol_info.xml
@@ -1,0 +1,23 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M12,22C17.5228,22 22,17.5228 22,12C22,6.4772 17.5228,2 12,2C6.4772,2 2,6.4772 2,12C2,17.5228 6.4772,22 12,22Z"
+        android:strokeColor="@android:color/black"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M12,16L12,12"
+        android:strokeColor="@android:color/black"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M12,8.5m-1,0a1,1 0,1 0,2 0a1,1 0,1 0,-2 0" />
+</vector>

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/HomeRegionalGuideSummary.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/HomeRegionalGuideSummary.kt
@@ -8,6 +8,16 @@ data class HomeRegionalGuideSummary(
     val disposalTime: String?,
 )
 
+sealed interface TodayRegionalWasteSummaryResult {
+    data class Summary(
+        val summary: HomeRegionalGuideSummary,
+    ) : TodayRegionalWasteSummaryResult
+
+    data object NoTodaySchedule : TodayRegionalWasteSummaryResult
+
+    data object NeedsScheduleConfirmation : TodayRegionalWasteSummaryResult
+}
+
 sealed interface HomeRegionalGuideSummaryResult {
     data object Loading : HomeRegionalGuideSummaryResult
 
@@ -18,6 +28,11 @@ sealed interface HomeRegionalGuideSummaryResult {
     ) : HomeRegionalGuideSummaryResult
 
     data class NoTodaySchedule(
+        val targetId: String,
+        val regionName: String,
+    ) : HomeRegionalGuideSummaryResult
+
+    data class ScheduleNeedsConfirmation(
         val targetId: String,
         val regionName: String,
     ) : HomeRegionalGuideSummaryResult

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/HomeRegionalGuideSummary.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/HomeRegionalGuideSummary.kt
@@ -1,0 +1,34 @@
+package com.team.yeogibeoryeo.domain.regionalguide.model
+
+data class HomeRegionalGuideSummary(
+    val targetId: String,
+    val regionName: String,
+    val wasteTypeNames: List<String>,
+    val disposalDays: String,
+    val disposalTime: String?,
+)
+
+sealed interface HomeRegionalGuideSummaryResult {
+    data object Loading : HomeRegionalGuideSummaryResult
+
+    data object NoFavorite : HomeRegionalGuideSummaryResult
+
+    data class Success(
+        val summary: HomeRegionalGuideSummary,
+    ) : HomeRegionalGuideSummaryResult
+
+    data class NoTodaySchedule(
+        val targetId: String,
+        val regionName: String,
+    ) : HomeRegionalGuideSummaryResult
+
+    data class FavoriteRestoreFailed(
+        val targetId: String,
+    ) : HomeRegionalGuideSummaryResult
+
+    data class Failure(
+        val targetId: String,
+        val regionName: String,
+        val reason: RegionalGuideFailureReason,
+    ) : HomeRegionalGuideSummaryResult
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/GetTodayRegionalWasteSummaryUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/GetTodayRegionalWasteSummaryUseCase.kt
@@ -3,6 +3,7 @@ package com.team.yeogibeoryeo.domain.regionalguide.usecase
 import com.team.yeogibeoryeo.domain.regionalguide.model.HomeRegionalGuideSummary
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteSchedule
+import com.team.yeogibeoryeo.domain.regionalguide.model.TodayRegionalWasteSummaryResult
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.ZoneId
@@ -16,32 +17,40 @@ class GetTodayRegionalWasteSummaryUseCase
             regionName: String,
             guide: RegionalDisposalGuide,
             today: LocalDate = LocalDate.now(SEOUL_ZONE_ID),
-        ): HomeRegionalGuideSummary? {
+        ): TodayRegionalWasteSummaryResult {
             val todaySchedules =
                 guide.schedules.filter { schedule ->
                     schedule.disposalDays.hasDay(today.dayOfWeek)
                 }
 
-            if (todaySchedules.isEmpty()) return null
+            if (todaySchedules.isEmpty()) {
+                return if (guide.schedules.any { schedule -> schedule.disposalDays.needsConfirmation() }) {
+                    TodayRegionalWasteSummaryResult.NeedsScheduleConfirmation
+                } else {
+                    TodayRegionalWasteSummaryResult.NoTodaySchedule
+                }
+            }
 
-            return HomeRegionalGuideSummary(
-                targetId = targetId,
-                regionName = regionName,
-                wasteTypeNames =
-                    todaySchedules
-                        .map { schedule -> schedule.wasteType.description }
-                        .distinct(),
-                disposalDays =
-                    todaySchedules
-                        .mapNotNull { schedule -> schedule.disposalDays?.trimToNull() }
-                        .distinct()
-                        .joinToString(DISPLAY_SEPARATOR),
-                disposalTime =
-                    todaySchedules
-                        .mapNotNull { schedule -> schedule.displayTime() }
-                        .distinct()
-                        .joinToString(DISPLAY_SEPARATOR)
-                        .takeIf { it.isNotBlank() },
+            return TodayRegionalWasteSummaryResult.Summary(
+                HomeRegionalGuideSummary(
+                    targetId = targetId,
+                    regionName = regionName,
+                    wasteTypeNames =
+                        todaySchedules
+                            .map { schedule -> schedule.wasteType.description }
+                            .distinct(),
+                    disposalDays =
+                        todaySchedules
+                            .mapNotNull { schedule -> schedule.disposalDays?.trimToNull() }
+                            .distinct()
+                            .joinToString(DISPLAY_SEPARATOR),
+                    disposalTime =
+                        todaySchedules
+                            .mapNotNull { schedule -> schedule.displayTime() }
+                            .distinct()
+                            .joinToString(DISPLAY_SEPARATOR)
+                            .takeIf { it.isNotBlank() },
+                ),
             )
         }
 
@@ -53,6 +62,13 @@ class GetTodayRegionalWasteSummaryUseCase
                 ?.any { day -> day == dayLabel }
                 ?: false
         }
+
+        private fun String?.needsConfirmation(): Boolean =
+            this
+                ?.split(',')
+                ?.mapNotNull { day -> day.trimToNull() }
+                ?.any { day -> day in NEEDS_CONFIRMATION_DAY_LABELS }
+                ?: false
 
         private fun RegionalWasteSchedule.displayTime(): String? {
             val start = disposalStartTime.trimToNull()
@@ -71,6 +87,8 @@ class GetTodayRegionalWasteSummaryUseCase
             val SEOUL_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
 
             private const val DISPLAY_SEPARATOR = " / "
+
+            private val NEEDS_CONFIRMATION_DAY_LABELS = setOf("기타", "미지정")
 
             private val DAY_LABELS =
                 mapOf(

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/GetTodayRegionalWasteSummaryUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/GetTodayRegionalWasteSummaryUseCase.kt
@@ -1,0 +1,86 @@
+package com.team.yeogibeoryeo.domain.regionalguide.usecase
+
+import com.team.yeogibeoryeo.domain.regionalguide.model.HomeRegionalGuideSummary
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteSchedule
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.ZoneId
+import javax.inject.Inject
+
+class GetTodayRegionalWasteSummaryUseCase
+    @Inject
+    constructor() {
+        operator fun invoke(
+            targetId: String,
+            regionName: String,
+            guide: RegionalDisposalGuide,
+            today: LocalDate = LocalDate.now(SEOUL_ZONE_ID),
+        ): HomeRegionalGuideSummary? {
+            val todaySchedules =
+                guide.schedules.filter { schedule ->
+                    schedule.disposalDays.hasDay(today.dayOfWeek)
+                }
+
+            if (todaySchedules.isEmpty()) return null
+
+            return HomeRegionalGuideSummary(
+                targetId = targetId,
+                regionName = regionName,
+                wasteTypeNames =
+                    todaySchedules
+                        .map { schedule -> schedule.wasteType.description }
+                        .distinct(),
+                disposalDays =
+                    todaySchedules
+                        .mapNotNull { schedule -> schedule.disposalDays?.trimToNull() }
+                        .distinct()
+                        .joinToString(DISPLAY_SEPARATOR),
+                disposalTime =
+                    todaySchedules
+                        .mapNotNull { schedule -> schedule.displayTime() }
+                        .distinct()
+                        .joinToString(DISPLAY_SEPARATOR)
+                        .takeIf { it.isNotBlank() },
+            )
+        }
+
+        private fun String?.hasDay(dayOfWeek: DayOfWeek): Boolean {
+            val dayLabel = DAY_LABELS[dayOfWeek] ?: return false
+            return this
+                ?.split(',')
+                ?.mapNotNull { day -> day.trimToNull() }
+                ?.any { day -> day == dayLabel }
+                ?: false
+        }
+
+        private fun RegionalWasteSchedule.displayTime(): String? {
+            val start = disposalStartTime.trimToNull()
+            val end = disposalEndTime.trimToNull()
+            return when {
+                start != null && end != null -> "$start ~ $end"
+                start != null -> "$start 이후"
+                end != null -> "$end 이전"
+                else -> null
+            }
+        }
+
+        private fun String?.trimToNull(): String? = this?.trim()?.takeIf { it.isNotBlank() }
+
+        companion object {
+            val SEOUL_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
+
+            private const val DISPLAY_SEPARATOR = " / "
+
+            private val DAY_LABELS =
+                mapOf(
+                    DayOfWeek.MONDAY to "월",
+                    DayOfWeek.TUESDAY to "화",
+                    DayOfWeek.WEDNESDAY to "수",
+                    DayOfWeek.THURSDAY to "목",
+                    DayOfWeek.FRIDAY to "금",
+                    DayOfWeek.SATURDAY to "토",
+                    DayOfWeek.SUNDAY to "일",
+                )
+        }
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/ObserveHomeRegionalGuideSummaryUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/ObserveHomeRegionalGuideSummaryUseCase.kt
@@ -8,6 +8,7 @@ import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveRegionalGuideFavorit
 import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.regionalguide.model.HomeRegionalGuideSummaryResult
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideLookupResult
+import com.team.yeogibeoryeo.domain.regionalguide.model.TodayRegionalWasteSummaryResult
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -62,20 +63,27 @@ class ObserveHomeRegionalGuideSummaryUseCase
                     )
             ) {
                 is RegionalGuideLookupResult.Success -> {
-                    val summary =
-                        getTodayRegionalWasteSummaryUseCase(
+                    when (
+                        val summaryResult = getTodayRegionalWasteSummaryUseCase(
                             targetId = snapshot.targetId,
                             regionName = regionName,
                             guide = result.guide,
                         )
+                    ) {
+                        is TodayRegionalWasteSummaryResult.Summary ->
+                            HomeRegionalGuideSummaryResult.Success(summaryResult.summary)
 
-                    if (summary == null) {
-                        HomeRegionalGuideSummaryResult.NoTodaySchedule(
-                            targetId = snapshot.targetId,
-                            regionName = regionName,
-                        )
-                    } else {
-                        HomeRegionalGuideSummaryResult.Success(summary)
+                        TodayRegionalWasteSummaryResult.NoTodaySchedule ->
+                            HomeRegionalGuideSummaryResult.NoTodaySchedule(
+                                targetId = snapshot.targetId,
+                                regionName = regionName,
+                            )
+
+                        TodayRegionalWasteSummaryResult.NeedsScheduleConfirmation ->
+                            HomeRegionalGuideSummaryResult.ScheduleNeedsConfirmation(
+                                targetId = snapshot.targetId,
+                                regionName = regionName,
+                            )
                     }
                 }
 

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/ObserveHomeRegionalGuideSummaryUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/ObserveHomeRegionalGuideSummaryUseCase.kt
@@ -1,0 +1,108 @@
+package com.team.yeogibeoryeo.domain.regionalguide.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveRegionalGuideFavoriteSnapshotsUseCase
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.regionalguide.model.HomeRegionalGuideSummaryResult
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideLookupResult
+import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+
+class ObserveHomeRegionalGuideSummaryUseCase
+    @Inject
+    constructor(
+        private val observeFavoritesUseCase: ObserveFavoritesUseCase,
+        private val observeRegionalGuideFavoriteSnapshotsUseCase: ObserveRegionalGuideFavoriteSnapshotsUseCase,
+        private val getRegionalDisposalGuideUseCase: GetRegionalDisposalGuideUseCase,
+        private val getTodayRegionalWasteSummaryUseCase: GetTodayRegionalWasteSummaryUseCase,
+    ) {
+        @OptIn(ExperimentalCoroutinesApi::class)
+        operator fun invoke(): Flow<HomeRegionalGuideSummaryResult> =
+            combine(
+                observeFavoritesUseCase(FavoriteTargetType.REGIONAL_GUIDE),
+                observeRegionalGuideFavoriteSnapshotsUseCase(),
+            ) { favorites, snapshots ->
+                favorites.latestRegionalGuideFavorite() to snapshots.associateBy { it.targetId }
+            }
+                .flatMapLatest { (favorite, snapshotsByTargetId) ->
+                    flow {
+                        if (favorite == null) {
+                            emit(HomeRegionalGuideSummaryResult.NoFavorite)
+                            return@flow
+                        }
+
+                        val snapshot = snapshotsByTargetId[favorite.targetId]
+                        if (snapshot == null) {
+                            emit(HomeRegionalGuideSummaryResult.FavoriteRestoreFailed(favorite.targetId))
+                            return@flow
+                        }
+
+                        emit(HomeRegionalGuideSummaryResult.Loading)
+                        emit(loadSummary(snapshot))
+                    }
+                }
+
+        private suspend fun loadSummary(
+            snapshot: RegionalGuideFavoriteSnapshot,
+        ): HomeRegionalGuideSummaryResult {
+            val regionName = snapshot.region.displayName()
+            return when (
+                val result =
+                    getRegionalDisposalGuideUseCase(
+                        region = snapshot.region,
+                        preferredTargetRegionName = snapshot.targetRegionName,
+                        preferredManagementZoneName = snapshot.managementZoneName,
+                    )
+            ) {
+                is RegionalGuideLookupResult.Success -> {
+                    val summary =
+                        getTodayRegionalWasteSummaryUseCase(
+                            targetId = snapshot.targetId,
+                            regionName = regionName,
+                            guide = result.guide,
+                        )
+
+                    if (summary == null) {
+                        HomeRegionalGuideSummaryResult.NoTodaySchedule(
+                            targetId = snapshot.targetId,
+                            regionName = regionName,
+                        )
+                    } else {
+                        HomeRegionalGuideSummaryResult.Success(summary)
+                    }
+                }
+
+                is RegionalGuideLookupResult.Failure ->
+                    HomeRegionalGuideSummaryResult.Failure(
+                        targetId = snapshot.targetId,
+                        regionName = regionName,
+                        reason = result.reason,
+                    )
+
+                is RegionalGuideLookupResult.Candidates,
+                RegionalGuideLookupResult.CandidateNotFound,
+                RegionalGuideLookupResult.NotFound,
+                ->
+                    HomeRegionalGuideSummaryResult.FavoriteRestoreFailed(snapshot.targetId)
+            }
+        }
+
+        private fun List<Favorite>.latestRegionalGuideFavorite(): Favorite? =
+            maxByOrNull { favorite -> favorite.savedAtMillis }
+
+        private fun Region.displayName(): String =
+            listOfNotNull(
+                sido?.trimToNull(),
+                sigungu?.trimToNull(),
+                eupmyeondong?.trimToNull(),
+            ).joinToString(" > ")
+
+        private fun String?.trimToNull(): String? = this?.trim()?.takeIf { it.isNotBlank() }
+    }

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/GetTodayRegionalWasteSummaryUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/GetTodayRegionalWasteSummaryUseCaseTest.kt
@@ -1,0 +1,117 @@
+package com.team.yeogibeoryeo.domain.regionalguide.usecase
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteSchedule
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteType
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GetTodayRegionalWasteSummaryUseCaseTest {
+    private val useCase = GetTodayRegionalWasteSummaryUseCase()
+
+    @Test
+    fun `today schedules are summarized by Asia Seoul date input`() {
+        val guide =
+            sampleGuide(
+                schedules =
+                    listOf(
+                        sampleSchedule(
+                            type = RegionalWasteType.GENERAL,
+                            days = "월, 수, 금",
+                            start = "18:00",
+                        ),
+                        sampleSchedule(
+                            type = RegionalWasteType.RECYCLABLE,
+                            days = "화, 목",
+                            start = "19:00",
+                        ),
+                    ),
+            )
+
+        val summary =
+            useCase(
+                targetId = "target-id",
+                regionName = "서울특별시 > 노원구 > 하계동",
+                guide = guide,
+                today = LocalDate.of(2026, 6, 15),
+            )
+
+        requireNotNull(summary)
+        assertEquals("target-id", summary.targetId)
+        assertEquals(listOf(RegionalWasteType.GENERAL.description), summary.wasteTypeNames)
+        assertEquals("월, 수, 금", summary.disposalDays)
+        assertEquals("18:00 이후", summary.disposalTime)
+    }
+
+    @Test
+    fun `no matching weekday returns null`() {
+        val guide =
+            sampleGuide(
+                schedules =
+                    listOf(
+                        sampleSchedule(
+                            type = RegionalWasteType.GENERAL,
+                            days = "화, 목",
+                        ),
+                    ),
+            )
+
+        val summary =
+            useCase(
+                targetId = "target-id",
+                regionName = "서울특별시 > 노원구 > 하계동",
+                guide = guide,
+                today = LocalDate.of(2026, 6, 15),
+            )
+
+        assertNull(summary)
+    }
+
+    @Test
+    fun `blank days are not inferred as today schedules`() {
+        val guide =
+            sampleGuide(
+                schedules =
+                    listOf(
+                        sampleSchedule(
+                            type = RegionalWasteType.GENERAL,
+                            days = null,
+                        ),
+                    ),
+            )
+
+        val summary =
+            useCase(
+                targetId = "target-id",
+                regionName = "서울특별시 > 노원구 > 하계동",
+                guide = guide,
+                today = LocalDate.of(2026, 6, 15),
+            )
+
+        assertNull(summary)
+    }
+
+    private fun sampleGuide(
+        schedules: List<RegionalWasteSchedule>,
+    ): RegionalDisposalGuide =
+        RegionalDisposalGuide(
+            region = Region(sido = "서울특별시", sigungu = "노원구", eupmyeondong = "하계동"),
+            schedules = schedules,
+        )
+
+    private fun sampleSchedule(
+        type: RegionalWasteType,
+        days: String?,
+        start: String? = null,
+        end: String? = null,
+    ): RegionalWasteSchedule =
+        RegionalWasteSchedule(
+            wasteType = type,
+            disposalDays = days,
+            disposalStartTime = start,
+            disposalEndTime = end,
+        )
+}

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/GetTodayRegionalWasteSummaryUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/GetTodayRegionalWasteSummaryUseCaseTest.kt
@@ -4,9 +4,9 @@ import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteSchedule
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteType
+import com.team.yeogibeoryeo.domain.regionalguide.model.TodayRegionalWasteSummaryResult
 import java.time.LocalDate
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 
 class GetTodayRegionalWasteSummaryUseCaseTest {
@@ -39,11 +39,13 @@ class GetTodayRegionalWasteSummaryUseCaseTest {
                 today = LocalDate.of(2026, 6, 15),
             )
 
-        requireNotNull(summary)
-        assertEquals("target-id", summary.targetId)
-        assertEquals(listOf(RegionalWasteType.GENERAL.description), summary.wasteTypeNames)
-        assertEquals("월, 수, 금", summary.disposalDays)
-        assertEquals("18:00 이후", summary.disposalTime)
+        require(summary is TodayRegionalWasteSummaryResult.Summary)
+        summary.summary.run {
+            assertEquals("target-id", targetId)
+            assertEquals(listOf(RegionalWasteType.GENERAL.description), wasteTypeNames)
+            assertEquals("월, 수, 금", disposalDays)
+            assertEquals("18:00 이후", disposalTime)
+        }
     }
 
     @Test
@@ -67,7 +69,7 @@ class GetTodayRegionalWasteSummaryUseCaseTest {
                 today = LocalDate.of(2026, 6, 15),
             )
 
-        assertNull(summary)
+        assertEquals(TodayRegionalWasteSummaryResult.NoTodaySchedule, summary)
     }
 
     @Test
@@ -91,7 +93,32 @@ class GetTodayRegionalWasteSummaryUseCaseTest {
                 today = LocalDate.of(2026, 6, 15),
             )
 
-        assertNull(summary)
+        assertEquals(TodayRegionalWasteSummaryResult.NoTodaySchedule, summary)
+    }
+
+    @Test
+    fun `unknown weekday returns needs confirmation`() {
+        val guide =
+            sampleGuide(
+                schedules =
+                    listOf(
+                        sampleSchedule(
+                            type = RegionalWasteType.GENERAL,
+                            days = "기타",
+                            start = "18:00",
+                        ),
+                    ),
+            )
+
+        val summary =
+            useCase(
+                targetId = "target-id",
+                regionName = "서울특별시 > 노원구 > 하계동",
+                guide = guide,
+                today = LocalDate.of(2026, 6, 15),
+            )
+
+        assertEquals(TodayRegionalWasteSummaryResult.NeedsScheduleConfirmation, summary)
     }
 
     private fun sampleGuide(

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/ObserveHomeRegionalGuideSummaryUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/ObserveHomeRegionalGuideSummaryUseCaseTest.kt
@@ -1,0 +1,426 @@
+package com.team.yeogibeoryeo.domain.regionalguide.usecase
+
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteSnapshotRepository
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveRegionalGuideFavoriteSnapshotsUseCase
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.regionalguide.model.HomeRegionalGuideSummaryResult
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideLookupException
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideFailureReason
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideLookupResult
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideQuery
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteSchedule
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteType
+import com.team.yeogibeoryeo.domain.regionalguide.repository.RegionalDisposalGuideRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ObserveHomeRegionalGuideSummaryUseCaseTest {
+    @Test
+    fun `no regional guide favorite returns no favorite`() =
+        runBlocking {
+            val favoriteRepository =
+                FakeFavoriteRepository(
+                    initialFavorites =
+                        listOf(
+                            Favorite(
+                                type = FavoriteTargetType.ITEM_GUIDE,
+                                targetId = "item-guide",
+                                savedAtMillis = 1L,
+                            ),
+                        ),
+                )
+            val useCase = createUseCase(favoriteRepository = favoriteRepository)
+
+            assertEquals(HomeRegionalGuideSummaryResult.NoFavorite, useCase().first())
+        }
+
+    @Test
+    fun `latest regional guide favorite is selected`() =
+        runBlocking {
+            val oldSnapshot = sampleSnapshot(targetId = "old", sigungu = "중구")
+            val latestSnapshot = sampleSnapshot(targetId = "latest", sigungu = "노원구")
+            val favoriteRepository =
+                FakeFavoriteRepository(
+                    initialFavorites =
+                        listOf(
+                            Favorite(
+                                type = FavoriteTargetType.REGIONAL_GUIDE,
+                                targetId = oldSnapshot.targetId,
+                                savedAtMillis = 1L,
+                            ),
+                            Favorite(
+                                type = FavoriteTargetType.REGIONAL_GUIDE,
+                                targetId = latestSnapshot.targetId,
+                                savedAtMillis = 2L,
+                            ),
+                        ),
+                )
+            val snapshotRepository =
+                FakeRegionalGuideFavoriteSnapshotRepository(
+                    initialSnapshots = listOf(oldSnapshot, latestSnapshot),
+                )
+            val regionalRepository =
+                FakeRegionalDisposalGuideRepository(
+                    candidates =
+                        listOf(
+                            sampleGuide(region = latestSnapshot.region),
+                        ),
+                )
+            val useCase =
+                createUseCase(
+                    favoriteRepository = favoriteRepository,
+                    snapshotRepository = snapshotRepository,
+                    regionalRepository = regionalRepository,
+                )
+
+            val result = useCase().drop(1).first()
+
+            assertTrue(result is HomeRegionalGuideSummaryResult.Success)
+            assertEquals("latest", (result as HomeRegionalGuideSummaryResult.Success).summary.targetId)
+            assertEquals(listOf("노원구"), regionalRepository.requestedSigungu)
+        }
+
+    @Test
+    fun `missing snapshot returns favorite restore failed`() =
+        runBlocking {
+            val favoriteRepository =
+                FakeFavoriteRepository(
+                    initialFavorites =
+                        listOf(
+                            Favorite(
+                                type = FavoriteTargetType.REGIONAL_GUIDE,
+                                targetId = "missing",
+                                savedAtMillis = 1L,
+                            ),
+                        ),
+                )
+            val useCase = createUseCase(favoriteRepository = favoriteRepository)
+
+            val result = useCase().first()
+
+            assertEquals(HomeRegionalGuideSummaryResult.FavoriteRestoreFailed("missing"), result)
+        }
+
+    @Test
+    fun `multiple restored candidates are not selected arbitrarily`() =
+        runBlocking {
+            val snapshot = sampleSnapshot(targetId = "regional")
+            val favoriteRepository =
+                FakeFavoriteRepository(
+                    initialFavorites =
+                        listOf(
+                            Favorite(
+                                type = FavoriteTargetType.REGIONAL_GUIDE,
+                                targetId = snapshot.targetId,
+                                savedAtMillis = 1L,
+                            ),
+                        ),
+                )
+            val useCase =
+                createUseCase(
+                    favoriteRepository = favoriteRepository,
+                    snapshotRepository = FakeRegionalGuideFavoriteSnapshotRepository(listOf(snapshot)),
+                    regionalRepository =
+                        FakeRegionalDisposalGuideRepository(
+                            candidates =
+                                listOf(
+                                    sampleGuide(region = snapshot.region, managementZoneName = "노은2동"),
+                                    sampleGuide(region = snapshot.region, managementZoneName = "노은3동"),
+                                ),
+                        ),
+                )
+
+            val result = useCase().drop(1).first()
+
+            assertEquals(HomeRegionalGuideSummaryResult.FavoriteRestoreFailed("regional"), result)
+        }
+
+    @Test
+    fun `no today schedule returns no today schedule`() =
+        runBlocking {
+            val snapshot = sampleSnapshot(targetId = "regional")
+            val favoriteRepository =
+                FakeFavoriteRepository(
+                    initialFavorites =
+                        listOf(
+                            Favorite(
+                                type = FavoriteTargetType.REGIONAL_GUIDE,
+                                targetId = snapshot.targetId,
+                                savedAtMillis = 1L,
+                            ),
+                        ),
+                )
+            val useCase =
+                createUseCase(
+                    favoriteRepository = favoriteRepository,
+                    snapshotRepository = FakeRegionalGuideFavoriteSnapshotRepository(listOf(snapshot)),
+                    regionalRepository =
+                        FakeRegionalDisposalGuideRepository(
+                            candidates =
+                                listOf(
+                                    sampleGuide(
+                                        region = snapshot.region,
+                                        schedules =
+                                            listOf(
+                                                sampleSchedule(
+                                                    type = RegionalWasteType.GENERAL,
+                                                    days = "미지정",
+                                                ),
+                                            ),
+                                    ),
+                                ),
+                        ),
+                )
+
+            val result = useCase().drop(1).first()
+
+            assertEquals(
+                HomeRegionalGuideSummaryResult.NoTodaySchedule(
+                    targetId = "regional",
+                    regionName = "서울특별시 > 노원구 > 하계동",
+                ),
+                result,
+            )
+        }
+
+    @Test
+    fun `repository failure returns failure state`() =
+        runBlocking {
+            val snapshot = sampleSnapshot(targetId = "regional")
+            val favoriteRepository =
+                FakeFavoriteRepository(
+                    initialFavorites =
+                        listOf(
+                            Favorite(
+                                type = FavoriteTargetType.REGIONAL_GUIDE,
+                                targetId = snapshot.targetId,
+                                savedAtMillis = 1L,
+                            ),
+                        ),
+                )
+            val useCase =
+                createUseCase(
+                    favoriteRepository = favoriteRepository,
+                    snapshotRepository = FakeRegionalGuideFavoriteSnapshotRepository(listOf(snapshot)),
+                    regionalRepository =
+                        FakeRegionalDisposalGuideRepository(
+                            result =
+                                Result.failure(
+                                    RegionalGuideLookupException(
+                                        reason = RegionalGuideFailureReason.NETWORK,
+                                    ),
+                                ),
+                        ),
+                )
+
+            val result = useCase().drop(1).first()
+
+            assertEquals(
+                HomeRegionalGuideSummaryResult.Failure(
+                    targetId = "regional",
+                    regionName = "서울특별시 > 노원구 > 하계동",
+                    reason = RegionalGuideFailureReason.NETWORK,
+                ),
+                result,
+            )
+        }
+
+    @Test
+    fun `favorite changes refresh summary`() =
+        runBlocking {
+            val firstSnapshot = sampleSnapshot(targetId = "first", sigungu = "중구")
+            val secondSnapshot = sampleSnapshot(targetId = "second", sigungu = "노원구")
+            val favoriteRepository = FakeFavoriteRepository()
+            val snapshotRepository =
+                FakeRegionalGuideFavoriteSnapshotRepository(
+                    initialSnapshots = listOf(firstSnapshot, secondSnapshot),
+                )
+            val useCase =
+                createUseCase(
+                    favoriteRepository = favoriteRepository,
+                    snapshotRepository = snapshotRepository,
+                    regionalRepository =
+                        FakeRegionalDisposalGuideRepository(
+                            candidates =
+                                listOf(
+                                    sampleGuide(region = firstSnapshot.region),
+                                    sampleGuide(region = secondSnapshot.region),
+                                ),
+                        ),
+                )
+
+            favoriteRepository.addFavorite(
+                Favorite(
+                    type = FavoriteTargetType.REGIONAL_GUIDE,
+                    targetId = firstSnapshot.targetId,
+                    savedAtMillis = 1L,
+                ),
+            )
+            val firstResult = useCase().drop(1).first() as HomeRegionalGuideSummaryResult.Success
+
+            favoriteRepository.addFavorite(
+                Favorite(
+                    type = FavoriteTargetType.REGIONAL_GUIDE,
+                    targetId = secondSnapshot.targetId,
+                    savedAtMillis = 2L,
+                ),
+            )
+            val secondResult = useCase().drop(1).first() as HomeRegionalGuideSummaryResult.Success
+
+            assertEquals("first", firstResult.summary.targetId)
+            assertEquals("second", secondResult.summary.targetId)
+        }
+
+    private fun createUseCase(
+        favoriteRepository: FakeFavoriteRepository = FakeFavoriteRepository(),
+        snapshotRepository: FakeRegionalGuideFavoriteSnapshotRepository =
+            FakeRegionalGuideFavoriteSnapshotRepository(),
+        regionalRepository: FakeRegionalDisposalGuideRepository = FakeRegionalDisposalGuideRepository(),
+    ): ObserveHomeRegionalGuideSummaryUseCase =
+        ObserveHomeRegionalGuideSummaryUseCase(
+            observeFavoritesUseCase = ObserveFavoritesUseCase(favoriteRepository),
+            observeRegionalGuideFavoriteSnapshotsUseCase =
+                ObserveRegionalGuideFavoriteSnapshotsUseCase(snapshotRepository),
+            getRegionalDisposalGuideUseCase =
+                GetRegionalDisposalGuideUseCase(
+                    repository = regionalRepository,
+                    normalizeRegionalGuideQueryUseCase = NormalizeRegionalGuideQueryUseCase(),
+                    selectRegionalGuideCandidateUseCase = SelectRegionalGuideCandidateUseCase(),
+                ),
+            getTodayRegionalWasteSummaryUseCase = GetTodayRegionalWasteSummaryUseCase(),
+        )
+
+    private fun sampleSnapshot(
+        targetId: String,
+        sigungu: String = "노원구",
+    ): RegionalGuideFavoriteSnapshot =
+        RegionalGuideFavoriteSnapshot(
+            targetId = targetId,
+            region = Region(sido = "서울특별시", sigungu = sigungu, eupmyeondong = "하계동"),
+            targetRegionName = null,
+            managementZoneName = null,
+        )
+
+    private fun sampleGuide(
+        region: Region = Region(sido = "서울특별시", sigungu = "노원구", eupmyeondong = "하계동"),
+        managementZoneName: String? = null,
+        targetRegionName: String? = region.eupmyeondong,
+        schedules: List<RegionalWasteSchedule> =
+            listOf(
+                sampleSchedule(
+                    type = RegionalWasteType.GENERAL,
+                    days = "월, 화, 수, 목, 금, 토, 일",
+                    start = "18:00",
+                ),
+            ),
+    ): RegionalDisposalGuide =
+        RegionalDisposalGuide(
+            region = region,
+            managementZoneName = managementZoneName,
+            targetRegionName = targetRegionName,
+            schedules = schedules,
+        )
+
+    private fun sampleSchedule(
+        type: RegionalWasteType,
+        days: String?,
+        start: String? = null,
+    ): RegionalWasteSchedule =
+        RegionalWasteSchedule(
+            wasteType = type,
+            disposalDays = days,
+            disposalStartTime = start,
+        )
+
+    private class FakeFavoriteRepository(
+        initialFavorites: List<Favorite> = emptyList(),
+    ) : FavoriteRepository {
+        private val favorites = MutableStateFlow(initialFavorites)
+
+        override fun observeFavorites(): Flow<List<Favorite>> = favorites
+
+        override fun observeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Flow<Boolean> =
+            favorites.map { items ->
+                items.any { it.type == type && it.targetId == targetId }
+            }
+
+        override suspend fun isFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Boolean =
+            favorites.value.any { it.type == type && it.targetId == targetId }
+
+        override suspend fun toggleFavorite(favorite: Favorite): Boolean {
+            return if (isFavorite(favorite.type, favorite.targetId)) {
+                removeFavorite(favorite.type, favorite.targetId)
+                false
+            } else {
+                addFavorite(favorite)
+                true
+            }
+        }
+
+        override suspend fun addFavorite(favorite: Favorite) {
+            favorites.value =
+                favorites.value
+                    .filterNot { it.type == favorite.type && it.targetId == favorite.targetId } + favorite
+        }
+
+        override suspend fun removeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ) {
+            favorites.value =
+                favorites.value.filterNot { it.type == type && it.targetId == targetId }
+        }
+    }
+
+    private class FakeRegionalGuideFavoriteSnapshotRepository(
+        initialSnapshots: List<RegionalGuideFavoriteSnapshot> = emptyList(),
+    ) : RegionalGuideFavoriteSnapshotRepository {
+        private val snapshots = MutableStateFlow(initialSnapshots)
+
+        override fun observeSnapshots(): Flow<List<RegionalGuideFavoriteSnapshot>> = snapshots
+
+        override suspend fun getSnapshot(targetId: String): RegionalGuideFavoriteSnapshot? =
+            snapshots.value.firstOrNull { it.targetId == targetId }
+
+        override suspend fun upsertSnapshot(snapshot: RegionalGuideFavoriteSnapshot) {
+            snapshots.value = snapshots.value.filterNot { it.targetId == snapshot.targetId } + snapshot
+        }
+
+        override suspend fun deleteSnapshot(targetId: String) {
+            snapshots.value = snapshots.value.filterNot { it.targetId == targetId }
+        }
+    }
+
+    private class FakeRegionalDisposalGuideRepository(
+        private val candidates: List<RegionalDisposalGuide> = emptyList(),
+        private val result: Result<List<RegionalDisposalGuide>>? = null,
+    ) : RegionalDisposalGuideRepository {
+        val requestedSigungu = mutableListOf<String?>()
+
+        override suspend fun getRegionalDisposalGuideCandidates(
+            query: RegionalGuideQuery,
+        ): Result<List<RegionalDisposalGuide>> {
+            requestedSigungu += query.sigunguQuery
+            return result ?: Result.success(candidates.filter { it.region.sigungu == query.sigunguQuery })
+        }
+    }
+}

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/ObserveHomeRegionalGuideSummaryUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/ObserveHomeRegionalGuideSummaryUseCaseTest.kt
@@ -177,7 +177,7 @@ class ObserveHomeRegionalGuideSummaryUseCaseTest {
                                             listOf(
                                                 sampleSchedule(
                                                     type = RegionalWasteType.GENERAL,
-                                                    days = "미지정",
+                                                    days = "해당없음",
                                                 ),
                                             ),
                                     ),
@@ -189,6 +189,54 @@ class ObserveHomeRegionalGuideSummaryUseCaseTest {
 
             assertEquals(
                 HomeRegionalGuideSummaryResult.NoTodaySchedule(
+                    targetId = "regional",
+                    regionName = "서울특별시 > 노원구 > 하계동",
+                ),
+                result,
+            )
+        }
+
+    @Test
+    fun `unknown weekday returns schedule needs confirmation`() =
+        runBlocking {
+            val snapshot = sampleSnapshot(targetId = "regional")
+            val favoriteRepository =
+                FakeFavoriteRepository(
+                    initialFavorites =
+                        listOf(
+                            Favorite(
+                                type = FavoriteTargetType.REGIONAL_GUIDE,
+                                targetId = snapshot.targetId,
+                                savedAtMillis = 1L,
+                            ),
+                        ),
+                )
+            val useCase =
+                createUseCase(
+                    favoriteRepository = favoriteRepository,
+                    snapshotRepository = FakeRegionalGuideFavoriteSnapshotRepository(listOf(snapshot)),
+                    regionalRepository =
+                        FakeRegionalDisposalGuideRepository(
+                            candidates =
+                                listOf(
+                                    sampleGuide(
+                                        region = snapshot.region,
+                                        schedules =
+                                            listOf(
+                                                sampleSchedule(
+                                                    type = RegionalWasteType.GENERAL,
+                                                    days = "기타",
+                                                ),
+                                            ),
+                                    ),
+                                ),
+                        ),
+                )
+
+            val result = useCase().drop(1).first()
+
+            assertEquals(
+                HomeRegionalGuideSummaryResult.ScheduleNeedsConfirmation(
                     targetId = "regional",
                     regionName = "서울특별시 > 노원구 > 하계동",
                 ),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/HomeRegionalGuideSummaryViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/HomeRegionalGuideSummaryViewModel.kt
@@ -1,0 +1,45 @@
+package com.team.yeogibeoryeo.presentation.search
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.team.yeogibeoryeo.domain.regionalguide.usecase.ObserveHomeRegionalGuideSummaryUseCase
+import com.team.yeogibeoryeo.presentation.search.mapper.toUiState
+import com.team.yeogibeoryeo.presentation.search.model.HomeRegionalGuideSummaryUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeRegionalGuideSummaryViewModel
+    @Inject
+    constructor(
+        private val observeHomeRegionalGuideSummaryUseCase: ObserveHomeRegionalGuideSummaryUseCase,
+    ) : ViewModel() {
+        private val retryRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+        val uiState =
+            retryRequests
+                .onStart { emit(Unit) }
+                .flatMapLatest { observeHomeRegionalGuideSummaryUseCase() }
+                .map { result -> result.toUiState() }
+                .stateIn(
+                    scope = viewModelScope,
+                    started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
+                    initialValue = HomeRegionalGuideSummaryUiState.Loading,
+                )
+
+        fun retry() {
+            retryRequests.tryEmit(Unit)
+        }
+
+        private companion object {
+            const val STOP_TIMEOUT_MILLIS = 5_000L
+        }
+    }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
@@ -19,7 +19,9 @@ import androidx.compose.ui.text.font.FontWeight
 import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchBar
+import com.team.yeogibeoryeo.presentation.search.components.HomeRegionalGuideSummaryBanner
 import com.team.yeogibeoryeo.presentation.search.components.QuickCategoryGrid
+import com.team.yeogibeoryeo.presentation.search.model.HomeRegionalGuideSummaryUiState
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
 
 @Composable
@@ -27,6 +29,9 @@ fun ItemSearchInitialContent(
     query: String,
     onQueryChange: (String) -> Unit,
     onSearchClick: () -> Unit,
+    regionalGuideSummaryState: HomeRegionalGuideSummaryUiState,
+    onRegionalGuideSummaryClick: (String) -> Unit = {},
+    onRegionalGuideSummaryRetryClick: () -> Unit = {},
     onQuickCategoryClick: (RepresentativeGuideCategory) -> Unit,
     listState: LazyListState,
     modifier: Modifier = Modifier,
@@ -61,6 +66,14 @@ fun ItemSearchInitialContent(
                     placeholder = stringResource(R.string.item_search_query_label),
                     modifier = Modifier.fillMaxWidth(),
                     iconSize = metrics.searchIconSize,
+                )
+            }
+
+            item {
+                HomeRegionalGuideSummaryBanner(
+                    state = regionalGuideSummaryState,
+                    onClick = onRegionalGuideSummaryClick,
+                    onRetryClick = onRegionalGuideSummaryRetryClick,
                 )
             }
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -34,15 +34,20 @@ import com.team.yeogibeoryeo.presentation.search.components.DisposalItemCard
 import com.team.yeogibeoryeo.presentation.search.components.EmptySearchResult
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchBar
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchLoadingContent
+import com.team.yeogibeoryeo.presentation.search.model.HomeRegionalGuideSummaryUiState
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
 
 @Composable
 fun ItemSearchRoute(
     initialQuery: String? = null,
     onGuideSelected: (DisposalItemGuide) -> Unit,
+    onRegionalGuideSummaryClick: (String) -> Unit,
     viewModel: ItemSearchViewModel = hiltViewModel(),
+    regionalGuideSummaryViewModel: HomeRegionalGuideSummaryViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val regionalGuideSummaryState by
+        regionalGuideSummaryViewModel.uiState.collectAsStateWithLifecycle()
     val currentOnGuideSelected by rememberUpdatedState(onGuideSelected)
 
     val searchResultListState = rememberLazyListState()
@@ -80,9 +85,12 @@ fun ItemSearchRoute(
 
     ItemSearchScreen(
         uiState = uiState,
+        regionalGuideSummaryState = regionalGuideSummaryState,
         onQueryChange = viewModel::onQueryChange,
         onSearchClick = viewModel::search,
         onGuideClick = onGuideSelected,
+        onRegionalGuideSummaryClick = onRegionalGuideSummaryClick,
+        onRegionalGuideSummaryRetryClick = regionalGuideSummaryViewModel::retry,
         onQuickCategoryClick = viewModel::openCategoryGuide,
         searchResultListState = searchResultListState,
         categoryListState = categoryListState,
@@ -92,9 +100,12 @@ fun ItemSearchRoute(
 @Composable
 fun ItemSearchScreen(
     uiState: ItemSearchUiState,
+    regionalGuideSummaryState: HomeRegionalGuideSummaryUiState = HomeRegionalGuideSummaryUiState.NoFavorite,
     onQueryChange: (String) -> Unit,
     onSearchClick: () -> Unit,
     onGuideClick: (DisposalItemGuide) -> Unit,
+    onRegionalGuideSummaryClick: (String) -> Unit = {},
+    onRegionalGuideSummaryRetryClick: () -> Unit = {},
     onQuickCategoryClick: (RepresentativeGuideCategory) -> Unit,
     modifier: Modifier = Modifier,
     searchResultListState: LazyListState = rememberLazyListState(),
@@ -105,6 +116,9 @@ fun ItemSearchScreen(
             query = uiState.query,
             onQueryChange = onQueryChange,
             onSearchClick = onSearchClick,
+            regionalGuideSummaryState = regionalGuideSummaryState,
+            onRegionalGuideSummaryClick = onRegionalGuideSummaryClick,
+            onRegionalGuideSummaryRetryClick = onRegionalGuideSummaryRetryClick,
             onQuickCategoryClick = onQuickCategoryClick,
             listState = categoryListState,
             modifier = modifier,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/HomeRegionalGuideSummaryBanner.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/HomeRegionalGuideSummaryBanner.kt
@@ -1,23 +1,31 @@
 package com.team.yeogibeoryeo.presentation.search.components
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.presentation.search.model.HomeRegionalGuideSummaryUiState
+import com.team.yeogibeoryeo.common.R as CommonR
 
 @Composable
 fun HomeRegionalGuideSummaryBanner(
@@ -33,8 +41,18 @@ fun HomeRegionalGuideSummaryBanner(
                 .fillMaxWidth()
                 .then(
                     when {
-                        content.retryable -> Modifier.clickable { onRetryClick() }
-                        content.targetId != null -> Modifier.clickable { onClick(content.targetId) }
+                        content.retryable ->
+                            Modifier.clickable(
+                                onClickLabel = content.actionLabel,
+                                role = Role.Button,
+                                onClick = onRetryClick,
+                            )
+                        content.targetId != null ->
+                            Modifier.clickable(
+                                onClickLabel = content.actionLabel,
+                                role = Role.Button,
+                                onClick = { onClick(content.targetId) },
+                            )
                         else -> Modifier
                     },
                 ),
@@ -44,36 +62,70 @@ fun HomeRegionalGuideSummaryBanner(
             ),
         shape = RoundedCornerShape(8.dp),
     ) {
-        Column(
+        Row(
             modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(
-                text = content.title,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            Text(
-                text = content.description,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-            )
-            if (content.detail != null) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
+            Box(
+                modifier =
+                    Modifier
+                        .size(56.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.surface,
+                            shape = CircleShape,
+                        ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    painter = painterResource(id = CommonR.drawable.ic_symbol_info),
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Text(
+                    text = content.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = content.description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (content.detail != null) {
                     Text(
                         text = content.detail,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+
+            if (content.showChevron) {
+                Row(
+                    modifier = Modifier.size(32.dp),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        painter = painterResource(id = CommonR.drawable.ic_action_chevron_right),
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
                     )
                 }
             }
@@ -87,6 +139,8 @@ private data class HomeRegionalGuideBannerContent(
     val detail: String? = null,
     val targetId: String? = null,
     val retryable: Boolean = false,
+    val actionLabel: String? = null,
+    val showChevron: Boolean = false,
 )
 
 private fun HomeRegionalGuideSummaryUiState.toBannerContent(): HomeRegionalGuideBannerContent =
@@ -113,6 +167,8 @@ private fun HomeRegionalGuideSummaryUiState.toBannerContent(): HomeRegionalGuide
                         disposalTime?.let { add("시간 $it") }
                     }.joinToString(" · "),
                 targetId = targetId,
+                actionLabel = "지역 가이드 상세 보기",
+                showChevron = true,
             )
 
         is HomeRegionalGuideSummaryUiState.NoTodaySchedule ->
@@ -121,13 +177,24 @@ private fun HomeRegionalGuideSummaryUiState.toBannerContent(): HomeRegionalGuide
                 description = "오늘 배출 가능한 일정이 없어요.",
                 detail = "상세 배출 기준을 확인하려면 눌러 보세요.",
                 targetId = targetId,
+                actionLabel = "지역 가이드 상세 보기",
+                showChevron = true,
+            )
+
+        is HomeRegionalGuideSummaryUiState.ScheduleNeedsConfirmation ->
+            HomeRegionalGuideBannerContent(
+                title = regionName,
+                description = "배출 요일 정보 확인이 필요해요.",
+                detail = "상세 안내에서 배출 기준을 확인해 주세요.",
+                targetId = targetId,
+                actionLabel = "지역 가이드 상세 보기",
+                showChevron = true,
             )
 
         is HomeRegionalGuideSummaryUiState.FavoriteRestoreFailed ->
             HomeRegionalGuideBannerContent(
                 title = "지역별 배출 가이드",
                 description = "저장된 지역 정보를 다시 확인해 주세요.",
-                targetId = targetId,
             )
 
         is HomeRegionalGuideSummaryUiState.LoadFailed ->
@@ -137,5 +204,6 @@ private fun HomeRegionalGuideSummaryUiState.toBannerContent(): HomeRegionalGuide
                 detail = "눌러서 다시 시도해 주세요.",
                 targetId = targetId,
                 retryable = true,
+                actionLabel = "배출 정보 다시 불러오기",
             )
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/HomeRegionalGuideSummaryBanner.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/HomeRegionalGuideSummaryBanner.kt
@@ -1,0 +1,141 @@
+package com.team.yeogibeoryeo.presentation.search.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.presentation.search.model.HomeRegionalGuideSummaryUiState
+
+@Composable
+fun HomeRegionalGuideSummaryBanner(
+    state: HomeRegionalGuideSummaryUiState,
+    onClick: (String) -> Unit,
+    onRetryClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val content = state.toBannerContent()
+    Card(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .then(
+                    when {
+                        content.retryable -> Modifier.clickable { onRetryClick() }
+                        content.targetId != null -> Modifier.clickable { onClick(content.targetId) }
+                        else -> Modifier
+                    },
+                ),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+            ),
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = content.title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = content.description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (content.detail != null) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = content.detail,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private data class HomeRegionalGuideBannerContent(
+    val title: String,
+    val description: String,
+    val detail: String? = null,
+    val targetId: String? = null,
+    val retryable: Boolean = false,
+)
+
+private fun HomeRegionalGuideSummaryUiState.toBannerContent(): HomeRegionalGuideBannerContent =
+    when (this) {
+        HomeRegionalGuideSummaryUiState.Loading ->
+            HomeRegionalGuideBannerContent(
+                title = "지역별 배출 가이드",
+                description = "즐겨찾기한 지역의 오늘 배출 정보를 불러오는 중입니다.",
+            )
+
+        HomeRegionalGuideSummaryUiState.NoFavorite ->
+            HomeRegionalGuideBannerContent(
+                title = "지역별 배출 가이드",
+                description = "지역 가이드를 즐겨찾기하면 오늘 배출 정보를 여기에서 확인할 수 있어요.",
+            )
+
+        is HomeRegionalGuideSummaryUiState.Summary ->
+            HomeRegionalGuideBannerContent(
+                title = regionName,
+                description = "오늘 배출: $wasteTypesText",
+                detail =
+                    buildList {
+                        add("요일 $disposalDays")
+                        disposalTime?.let { add("시간 $it") }
+                    }.joinToString(" · "),
+                targetId = targetId,
+            )
+
+        is HomeRegionalGuideSummaryUiState.NoTodaySchedule ->
+            HomeRegionalGuideBannerContent(
+                title = regionName,
+                description = "오늘 배출 가능한 일정이 없어요.",
+                detail = "상세 배출 기준을 확인하려면 눌러 보세요.",
+                targetId = targetId,
+            )
+
+        is HomeRegionalGuideSummaryUiState.FavoriteRestoreFailed ->
+            HomeRegionalGuideBannerContent(
+                title = "지역별 배출 가이드",
+                description = "저장된 지역 정보를 다시 확인해 주세요.",
+                targetId = targetId,
+            )
+
+        is HomeRegionalGuideSummaryUiState.LoadFailed ->
+            HomeRegionalGuideBannerContent(
+                title = regionName,
+                description = "최신 배출 정보를 불러오지 못했어요.",
+                detail = "눌러서 다시 시도해 주세요.",
+                targetId = targetId,
+                retryable = true,
+            )
+    }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/mapper/HomeRegionalGuideSummaryUiMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/mapper/HomeRegionalGuideSummaryUiMapper.kt
@@ -1,0 +1,33 @@
+package com.team.yeogibeoryeo.presentation.search.mapper
+
+import com.team.yeogibeoryeo.domain.regionalguide.model.HomeRegionalGuideSummaryResult
+import com.team.yeogibeoryeo.presentation.search.model.HomeRegionalGuideSummaryUiState
+
+fun HomeRegionalGuideSummaryResult.toUiState(): HomeRegionalGuideSummaryUiState =
+    when (this) {
+        HomeRegionalGuideSummaryResult.Loading -> HomeRegionalGuideSummaryUiState.Loading
+        HomeRegionalGuideSummaryResult.NoFavorite -> HomeRegionalGuideSummaryUiState.NoFavorite
+        is HomeRegionalGuideSummaryResult.Success ->
+            HomeRegionalGuideSummaryUiState.Summary(
+                targetId = summary.targetId,
+                regionName = summary.regionName,
+                wasteTypesText = summary.wasteTypeNames.joinToString(", "),
+                disposalDays = summary.disposalDays,
+                disposalTime = summary.disposalTime,
+            )
+
+        is HomeRegionalGuideSummaryResult.NoTodaySchedule ->
+            HomeRegionalGuideSummaryUiState.NoTodaySchedule(
+                targetId = targetId,
+                regionName = regionName,
+            )
+
+        is HomeRegionalGuideSummaryResult.FavoriteRestoreFailed ->
+            HomeRegionalGuideSummaryUiState.FavoriteRestoreFailed(targetId = targetId)
+
+        is HomeRegionalGuideSummaryResult.Failure ->
+            HomeRegionalGuideSummaryUiState.LoadFailed(
+                targetId = targetId,
+                regionName = regionName,
+            )
+    }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/mapper/HomeRegionalGuideSummaryUiMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/mapper/HomeRegionalGuideSummaryUiMapper.kt
@@ -22,6 +22,12 @@ fun HomeRegionalGuideSummaryResult.toUiState(): HomeRegionalGuideSummaryUiState 
                 regionName = regionName,
             )
 
+        is HomeRegionalGuideSummaryResult.ScheduleNeedsConfirmation ->
+            HomeRegionalGuideSummaryUiState.ScheduleNeedsConfirmation(
+                targetId = targetId,
+                regionName = regionName,
+            )
+
         is HomeRegionalGuideSummaryResult.FavoriteRestoreFailed ->
             HomeRegionalGuideSummaryUiState.FavoriteRestoreFailed(targetId = targetId)
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/model/HomeRegionalGuideSummaryUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/model/HomeRegionalGuideSummaryUiState.kt
@@ -18,6 +18,11 @@ sealed interface HomeRegionalGuideSummaryUiState {
         val regionName: String,
     ) : HomeRegionalGuideSummaryUiState
 
+    data class ScheduleNeedsConfirmation(
+        val targetId: String,
+        val regionName: String,
+    ) : HomeRegionalGuideSummaryUiState
+
     data class FavoriteRestoreFailed(
         val targetId: String,
     ) : HomeRegionalGuideSummaryUiState

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/model/HomeRegionalGuideSummaryUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/model/HomeRegionalGuideSummaryUiState.kt
@@ -1,0 +1,29 @@
+package com.team.yeogibeoryeo.presentation.search.model
+
+sealed interface HomeRegionalGuideSummaryUiState {
+    data object Loading : HomeRegionalGuideSummaryUiState
+
+    data object NoFavorite : HomeRegionalGuideSummaryUiState
+
+    data class Summary(
+        val targetId: String,
+        val regionName: String,
+        val wasteTypesText: String,
+        val disposalDays: String,
+        val disposalTime: String?,
+    ) : HomeRegionalGuideSummaryUiState
+
+    data class NoTodaySchedule(
+        val targetId: String,
+        val regionName: String,
+    ) : HomeRegionalGuideSummaryUiState
+
+    data class FavoriteRestoreFailed(
+        val targetId: String,
+    ) : HomeRegionalGuideSummaryUiState
+
+    data class LoadFailed(
+        val targetId: String,
+        val regionName: String,
+    ) : HomeRegionalGuideSummaryUiState
+}

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/HomeRegionalGuideSummaryViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/HomeRegionalGuideSummaryViewModelTest.kt
@@ -1,0 +1,264 @@
+package com.team.yeogibeoryeo.presentation.search
+
+import com.team.yeogibeoryeo.domain.favorite.model.Favorite
+import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
+import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
+import com.team.yeogibeoryeo.domain.favorite.repository.RegionalGuideFavoriteSnapshotRepository
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
+import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveRegionalGuideFavoriteSnapshotsUseCase
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideQuery
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteSchedule
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteType
+import com.team.yeogibeoryeo.domain.regionalguide.repository.RegionalDisposalGuideRepository
+import com.team.yeogibeoryeo.domain.regionalguide.usecase.GetRegionalDisposalGuideUseCase
+import com.team.yeogibeoryeo.domain.regionalguide.usecase.GetTodayRegionalWasteSummaryUseCase
+import com.team.yeogibeoryeo.domain.regionalguide.usecase.NormalizeRegionalGuideQueryUseCase
+import com.team.yeogibeoryeo.domain.regionalguide.usecase.ObserveHomeRegionalGuideSummaryUseCase
+import com.team.yeogibeoryeo.domain.regionalguide.usecase.SelectRegionalGuideCandidateUseCase
+import com.team.yeogibeoryeo.presentation.search.model.HomeRegionalGuideSummaryUiState
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeRegionalGuideSummaryViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `no regional guide favorite shows no favorite state`() =
+        runTest {
+            val viewModel = createViewModel()
+            collectState(viewModel)
+            advanceUntilIdle()
+
+            assertEquals(
+                HomeRegionalGuideSummaryUiState.NoFavorite,
+                viewModel.uiState.value,
+            )
+        }
+
+    @Test
+    fun `latest regional guide favorite summary is shown`() =
+        runTest {
+            val snapshot =
+                sampleSnapshot(
+                    targetId = "regional-target",
+                    region = Region(sido = "Sido", sigungu = "Sigungu", eupmyeondong = "Dong"),
+                )
+            val viewModel =
+                createViewModel(
+                    favoriteRepository =
+                        FakeFavoriteRepository(
+                            initialFavorites =
+                                listOf(
+                                    Favorite(
+                                        type = FavoriteTargetType.REGIONAL_GUIDE,
+                                        targetId = snapshot.targetId,
+                                        savedAtMillis = 1L,
+                                    ),
+                                ),
+                        ),
+                    snapshotRepository =
+                        FakeRegionalGuideFavoriteSnapshotRepository(
+                            initialSnapshots = listOf(snapshot),
+                        ),
+                    regionalRepository =
+                        FakeRegionalDisposalGuideRepository(
+                            guides = listOf(sampleGuide(region = snapshot.region)),
+                        ),
+                )
+            collectState(viewModel)
+            advanceUntilIdle()
+
+            val summary = viewModel.uiState.value as HomeRegionalGuideSummaryUiState.Summary
+            assertEquals("regional-target", summary.targetId)
+            assertEquals("Sido > Sigungu > Dong", summary.regionName)
+            assertEquals("월, 화, 수, 목, 금, 토, 일", summary.disposalDays)
+            assertEquals("18:00 이후", summary.disposalTime)
+        }
+
+    @Test
+    fun `retry restarts latest info lookup`() =
+        runTest {
+            val snapshot = sampleSnapshot(targetId = "regional-target")
+            val regionalRepository =
+                FakeRegionalDisposalGuideRepository(
+                    guides = listOf(sampleGuide(region = snapshot.region)),
+                )
+            val viewModel =
+                createViewModel(
+                    favoriteRepository =
+                        FakeFavoriteRepository(
+                            initialFavorites =
+                                listOf(
+                                    Favorite(
+                                        type = FavoriteTargetType.REGIONAL_GUIDE,
+                                        targetId = snapshot.targetId,
+                                        savedAtMillis = 1L,
+                                    ),
+                                ),
+                        ),
+                    snapshotRepository =
+                        FakeRegionalGuideFavoriteSnapshotRepository(
+                            initialSnapshots = listOf(snapshot),
+                        ),
+                    regionalRepository = regionalRepository,
+                )
+            collectState(viewModel)
+            advanceUntilIdle()
+
+            viewModel.retry()
+            advanceUntilIdle()
+
+            assertEquals(2, regionalRepository.requestCount)
+        }
+
+    private fun TestScope.collectState(viewModel: HomeRegionalGuideSummaryViewModel) {
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.uiState.collect()
+        }
+    }
+
+    private fun createViewModel(
+        favoriteRepository: FakeFavoriteRepository = FakeFavoriteRepository(),
+        snapshotRepository: FakeRegionalGuideFavoriteSnapshotRepository =
+            FakeRegionalGuideFavoriteSnapshotRepository(),
+        regionalRepository: FakeRegionalDisposalGuideRepository =
+            FakeRegionalDisposalGuideRepository(),
+    ): HomeRegionalGuideSummaryViewModel =
+        HomeRegionalGuideSummaryViewModel(
+            observeHomeRegionalGuideSummaryUseCase =
+                ObserveHomeRegionalGuideSummaryUseCase(
+                    observeFavoritesUseCase = ObserveFavoritesUseCase(favoriteRepository),
+                    observeRegionalGuideFavoriteSnapshotsUseCase =
+                        ObserveRegionalGuideFavoriteSnapshotsUseCase(snapshotRepository),
+                    getRegionalDisposalGuideUseCase =
+                        GetRegionalDisposalGuideUseCase(
+                            repository = regionalRepository,
+                            normalizeRegionalGuideQueryUseCase = NormalizeRegionalGuideQueryUseCase(),
+                            selectRegionalGuideCandidateUseCase = SelectRegionalGuideCandidateUseCase(),
+                        ),
+                    getTodayRegionalWasteSummaryUseCase = GetTodayRegionalWasteSummaryUseCase(),
+                ),
+        )
+
+    private fun sampleSnapshot(
+        targetId: String,
+        region: Region = Region(sido = "Sido", sigungu = "Sigungu", eupmyeondong = "Dong"),
+    ): RegionalGuideFavoriteSnapshot =
+        RegionalGuideFavoriteSnapshot(
+            targetId = targetId,
+            region = region,
+            targetRegionName = null,
+            managementZoneName = null,
+        )
+
+    private fun sampleGuide(
+        region: Region,
+    ): RegionalDisposalGuide =
+        RegionalDisposalGuide(
+            region = region,
+            targetRegionName = region.eupmyeondong,
+            schedules =
+                listOf(
+                    RegionalWasteSchedule(
+                        wasteType = RegionalWasteType.GENERAL,
+                        disposalDays = "월, 화, 수, 목, 금, 토, 일",
+                        disposalStartTime = "18:00",
+                    ),
+                ),
+        )
+
+    private class FakeFavoriteRepository(
+        initialFavorites: List<Favorite> = emptyList(),
+    ) : FavoriteRepository {
+        private val favorites = MutableStateFlow(initialFavorites)
+
+        override fun observeFavorites(): Flow<List<Favorite>> = favorites
+
+        override fun observeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Flow<Boolean> =
+            favorites.map { items ->
+                items.any { it.type == type && it.targetId == targetId }
+            }
+
+        override suspend fun isFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ): Boolean =
+            favorites.value.any { it.type == type && it.targetId == targetId }
+
+        override suspend fun toggleFavorite(favorite: Favorite): Boolean {
+            return if (isFavorite(favorite.type, favorite.targetId)) {
+                removeFavorite(favorite.type, favorite.targetId)
+                false
+            } else {
+                addFavorite(favorite)
+                true
+            }
+        }
+
+        override suspend fun addFavorite(favorite: Favorite) {
+            favorites.value =
+                favorites.value
+                    .filterNot { it.type == favorite.type && it.targetId == favorite.targetId } + favorite
+        }
+
+        override suspend fun removeFavorite(
+            type: FavoriteTargetType,
+            targetId: String,
+        ) {
+            favorites.value =
+                favorites.value.filterNot { it.type == type && it.targetId == targetId }
+        }
+    }
+
+    private class FakeRegionalGuideFavoriteSnapshotRepository(
+        initialSnapshots: List<RegionalGuideFavoriteSnapshot> = emptyList(),
+    ) : RegionalGuideFavoriteSnapshotRepository {
+        private val snapshots = MutableStateFlow(initialSnapshots)
+
+        override fun observeSnapshots(): Flow<List<RegionalGuideFavoriteSnapshot>> = snapshots
+
+        override suspend fun getSnapshot(targetId: String): RegionalGuideFavoriteSnapshot? =
+            snapshots.value.firstOrNull { it.targetId == targetId }
+
+        override suspend fun upsertSnapshot(snapshot: RegionalGuideFavoriteSnapshot) {
+            snapshots.value = snapshots.value.filterNot { it.targetId == snapshot.targetId } + snapshot
+        }
+
+        override suspend fun deleteSnapshot(targetId: String) {
+            snapshots.value = snapshots.value.filterNot { it.targetId == targetId }
+        }
+    }
+
+    private class FakeRegionalDisposalGuideRepository(
+        private val guides: List<RegionalDisposalGuide> = emptyList(),
+    ) : RegionalDisposalGuideRepository {
+        var requestCount = 0
+            private set
+
+        override suspend fun getRegionalDisposalGuideCandidates(
+            query: RegionalGuideQuery,
+        ): Result<List<RegionalDisposalGuide>> {
+            requestCount += 1
+            return Result.success(guides.filter { guide -> guide.region.sigungu == query.sigunguQuery })
+        }
+    }
+}

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/HomeRegionalGuideSummaryViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/HomeRegionalGuideSummaryViewModelTest.kt
@@ -127,6 +127,49 @@ class HomeRegionalGuideSummaryViewModelTest {
             assertEquals(2, regionalRepository.requestCount)
         }
 
+    @Test
+    fun `unknown weekday shows schedule confirmation state`() =
+        runTest {
+            val snapshot = sampleSnapshot(targetId = "regional-target")
+            val viewModel =
+                createViewModel(
+                    favoriteRepository =
+                        FakeFavoriteRepository(
+                            initialFavorites =
+                                listOf(
+                                    Favorite(
+                                        type = FavoriteTargetType.REGIONAL_GUIDE,
+                                        targetId = snapshot.targetId,
+                                        savedAtMillis = 1L,
+                                    ),
+                                ),
+                        ),
+                    snapshotRepository =
+                        FakeRegionalGuideFavoriteSnapshotRepository(
+                            initialSnapshots = listOf(snapshot),
+                        ),
+                    regionalRepository =
+                        FakeRegionalDisposalGuideRepository(
+                            guides = listOf(
+                                sampleGuide(
+                                    region = snapshot.region,
+                                    schedules = listOf(sampleSchedule(days = "기타")),
+                                ),
+                            ),
+                        ),
+                )
+            collectState(viewModel)
+            advanceUntilIdle()
+
+            assertEquals(
+                HomeRegionalGuideSummaryUiState.ScheduleNeedsConfirmation(
+                    targetId = "regional-target",
+                    regionName = "Sido > Sigungu > Dong",
+                ),
+                viewModel.uiState.value,
+            )
+        }
+
     private fun TestScope.collectState(viewModel: HomeRegionalGuideSummaryViewModel) {
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             viewModel.uiState.collect()
@@ -169,18 +212,28 @@ class HomeRegionalGuideSummaryViewModelTest {
 
     private fun sampleGuide(
         region: Region,
+        schedules: List<RegionalWasteSchedule> =
+            listOf(
+                sampleSchedule(
+                    days = "월, 화, 수, 목, 금, 토, 일",
+                    start = "18:00",
+                ),
+            ),
     ): RegionalDisposalGuide =
         RegionalDisposalGuide(
             region = region,
             targetRegionName = region.eupmyeondong,
-            schedules =
-                listOf(
-                    RegionalWasteSchedule(
-                        wasteType = RegionalWasteType.GENERAL,
-                        disposalDays = "월, 화, 수, 목, 금, 토, 일",
-                        disposalStartTime = "18:00",
-                    ),
-                ),
+            schedules = schedules,
+        )
+
+    private fun sampleSchedule(
+        days: String?,
+        start: String? = null,
+    ): RegionalWasteSchedule =
+        RegionalWasteSchedule(
+            wasteType = RegionalWasteType.GENERAL,
+            disposalDays = days,
+            disposalStartTime = start,
         )
 
     private class FakeFavoriteRepository(


### PR DESCRIPTION
## 작업 내용

- 품목 홈에 지역 가이드 즐겨찾기 기반 요약 배너를 추가했습니다.
- 최근 추가된 지역 가이드 즐겨찾기와 `RegionalGuideFavoriteSnapshot`을 사용해 최신 `/info` 데이터를 조회합니다.
- 오늘 배출 가능한 항목, 배출 요일, 배출 시간을 `Asia/Seoul` 기준으로 계산해 표시합니다.
- 요약 배너 전용 ViewModel과 UiState를 추가해 품목 검색 상태와 책임을 분리했습니다.
- 즐겨찾기 없음, 오늘 일정 없음, 조회 실패, 후보 복원 실패 상태를 처리했습니다.
- 지역 가이드 즐겨찾기 추가·삭제로 대표 지역이 바뀌면 배너에도 반영되도록 했습니다.

## 주요 변경 사항

- 저장된 `managementZoneName`과 `targetRegionName`을 사용해 정확한 `/info` 후보를 복원합니다.
- 복수 후보가 남거나 저장된 후보를 복원할 수 없으면 첫 번째 후보를 임의 선택하지 않습니다.
- 일정 문자열을 Composable에서 직접 파싱하지 않고 별도 use case에서 오늘 배출 정보를 계산합니다.
- `기타`/`미지정` 요일 값은 오늘 일정 없음이 아니라 배출 요일 확인 필요 상태로 분리했습니다.
- 배너 선택 시 저장된 `targetId`를 `initialFavoriteTargetId`로 전달해 해당 지역 가이드 화면으로 이동합니다.
- 이동 가능한 배너에 `Role.Button`, `onClickLabel`, 원형 안내 아이콘, chevron을 적용했습니다.
- 홈에서 법정동·행정동 매칭이나 별도의 후보 추론은 추가하지 않았습니다.

## Navigation

- 홈 배너로 진입한 지역 가이드 화면은 안내 탭 흐름으로 표시됩니다.
- 지역 가이드 화면에서 다른 하단 탭을 선택하면 해당 탭의 시작 화면으로 이동합니다.
- 다른 탭에서 안내 탭으로 이동하거나 안내 탭을 재선택하면 이전 상세 화면을 자동 복원하지 않고 안내 탭 시작 화면을 표시합니다.
- Favorites에서 지역 가이드로 진입한 기존 복귀 흐름은 유지했습니다.

## 확인한 상태

- 지역 가이드 즐겨찾기 없음
- 정상 요약 배너 표시
- 오늘 배출 일정 없음
- 배출 요일 확인 필요
- `/info` 조회 실패
- 저장된 후보 복원 실패

## 테스트

- [x] `./gradlew :domain:test`
- [x] `./gradlew :presentation:testDebugUnitTest`
- [x] `./gradlew :presentation:compileDebugKotlin`
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `./gradlew :app:testDebugUnitTest`
- [x] `git diff --check`

## 스크린샷

| 품목 홈 요약 배너 | 지역 가이드 즐겨찾기 목록 |
| --- | --- |
| <img width="1344" height="2992" alt="Screenshot_20260624_000306" src="https://github.com/user-attachments/assets/7bd08a97-37ca-436f-a71d-872e1281d158" /> | <img width="1344" height="2992" alt="Screenshot_20260624_001945" src="https://github.com/user-attachments/assets/7279219b-e5ca-4c90-b30b-dd005d11ee3f" /> |

## 제외한 범위

- 대표 지역 직접 지정 및 고정 핀 기능
- 여러 지역을 표시하는 요약 배너
- 법정동·행정동 매칭 및 직접 매칭 실패 fallback 변경
- API 보정 데이터
- 영속 캐시 및 백그라운드 동기화
- 홈 카드 공통 토큰/컴포넌트 정리

## 관련 이슈

- Related #178
- Related #173