### PR TITLE
[Fix] 공식 안내 CTA 실패 피드백 추가

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/components/MessageSnackbar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/components/MessageSnackbar.kt
@@ -6,39 +6,33 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.common.design.theme.YeogiBeoryeoTheme
-import com.team.yeogibeoryeo.common.R as CommonR
 
 @Composable
-fun FavoriteSnackbar(
+fun MessageSnackbar(
     message: String,
     modifier: Modifier = Modifier,
+    icon: @Composable (() -> Unit)? = null,
 ) {
     Snackbar(
-        modifier = modifier.padding(16.dp),
-        shape = RoundedCornerShape(12.dp),
+        modifier = modifier.padding(SnackbarPadding),
+        shape = MaterialTheme.shapes.medium,
         containerColor = MaterialTheme.colorScheme.tertiaryContainer,
         contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                painter = painterResource(id = CommonR.drawable.ic_favorite_filled),
-                contentDescription = null,
-                modifier = Modifier.size(20.dp),
-                tint = MaterialTheme.colorScheme.tertiary,
-            )
-            Spacer(modifier = Modifier.width(12.dp))
+            if (icon != null) {
+                icon()
+                Spacer(modifier = Modifier.width(SnackbarIconTextSpacing))
+            }
             Text(
                 text = message,
                 style = MaterialTheme.typography.bodyMedium,
@@ -47,15 +41,18 @@ fun FavoriteSnackbar(
     }
 }
 
+private val SnackbarPadding = 16.dp
+private val SnackbarIconTextSpacing = 12.dp
+
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
 @Composable
-private fun FavoriteSnackbarPreview() {
+private fun MessageSnackbarPreview() {
     YeogiBeoryeoTheme {
         Box(
             modifier = Modifier.size(width = 360.dp, height = 160.dp),
             contentAlignment = Alignment.BottomCenter,
         ) {
-            FavoriteSnackbar(message = "즐겨찾기에 추가되었습니다")
+            MessageSnackbar(message = "즐겨찾기에 추가되었습니다")
         }
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailRoute.kt
@@ -5,25 +5,34 @@ import android.net.Uri
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.team.yeogibeoryeo.common.R as CommonR
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.presentation.R
-import com.team.yeogibeoryeo.presentation.common.components.FavoriteSnackbar
+import com.team.yeogibeoryeo.presentation.common.components.MessageSnackbar
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchStatusDescription
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchStatusContent
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchLoadingContent
@@ -40,6 +49,7 @@ fun ItemGuideDetailRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
+    var snackbarIcon by remember { mutableStateOf(ItemGuideDetailMessageIcon.Favorite) }
     val currentContext by rememberUpdatedState(LocalContext.current)
 
     LaunchedEffect(guideId) {
@@ -49,7 +59,8 @@ fun ItemGuideDetailRoute(
     LaunchedEffect(viewModel.events) {
         viewModel.events.collect { event ->
             when (event) {
-                is ItemGuideDetailEvent.ShowFavoriteMessage -> {
+                is ItemGuideDetailEvent.ShowMessage -> {
+                    snackbarIcon = event.icon
                     snackbarHostState.showSnackbar(currentContext.getString(event.messageResId))
                 }
             }
@@ -60,7 +71,10 @@ fun ItemGuideDetailRoute(
         modifier = modifier,
         snackbarHost = {
             SnackbarHost(hostState = snackbarHostState) { snackbarData ->
-                FavoriteSnackbar(message = snackbarData.visuals.message)
+                MessageSnackbar(
+                    message = snackbarData.visuals.message,
+                    icon = { ItemGuideDetailSnackbarIcon(icon = snackbarIcon) },
+                )
             }
         },
         contentWindowInsets = WindowInsets(0.dp),
@@ -87,6 +101,8 @@ fun ItemGuideDetailRoute(
                             currentContext.startActivity(
                                 Intent(Intent.ACTION_VIEW, Uri.parse(url)),
                             )
+                        }.onFailure {
+                            viewModel.showOfficialGuideOpenFailedMessage()
                         }
                     },
                     onBottomBarVisibilityChanged = onBottomBarVisibilityChanged,
@@ -117,3 +133,28 @@ fun ItemGuideDetailRoute(
         }
     }
 }
+
+@Composable
+private fun ItemGuideDetailSnackbarIcon(icon: ItemGuideDetailMessageIcon) {
+    when (icon) {
+        ItemGuideDetailMessageIcon.Favorite -> {
+            Icon(
+                painter = painterResource(id = CommonR.drawable.ic_favorite_filled),
+                contentDescription = null,
+                modifier = Modifier.size(SnackbarIconSize),
+                tint = MaterialTheme.colorScheme.tertiary,
+            )
+        }
+
+        ItemGuideDetailMessageIcon.Warning -> {
+            Icon(
+                imageVector = Icons.Filled.ErrorOutline,
+                contentDescription = null,
+                modifier = Modifier.size(SnackbarIconSize),
+                tint = MaterialTheme.colorScheme.tertiary,
+            )
+        }
+    }
+}
+
+private val SnackbarIconSize = 20.dp

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModel.kt
@@ -94,8 +94,24 @@ constructor(
                 }
             val latestState = uiState.value
             if (latestState is ItemGuideDetailUiState.Success && latestState.guide.id == guide.id) {
-                _events.emit(ItemGuideDetailEvent.ShowFavoriteMessage(messageResId))
+                _events.emit(
+                    ItemGuideDetailEvent.ShowMessage(
+                        messageResId = messageResId,
+                        icon = ItemGuideDetailMessageIcon.Favorite,
+                    ),
+                )
             }
+        }
+    }
+
+    fun showOfficialGuideOpenFailedMessage() {
+        viewModelScope.launch {
+            _events.emit(
+                ItemGuideDetailEvent.ShowMessage(
+                    messageResId = R.string.item_guide_action_open_failed_message,
+                    icon = ItemGuideDetailMessageIcon.Warning,
+                ),
+            )
         }
     }
 
@@ -131,7 +147,13 @@ sealed interface ItemGuideDetailUiState {
 }
 
 sealed interface ItemGuideDetailEvent {
-    data class ShowFavoriteMessage(
+    data class ShowMessage(
         @param:StringRes val messageResId: Int,
+        val icon: ItemGuideDetailMessageIcon,
     ) : ItemGuideDetailEvent
+}
+
+enum class ItemGuideDetailMessageIcon {
+    Favorite,
+    Warning,
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="item_guide_action_find_hazardous_waste_bin_description">전용수거함 위치를 확인할 수 있습니다.</string>
     <string name="item_guide_action_free_pickup">무상방문수거 안내 보기</string>
     <string name="item_guide_action_free_pickup_description">방문수거는 지도 장소가 아니라 예약 안내로 확인합니다.</string>
+    <string name="item_guide_action_open_failed_message">공식 안내를 열 수 있는 앱이 없습니다.</string>
     <string name="back_action">뒤로가기</string>
     <string name="favorite_add_action">즐겨찾기 추가</string>
     <string name="favorite_remove_action">즐겨찾기 해제</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -47,7 +47,7 @@
     <string name="item_guide_action_find_hazardous_waste_bin_description">전용수거함 위치를 확인할 수 있습니다.</string>
     <string name="item_guide_action_free_pickup">무상방문수거 안내 보기</string>
     <string name="item_guide_action_free_pickup_description">방문수거는 지도 장소가 아니라 예약 안내로 확인합니다.</string>
-    <string name="item_guide_action_open_failed_message">공식 안내를 열 수 있는 앱이 없습니다.</string>
+    <string name="item_guide_action_open_failed_message">공식 안내를 열 수 있는 앱이 없습니다. 브라우저 앱을 설치하거나 활성화한 뒤 다시 시도해주세요.</string>
     <string name="back_action">뒤로가기</string>
     <string name="favorite_add_action">즐겨찾기 추가</string>
     <string name="favorite_remove_action">즐겨찾기 해제</string>

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModelTest.kt
@@ -81,7 +81,7 @@ class ItemGuideDetailViewModelTest {
             assertTrue(state.isFavorite)
             assertEquals(
                 R.string.item_guide_detail_favorite_added_message,
-                (event.await() as ItemGuideDetailEvent.ShowFavoriteMessage).messageResId,
+                (event.await() as ItemGuideDetailEvent.ShowMessage).messageResId,
             )
         }
 
@@ -116,8 +116,29 @@ class ItemGuideDetailViewModelTest {
             assertFalse(state.isFavorite)
             assertEquals(
                 R.string.item_guide_detail_favorite_removed_message,
-                (event.await() as ItemGuideDetailEvent.ShowFavoriteMessage).messageResId,
+                (event.await() as ItemGuideDetailEvent.ShowMessage).messageResId,
             )
+        }
+
+    @Test
+    fun `공식 안내 실행 실패 메시지 이벤트를 보낸다`() =
+        runTest {
+            val viewModel =
+                createViewModel(
+                    itemRepository = FakeItemRepository(guide = sampleGuide("전기밥솥")),
+                    favoriteRepository = FakeFavoriteRepository(),
+                )
+
+            val event = async(start = CoroutineStart.UNDISPATCHED) { viewModel.events.first() }
+            viewModel.showOfficialGuideOpenFailedMessage()
+            advanceUntilIdle()
+
+            val messageEvent = event.await() as ItemGuideDetailEvent.ShowMessage
+            assertEquals(
+                R.string.item_guide_action_open_failed_message,
+                messageEvent.messageResId,
+            )
+            assertEquals(ItemGuideDetailMessageIcon.Warning, messageEvent.icon)
         }
 
     @Test


### PR DESCRIPTION
## 작업 내용
- 공식 안내 CTA 실행 실패 시 스낵바 안내를 표시하도록 수정했습니다.
- 실패 안내를 `ItemGuideDetailEvent.ShowMessage` one-shot event로 처리했습니다.
- 즐겨찾기 전용 스낵바를 `MessageSnackbar`로 정리하고 아이콘 slot을 받을 수 있게 변경했습니다.

## 변경 이유
공식 안내 CTA에서 `Intent.ACTION_VIEW`를 처리할 수 있는 앱이 없으면 사용자가 아무 피드백을 받지 못했습니다.
실패 상황에서도 사용자가 현재 상태와 이후 행동을 알 수 있도록 안내 메시지를 표시합니다.

## 주요 변경 사항
- 공식 안내 실행 실패 문구 추가
- 실패 이벤트 추가 및 경고 아이콘 표시
- 스낵바 아이콘 slot화
- 즐겨찾기/공식 안내 실패 메시지 이벤트 테스트 보강

## 확인 사항
- 처리 가능한 브라우저가 없는 실기기 상태에서 `공식 안내를 열 수 있는 앱이 없습니다. 브라우저 앱을 설치하거나 활성화한 뒤 다시 시도해주세요.` 스낵바 노출 확인
- 브라우저 복구 후 기존 공식 안내 이동 흐름 유지 확인

## 스크린샷
<img width="260" alt="공식 안내 CTA 실행 실패 스낵바" src="https://github.com/user-attachments/assets/5ccd779b-575f-4a08-86d9-58582100ac10" />

## 테스트
- `./gradlew.bat :presentation:testDebugUnitTest --tests com.team.yeogibeoryeo.presentation.search.ItemGuideDetailViewModelTest :presentation:compileDebugKotlin :app:compileDebugKotlin --no-daemon --no-configuration-cache`
- `git diff --check`

## 관련 이슈
Related #184
