### PR TITLE
feat: 지도 수거 장소 카드에 현재 위치 기준 거리 표시

### DIFF
--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/CalculateDistanceMeterUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/CalculateDistanceMeterUseCase.kt
@@ -1,0 +1,33 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import javax.inject.Inject
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+class CalculateDistanceMeterUseCase @Inject constructor() {
+
+    operator fun invoke(
+        from: Coordinate,
+        to: Coordinate,
+    ): Int {
+        val latitudeDistance = Math.toRadians(to.latitude - from.latitude)
+        val longitudeDistance = Math.toRadians(to.longitude - from.longitude)
+        val fromLatitude = Math.toRadians(from.latitude)
+        val toLatitude = Math.toRadians(to.latitude)
+
+        val a = sin(latitudeDistance / 2) * sin(latitudeDistance / 2) +
+            cos(fromLatitude) * cos(toLatitude) *
+            sin(longitudeDistance / 2) * sin(longitudeDistance / 2)
+        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+
+        return (EARTH_RADIUS_METER * c).roundToInt()
+    }
+
+    private companion object {
+        const val EARTH_RADIUS_METER = 6_371_000
+    }
+}

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/CalculateDistanceMeterUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/CalculateDistanceMeterUseCaseTest.kt
@@ -1,0 +1,44 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CalculateDistanceMeterUseCaseTest {
+
+    private val useCase = CalculateDistanceMeterUseCase()
+
+    @Test
+    fun `같은 좌표의 거리는 0m로 계산한다`() {
+        val coordinate = Coordinate(
+            latitude = 37.5666102,
+            longitude = 126.9783881,
+        )
+
+        val distanceMeter = useCase(
+            from = coordinate,
+            to = coordinate,
+        )
+
+        assertEquals(0, distanceMeter)
+    }
+
+    @Test
+    fun `서로 다른 좌표의 거리를 meter 단위로 계산한다`() {
+        val seoulCityHall = Coordinate(
+            latitude = 37.5666102,
+            longitude = 126.9783881,
+        )
+        val nearbyCoordinate = Coordinate(
+            latitude = 37.567508,
+            longitude = 126.978960,
+        )
+
+        val distanceMeter = useCase(
+            from = seoulCityHall,
+            to = nearbyCoordinate,
+        )
+
+        assertEquals(112, distanceMeter)
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -8,6 +8,7 @@ import com.team.yeogibeoryeo.domain.favorite.usecase.ToggleCollectionSpotFavorit
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.usecase.CalculateDistanceMeterUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.GetFreshRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SaveRecentCurrentLocationSpotsUseCase
@@ -38,6 +39,7 @@ class CollectionSpotMapViewModel @Inject constructor(
     private val saveRecentCurrentLocationSpotsUseCase: SaveRecentCurrentLocationSpotsUseCase,
     private val observeFavoritesUseCase: ObserveFavoritesUseCase,
     private val toggleCollectionSpotFavoriteUseCase: ToggleCollectionSpotFavoriteUseCase,
+    private val calculateDistanceMeterUseCase: CalculateDistanceMeterUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CollectionSpotMapUiState())
@@ -232,8 +234,10 @@ class CollectionSpotMapViewModel @Inject constructor(
 
             if (!canApplyCurrentLocationResult()) return
 
-            updateSpotResult(spots)
-            saveRecentCurrentLocationSpotsUseCase(spots)
+            val spotsWithDistance = spots.withDistanceFrom(coordinate)
+
+            updateSpotResult(spotsWithDistance)
+            saveRecentCurrentLocationSpotsUseCase(spotsWithDistance)
         } catch (throwable: Throwable) {
             if (throwable is CancellationException) throw throwable
 
@@ -644,6 +648,20 @@ class CollectionSpotMapViewModel @Inject constructor(
     private fun List<CollectionSpot>.withFavoriteState(): List<CollectionSpot> =
         map { spot ->
             spot.copy(isBookmarked = spot.id in favoriteSpotIds)
+        }
+
+    private fun List<CollectionSpot>.withDistanceFrom(
+        coordinate: Coordinate,
+    ): List<CollectionSpot> =
+        map { spot ->
+            val spotCoordinate = spot.coordinate ?: return@map spot
+
+            spot.copy(
+                distanceMeter = calculateDistanceMeterUseCase(
+                    from = coordinate,
+                    to = spotCoordinate,
+                ),
+            )
         }
 
     private fun FavoriteSpotMapMoveRequest.toCollectionSpot(): CollectionSpot =

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.presentation.map.formatter.DistanceFormatter
 import com.team.yeogibeoryeo.presentation.map.mapper.toDisplayName
 import com.team.yeogibeoryeo.common.R as CommonR
 
@@ -59,6 +60,7 @@ fun SpotBottomCard(
             }
         }
     }
+    val distanceText = DistanceFormatter.format(spot.distanceMeter)
 
     Card(
         modifier = cardModifier,
@@ -97,11 +99,11 @@ fun SpotBottomCard(
                             },
                         )
 
-                        spot.distanceMeter?.let { distanceMeter ->
+                        distanceText?.let { formattedDistance ->
                             Spacer(modifier = Modifier.width(8.dp))
 
                             Text(
-                                text = "${distanceMeter}m",
+                                text = formattedDistance,
                                 style = MaterialTheme.typography.labelMedium,
                                 color = supportingContentColor,
                             )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/formatter/DistanceFormatter.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/formatter/DistanceFormatter.kt
@@ -1,0 +1,20 @@
+package com.team.yeogibeoryeo.presentation.map.formatter
+
+import java.util.Locale
+
+object DistanceFormatter {
+    fun format(distanceMeter: Int?): String? {
+        val distance = distanceMeter?.takeIf { it >= 0 } ?: return null
+
+        return if (distance < METER_PER_KILOMETER) {
+            "${distance}m"
+        } else {
+            val kilometerText = String
+                .format(Locale.US, "%.1f", distance / METER_PER_KILOMETER.toDouble())
+                .removeSuffix(".0")
+            "${kilometerText}km"
+        }
+    }
+
+    private const val METER_PER_KILOMETER = 1_000
+}

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapInitialEntryViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapInitialEntryViewModelTest.kt
@@ -12,6 +12,7 @@ import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.model.RecentCurrentLocationSpotCacheEntry
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import com.team.yeogibeoryeo.domain.spot.repository.RecentCurrentLocationSpotCacheRepository
+import com.team.yeogibeoryeo.domain.spot.usecase.CalculateDistanceMeterUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.GetFreshRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SaveRecentCurrentLocationSpotsUseCase
@@ -54,7 +55,7 @@ class CollectionSpotMapInitialEntryViewModelTest {
             viewModel.searchByCurrentLocationOnMapEntryIfPermitted(CollectionSpotType.MEDICINE_DROP_BOX)
 
             assertEquals(setOf(CollectionSpotType.MEDICINE_DROP_BOX), viewModel.uiState.value.selectedTypes)
-            assertEquals(listOf(medicineSpot), viewModel.uiState.value.spots)
+            assertEquals(listOf(medicineSpot).withDistanceFrom(currentCoordinate), viewModel.uiState.value.spots)
             assertEquals(1, repository.locationSearchCallCount)
             assertEquals(currentCoordinate, repository.lastLocationCoordinate)
             assertEquals(MapSearchMode.CURRENT_LOCATION, viewModel.uiState.value.searchMode)
@@ -123,7 +124,10 @@ class CollectionSpotMapInitialEntryViewModelTest {
             viewModel.searchByCurrentLocationOnMapEntryIfPermitted(CollectionSpotType.BATTERY_BIN)
 
             assertEquals(setOf(CollectionSpotType.BATTERY_BIN), viewModel.uiState.value.selectedTypes)
-            assertEquals(listOf(batterySpot), viewModel.uiState.value.spots)
+            assertEquals(
+                listOf(batterySpot).withDistanceFrom(Coordinate(latitude = 37.5666102, longitude = 126.9783881)),
+                viewModel.uiState.value.spots,
+            )
             assertEquals(1, repository.locationSearchCallCount)
         }
 
@@ -173,6 +177,7 @@ class CollectionSpotMapInitialEntryViewModelTest {
             toggleCollectionSpotFavoriteUseCase = ToggleCollectionSpotFavoriteUseCase(
                 collectionSpotFavoriteRepository = FakeCollectionSpotFavoriteRepository(favoriteRepository),
             ),
+            calculateDistanceMeterUseCase = CalculateDistanceMeterUseCase(),
         )
     }
 
@@ -188,6 +193,23 @@ class CollectionSpotMapInitialEntryViewModelTest {
             detailLocation = null,
             coordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881),
         )
+    }
+
+    private fun List<CollectionSpot>.withDistanceFrom(
+        coordinate: Coordinate,
+    ): List<CollectionSpot> {
+        val calculateDistanceMeterUseCase = CalculateDistanceMeterUseCase()
+
+        return map { spot ->
+            val spotCoordinate = spot.coordinate ?: return@map spot
+
+            spot.copy(
+                distanceMeter = calculateDistanceMeterUseCase(
+                    from = coordinate,
+                    to = spotCoordinate,
+                ),
+            )
+        }
     }
 
     private class FakeCurrentLocationProvider(

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -15,6 +15,7 @@ import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.model.RecentCurrentLocationSpotCacheEntry
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import com.team.yeogibeoryeo.domain.spot.repository.RecentCurrentLocationSpotCacheRepository
+import com.team.yeogibeoryeo.domain.spot.usecase.CalculateDistanceMeterUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.GetFreshRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SaveRecentCurrentLocationSpotsUseCase
@@ -142,7 +143,7 @@ class CollectionSpotMapViewModelTest {
 
             assertEquals(currentCoordinate, repository.lastLocationCoordinate)
             assertEquals(500, repository.lastRadiusMeter)
-            assertEquals(expectedSpots, viewModel.uiState.value.spots)
+            assertEquals(expectedSpots.withDistanceFrom(currentCoordinate), viewModel.uiState.value.spots)
             assertEquals(MapSearchMode.CURRENT_LOCATION, viewModel.uiState.value.searchMode)
             assertNull(viewModel.uiState.value.locationNoticeMessage)
             assertNull(viewModel.uiState.value.errorMessage)
@@ -152,6 +153,7 @@ class CollectionSpotMapViewModelTest {
     @Test
     fun `현재 위치 검색은 신선한 캐시가 있으면 캐시를 먼저 표시하고 조용히 갱신한다`() =
         runTest {
+            val currentCoordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881)
             val currentLocationResult = CompletableDeferred<CurrentLocationResult>()
             val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
             val refreshedSpot = sampleSpot("refresh", CollectionSpotType.RECYCLING_CENTER)
@@ -179,12 +181,12 @@ class CollectionSpotMapViewModelTest {
 
             currentLocationResult.complete(
                 CurrentLocationResult.Found(
-                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                    currentCoordinate,
                 ),
             )
             advanceUntilIdle()
 
-            assertEquals(listOf(refreshedSpot), viewModel.uiState.value.spots)
+            assertEquals(listOf(refreshedSpot).withDistanceFrom(currentCoordinate), viewModel.uiState.value.spots)
             assertEquals(1, repository.locationSearchCallCount)
         }
 
@@ -342,7 +344,10 @@ class CollectionSpotMapViewModelTest {
             viewModel.onSpotTypeClick(CollectionSpotType.RECYCLING_CENTER)
 
             assertEquals(setOf(CollectionSpotType.RECYCLING_CENTER), viewModel.uiState.value.selectedTypes)
-            assertEquals(listOf(recyclingCenterSpot), viewModel.uiState.value.spots)
+            assertEquals(
+                listOf(recyclingCenterSpot).withDistanceFrom(Coordinate(latitude = 37.5666102, longitude = 126.9783881)),
+                viewModel.uiState.value.spots,
+            )
         }
 
     @Test
@@ -477,7 +482,10 @@ class CollectionSpotMapViewModelTest {
             advanceUntilIdle()
 
             assertEquals("용답동", viewModel.uiState.value.searchKeyword)
-            assertEquals(listOf(locationSpot), viewModel.uiState.value.spots)
+            assertEquals(
+                listOf(locationSpot).withDistanceFrom(Coordinate(latitude = 37.5666102, longitude = 126.9783881)),
+                viewModel.uiState.value.spots,
+            )
             assertEquals(MapSearchMode.CURRENT_LOCATION, viewModel.uiState.value.searchMode)
             assertFalse(viewModel.uiState.value.isLoading)
         }
@@ -498,7 +506,7 @@ class CollectionSpotMapViewModelTest {
 
             assertEquals(1, repository.locationSearchCallCount)
             assertEquals(currentCoordinate, repository.lastLocationCoordinate)
-            assertEquals(expectedSpots, viewModel.uiState.value.spots)
+            assertEquals(expectedSpots.withDistanceFrom(currentCoordinate), viewModel.uiState.value.spots)
             assertEquals(MapSearchMode.CURRENT_LOCATION, viewModel.uiState.value.searchMode)
         }
 
@@ -592,7 +600,10 @@ class CollectionSpotMapViewModelTest {
             advanceUntilIdle()
 
             assertEquals(1, repository.locationSearchCallCount)
-            assertEquals(listOf(locationSpot), viewModel.uiState.value.spots)
+            assertEquals(
+                listOf(locationSpot).withDistanceFrom(Coordinate(latitude = 37.5666102, longitude = 126.9783881)),
+                viewModel.uiState.value.spots,
+            )
         }
 
     @Test
@@ -708,6 +719,7 @@ class CollectionSpotMapViewModelTest {
     @Test
     fun `유효한 캐시 표시 후 refresh 성공 시 화면 결과와 캐시를 최신 결과로 교체한다`() =
         runTest {
+            val currentCoordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881)
             val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
             val refreshedSpot = sampleSpot("refresh", CollectionSpotType.RECYCLING_CENTER)
             val cache = FakeRecentCurrentLocationSpotCacheRepository(
@@ -726,8 +738,8 @@ class CollectionSpotMapViewModelTest {
             viewModel.searchByCurrentLocationOnMapEntryIfPermitted()
             advanceUntilIdle()
 
-            assertEquals(listOf(refreshedSpot), viewModel.uiState.value.spots)
-            assertEquals(listOf(refreshedSpot), cache.entry?.spots)
+            assertEquals(listOf(refreshedSpot).withDistanceFrom(currentCoordinate), viewModel.uiState.value.spots)
+            assertEquals(listOf(refreshedSpot).withDistanceFrom(currentCoordinate), cache.entry?.spots)
             assertEquals(1, repository.locationSearchCallCount)
             assertEquals(1, cache.saveCallCount)
         }
@@ -780,7 +792,7 @@ class CollectionSpotMapViewModelTest {
             assertEquals(1, cache.getCallCount)
             assertEquals(1, repository.locationSearchCallCount)
             assertEquals(currentCoordinate, repository.lastLocationCoordinate)
-            assertEquals(listOf(expectedSpot), viewModel.uiState.value.spots)
+            assertEquals(listOf(expectedSpot).withDistanceFrom(currentCoordinate), viewModel.uiState.value.spots)
         }
 
     @Test
@@ -808,7 +820,10 @@ class CollectionSpotMapViewModelTest {
             advanceUntilIdle()
 
             assertEquals(1, repository.locationSearchCallCount)
-            assertEquals(listOf(expectedSpot), viewModel.uiState.value.spots)
+            assertEquals(
+                listOf(expectedSpot).withDistanceFrom(Coordinate(latitude = 37.5666102, longitude = 126.9783881)),
+                viewModel.uiState.value.spots,
+            )
         }
 
     @Test
@@ -894,7 +909,10 @@ class CollectionSpotMapViewModelTest {
             viewModel.searchByCurrentLocation()
 
             assertEquals(1, cache.saveCallCount)
-            assertEquals(listOf(expectedSpot), cache.entry?.spots)
+            assertEquals(
+                listOf(expectedSpot).withDistanceFrom(Coordinate(latitude = 37.5666102, longitude = 126.9783881)),
+                cache.entry?.spots,
+            )
         }
 
     @Test
@@ -1299,6 +1317,7 @@ class CollectionSpotMapViewModelTest {
                         snapshotRepository = snapshotRepository,
                     ),
             ),
+            calculateDistanceMeterUseCase = CalculateDistanceMeterUseCase(),
         )
     }
 
@@ -1323,6 +1342,23 @@ class CollectionSpotMapViewModelTest {
             detailLocation = null,
             coordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881),
         )
+    }
+
+    private fun List<CollectionSpot>.withDistanceFrom(
+        coordinate: Coordinate,
+    ): List<CollectionSpot> {
+        val calculateDistanceMeterUseCase = CalculateDistanceMeterUseCase()
+
+        return map { spot ->
+            val spotCoordinate = spot.coordinate ?: return@map spot
+
+            spot.copy(
+                distanceMeter = calculateDistanceMeterUseCase(
+                    from = coordinate,
+                    to = spotCoordinate,
+                ),
+            )
+        }
     }
 
     private fun sampleFavoriteSpotMapMoveRequest(

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/formatter/DistanceFormatterTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/formatter/DistanceFormatterTest.kt
@@ -1,0 +1,36 @@
+package com.team.yeogibeoryeo.presentation.map.formatter
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DistanceFormatterTest {
+    @Test
+    fun `1000m 미만은 m 단위로 표시한다`() {
+        assertEquals("120m", DistanceFormatter.format(120))
+        assertEquals("850m", DistanceFormatter.format(850))
+    }
+
+    @Test
+    fun `1000m 이상은 km 단위 한 자리로 표시한다`() {
+        assertEquals("1.2km", DistanceFormatter.format(1_200))
+        assertEquals("2.5km", DistanceFormatter.format(2_500))
+    }
+
+    @Test
+    fun `km 소수점이 0이면 정수 km로 표시한다`() {
+        assertEquals("1km", DistanceFormatter.format(1_000))
+        assertEquals("2km", DistanceFormatter.format(2_000))
+    }
+
+    @Test
+    fun `0m는 거리 값으로 표시한다`() {
+        assertEquals("0m", DistanceFormatter.format(0))
+    }
+
+    @Test
+    fun `null 또는 음수 거리는 표시하지 않는다`() {
+        assertNull(DistanceFormatter.format(null))
+        assertNull(DistanceFormatter.format(-1))
+    }
+}


### PR DESCRIPTION
## 작업 내용

Refs #174

지도 BottomSheet 수거 장소 카드에 **현재 위치 기준 거리 정보**를 표시하도록 개선했습니다.

| 구분 | 내용 |
| --- | --- |
| 거리 표시 대상 | `내 주변 검색`, Map 진입 자동 현재 위치 검색, 현재 위치 검색 refresh/캐시 결과 |
| 거리 미표시 대상 | 키워드 검색, 현 지도에서 검색, 즐겨찾기 장소 기준 주변 검색, Favorites 탭 |
| 거리 포맷 | `1000m` 미만은 `m`, `1000m` 이상은 `km` 단위로 표시 |
| 예외 처리 | `distanceMeter == null` 또는 음수 값은 표시하지 않음 |
| UI 위치 | 카드 상단 타입명 옆에 거리 표시 |
| 기존 정책 유지 | 검색, 필터, 마커 선택, BottomSheet, 즐겨찾기 토글 동작 유지 |

## 주요 변경 사항

| 파일/영역 | 변경 내용 |
| --- | --- |
| `SpotBottomCard` | `distanceMeter`가 있을 때 거리 텍스트 표시 |
| `DistanceFormatter` | 거리 표시 포맷 분리 |
| `CalculateDistanceMeterUseCase` | 현재 위치 기준 수거 장소 거리 계산 |
| `CollectionSpotMapViewModel` | 현재 위치 검색 결과에만 거리 계산 적용 |
| 테스트 | 거리 formatter, 거리 계산, 현재 위치 검색 결과 거리 반영 테스트 보강 |

## 정책 정리

| 검색 흐름 | 거리 표시 여부 | 이유 |
| --- | --- | --- |
| 내 주변 검색 | 표시 | 사용자 현재 위치 기준 거리 |
| Map 진입 자동 현재 위치 검색 | 표시 | 사용자 현재 위치 기준 거리 |
| 현재 위치 검색 캐시/refresh 결과 | 표시 | 최근 현재 위치 기준 결과 |
| 키워드 검색 | 미표시 | 현재 위치 기준점이 없음 |
| 현 지도에서 검색 | 미표시 | 지도 중심 기준 거리로 오해될 수 있어 이번 범위에서 제외 |
| 즐겨찾기 장소 기준 주변 검색 | 미표시 | 사용자 현재 위치가 아니라 선택한 장소 기준 검색 |
| Favorites 탭 | 미표시 | 현재 위치 기준 검색 결과가 아님 |

## 검증

| 항목 | 결과 |
| --- | --- |
| 현재 위치 검색 중 로딩 표시 | 확인 |
| 현재 위치 기준 BottomSheet 리스트 카드 거리 표시 | 확인 |
| 마커/카드 선택 후 강조 카드 거리 표시 | 확인 |
| 현 지도에서 검색 로딩 표시 | 확인 |
| 현 지도 검색 결과 거리 미표시 | 확인 |
| 즐겨찾기 장소 선택 시 거리 미표시 | 확인 |
| 즐겨찾기 장소 주변 리스트 거리 미표시 | 확인 |
| 기존 필터칩 / 마커 / BottomSheet 동작 | 확인 |
| 기존 즐겨찾기 토글 동작 | 확인 |

## 테스트

```bash
./gradlew.bat :domain:test --tests com.team.yeogibeoryeo.domain.spot.usecase.CalculateDistanceMeterUseCaseTest
./gradlew.bat :presentation:testDebugUnitTest
./gradlew.bat :presentation:compileDebugKotlin
./gradlew.bat :app:assembleDebug
git diff --check
```

## 스크린샷

| 현재 위치 검색 로딩 | 현재 위치 기준 거리 표시 |
| --- | --- |
| <img width="260" alt="현재 위치 주변 검색 로딩" src="https://github.com/user-attachments/assets/7e1ab11f-3ee9-4ae6-9b26-dd29edcc7779" /> | <img width="260" alt="현재 위치 기준 거리 표시" src="https://github.com/user-attachments/assets/b7277aac-e25d-44d6-b66e-5c2c4b3738fb" /> |

| 선택/강조 카드 거리 표시 | 현 지도 검색 로딩 |
| --- | --- |
| <img width="260" alt="선택 카드 거리 표시" src="https://github.com/user-attachments/assets/d68e707d-6471-4f00-8708-520b429ddd7c" /> | <img width="260" alt="현 지도 검색 로딩" src="https://github.com/user-attachments/assets/b8bc97ec-4805-430e-bbe3-5d2d81d86c39" /> |

| 현 지도 검색 거리 미표시 | 즐겨찾기 장소 선택 거리 미표시 |
| --- | --- |
| <img width="260" alt="현 지도 기준 거리 미표시" src="https://github.com/user-attachments/assets/91a5f9b0-838b-434d-b75c-b8b61b76ad6e" /> | <img width="260" alt="즐겨찾기 장소 선택 거리 미표시" src="https://github.com/user-attachments/assets/9e06151e-8f3c-4846-a4c4-e6ad5f92f223" /> |

| 즐겨찾기 주변 리스트 거리 미표시 |
| --- |
| <img width="260" alt="즐겨찾기 주변 리스트 거리 미표시" src="https://github.com/user-attachments/assets/e43d8158-0814-47c3-a633-5767a07e4f16" /> |