### PR TITLE
fix: 지역 가이드 후보 선택 후 검색어 표시 유지

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
@@ -203,8 +203,6 @@ class RegionalGuideViewModel @Inject constructor(
     fun onRegionCandidateSelected(candidate: RegionSearchCandidateUiModel) {
         if (!candidate.isValid) return
 
-        _searchKeyword.value = candidate.displayText
-
         val region = candidate.toRegion()
         searchBySelectedRegion(
             query = candidate.displayText,

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModelTest.kt
@@ -427,7 +427,7 @@ class RegionalGuideViewModelTest {
     }
 
     @Test
-    fun `candidate selection runs selected region lookup and updates selector state`() = runTest {
+    fun `candidate selection keeps search keyword and updates selector state`() = runTest {
         val regionalGuideRepository = FakeRegionalDisposalGuideRepository(
             candidates = listOf(
                 sampleGuide(
@@ -475,8 +475,10 @@ class RegionalGuideViewModelTest {
         viewModel.onRegionCandidateSelected(candidate)
         advanceUntilIdle()
 
-        assertEquals(candidate.displayText, viewModel.searchKeyword.value)
-        assertTrue(viewModel.uiState.value is RegionalGuideUiState.Success)
+        val state = viewModel.uiState.value as RegionalGuideUiState.Success
+
+        assertEquals("온양", viewModel.searchKeyword.value)
+        assertEquals(candidate.displayText, state.query)
         assertEquals("울주군", regionalGuideRepository.queries.single().sigunguQuery)
 
         with(viewModel.regionSelectorUiState.value) {
@@ -484,6 +486,68 @@ class RegionalGuideViewModelTest {
             assertEquals("울주군", selectedSigungu)
             assertEquals("온양읍", selectedEupmyeondong)
         }
+    }
+
+    @Test
+    fun `retry after candidate selection uses selected region instead of search keyword`() = runTest {
+        val regionalGuideRepository = FakeRegionalDisposalGuideRepository(
+            candidates = listOf(
+                sampleGuide(
+                    sido = "울산광역시",
+                    sigungu = "울주군",
+                    targetRegionName = "온양읍"
+                )
+            )
+        )
+        val viewModel = createViewModel(
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                sigunguOptionsBySido = mapOf(
+                    "울산광역시" to listOf("울주군")
+                ),
+                eupmyeondongOptionsByRegion = mapOf(
+                    "울산광역시" to mapOf(
+                        "울주군" to listOf("온양읍")
+                    )
+                ),
+                keywordRegions = listOf(
+                    Region(
+                        sido = "울산광역시",
+                        sigungu = "울주군",
+                        eupmyeondong = "온양읍"
+                    ),
+                    Region(
+                        sido = "충청남도",
+                        sigungu = "아산시",
+                        eupmyeondong = "온양1동"
+                    )
+                )
+            ),
+            regionalGuideRepository = regionalGuideRepository
+        )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("온양")
+        advanceTimeBy(400)
+        advanceUntilIdle()
+
+        val candidate = (viewModel.uiState.value as RegionalGuideUiState.Ambiguous)
+            .candidates
+            .first()
+
+        viewModel.onRegionCandidateSelected(candidate)
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("새검색")
+        viewModel.retryLastRequest()
+        advanceUntilIdle()
+
+        assertEquals("새검색", viewModel.searchKeyword.value)
+        assertEquals(2, regionalGuideRepository.queries.size)
+        assertTrue(
+            regionalGuideRepository.queries.all { query ->
+                query.sigunguQuery == "울주군"
+            }
+        )
     }
 
     @Test
@@ -724,6 +788,7 @@ class RegionalGuideViewModelTest {
 
         val state = viewModel.uiState.value as RegionalGuideUiState.Success
 
+        assertEquals("울주군", viewModel.searchKeyword.value)
         assertEquals("울주군", state.query)
         assertEquals(
             "범서, 온양, 웅촌, 언양, 삼남, 상북, 온산, 청량, 서생",


### PR DESCRIPTION
## 작업 내용

- 지역 가이드 자동 추천 후보 선택 시 검색창 값이 전체 지역 경로로 덮어써지지 않도록 수정했습니다.
- 검색창 입력 문자열과 실제 조회 대상으로 선택된 지역 상태를 분리했습니다.
- 후보 선택 후에도 사용자가 입력한 검색어가 검색창에 유지되도록 했습니다.
  - 예: `온양` 입력 → `울산광역시 > 울주군 > 온양읍` 후보 선택 → 검색창에는 `온양` 유지
- 선택된 실제 조회 지역은 기존처럼 `RegionSelectorUiState`와 compact 지역 표시에서 확인할 수 있도록 유지했습니다.
- retry는 검색창 문자열이 아니라 마지막으로 확정된 조회 요청을 기준으로 동작하도록 유지했습니다.

## 변경 이유

후보 선택 후 검색창 값이 전체 지역 경로로 변경되면, 사용자가 추가 검색을 시작할 때 긴 문자열을 지워야 했습니다.

실제 조회 지역은 compact 지역 표시와 지역 선택 상태에서 이미 확인할 수 있으므로, 검색창은 사용자의 입력 문자열을 유지하도록 책임을 분리했습니다.

## 주요 변경 사항

- `RegionalGuideViewModel.onRegionCandidateSelected()`에서 검색창 값을 후보 전체 경로로 덮어쓰던 처리를 제거했습니다.
- 후보 선택 조회는 기존 `searchBySelectedRegion()` 흐름을 사용해 실제 조회 지역과 compact 표시 상태를 유지했습니다.
- 자동 추천 후보 선택 후 검색어 유지 테스트를 보강했습니다.
- 후보 선택 후 검색창 문자열이 변경되어도 retry가 마지막 선택 지역 기준으로 동작하는 회귀 테스트를 추가했습니다.
- 다중 `/info` 후보 선택 후에도 검색어가 유지되는지 확인했습니다.

## 스크린샷

| 수정 전 | 수정 후 |
| --- | --- |
| 후보 선택 후 검색창이 전체 지역 경로로 변경된 상태 | 후보 선택 후에도 검색창에 원본 검색어가 유지된 상태 |
| <img width="720" height="1520" alt="검색창에 온양을 입력하고 후보 목록이 표시된 상태" src="https://github.com/user-attachments/assets/199bba06-c882-4e35-aa35-cc70ea00a658" /> | <img width="720" height="1520" alt="후보 선택 후 검색창 값이 `온양`으로 유지 상태" src="https://github.com/user-attachments/assets/f138e44c-854e-4b02-b9c6-8f3f64dcc826" /> |

### 동작 확인

- `온양` 입력 후 `울산광역시 > 울주군 > 온양읍` 후보 선택
- 후보 선택 후 검색창에는 `온양` 유지
- 실제 조회 지역은 compact 지역 표시 영역에 반영
- 검색창을 다시 선택해 바로 재검색 가능

## 기존 흐름 유지

- 자동 후보 추천 흐름 유지
- 다중 후보 선택 UX 유지
- 후보 선택 후 지역 가이드 조회 유지
- 지역 선택형 UI 조회 흐름 유지
- 주소 기반 `loadByAddress()` 진입 흐름 유지
- Favorites 지역 가이드 재진입 흐름 유지
- #151 키보드 및 focus 처리 흐름 유지
- #158 관리구역 / 대상지역 후보 식별 및 표시 정책 유지

## 테스트

- [x] `./gradlew :presentation:testDebugUnitTest --tests "com.team.yeogibeoryeo.presentation.regionalguide.RegionalGuideViewModelTest"`
- [x] `./gradlew :presentation:testDebugUnitTest :presentation:compileDebugKotlin :app:compileDebugKotlin`
- [x] `git diff --check`

## 제외한 범위

- 주소 파싱 로직 변경
- `/info` 조회 key 정규화 변경
- 후보 선택 UseCase 변경
- Navigation 변경
- 검색창 UI 리디자인
- #152 도로명 / 전체 주소 직접 검색
- #155 법정동 / 행정동 매핑
- #158 선택형 UI fallback 정책

## 관련 이슈

- Related #159
- Related #103  
- Related #158