### PR TITLE
[Refactor] 하단 탭 popUpTo route 타입 기준 정리

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/BottomTabNavigation.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/BottomTabNavigation.kt
@@ -3,7 +3,6 @@ package com.team.yeogibeoryeo.navigation
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.toRoute
 import com.team.yeogibeoryeo.R as AppR
@@ -91,7 +90,7 @@ private inline fun <reified T : Any> NavHostController.navigateBottomTabClearing
 ) {
     popRegionalGuideReentryToSourceRoot(currentBackStackEntry)
 
-    navigateBottomTab(route)
+    navigateBottomTab<T, ItemSearchRoute>(route)
 }
 
 private fun NavBackStackEntry?.isItemGuideDetailSource(source: ItemGuideDetailSource): Boolean =
@@ -127,7 +126,7 @@ private fun NavHostController.navigateRegionalGuideRoot(
 
     popRegionalGuideReentryToSourceRoot(currentBackStackEntry)
     navigate(RegionalGuideRoute()) {
-        popUpTo(graph.findStartDestination().id) {
+        popUpTo<ItemSearchRoute> {
             saveState = true
         }
         launchSingleTop = true
@@ -137,7 +136,7 @@ private fun NavHostController.navigateRegionalGuideRoot(
 
 private fun NavHostController.navigateItemSearchTab() {
     navigate(ItemSearchRoute()) {
-        popUpTo(graph.findStartDestination().id) {
+        popUpTo<ItemSearchRoute> {
             saveState = true
         }
         launchSingleTop = true
@@ -155,7 +154,7 @@ private fun NavHostController.navigateFavoritesRoot(
         }
         else -> {
             navigate(FavoritesRoute) {
-                popUpTo(graph.findStartDestination().id) {
+                popUpTo<ItemSearchRoute> {
                     saveState = true
                 }
                 launchSingleTop = true
@@ -175,7 +174,7 @@ private fun NavHostController.navigateMapRoot(
 
     if (currentBackStackEntry.isRegionalGuideSelected()) {
         navigate(MapRoute()) {
-            popUpTo(graph.findStartDestination().id) {
+            popUpTo<ItemSearchRoute> {
                 saveState = true
             }
             launchSingleTop = true

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavDestination.Companion.hasRoute
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -135,7 +134,7 @@ fun YeogiBeoryeoNavHost(
                     },
                     onCollectionSpotClick = { request ->
                         navController.navigate(request.toMapRoute()) {
-                            popUpTo(navController.graph.findStartDestination().id) {
+                            popUpTo<ItemSearchRoute> {
                                 saveState = true
                             }
                             launchSingleTop = true

--- a/common/src/main/java/com/team/yeogibeoryeo/common/navigation/NavControllerExtensions.kt
+++ b/common/src/main/java/com/team/yeogibeoryeo/common/navigation/NavControllerExtensions.kt
@@ -1,11 +1,10 @@
 package com.team.yeogibeoryeo.common.navigation
 
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 
-inline fun <reified T : Any> NavHostController.navigateBottomTab(route: T) {
+inline fun <reified T : Any, reified StartDestination : Any> NavHostController.navigateBottomTab(route: T) {
     navigate(route) {
-        popUpTo(graph.findStartDestination().id) {
+        popUpTo<StartDestination> {
             saveState = true
         }
         launchSingleTop = true


### PR DESCRIPTION
## 작업 내용
- 하단 탭 root 이동에서 `graph.findStartDestination().id` 기반 `popUpTo`를 제거했습니다.
- `navigateBottomTab()` 공통 helper가 시작 route 타입을 받도록 변경했습니다.
- 하단 탭과 즐겨찾기 → 지도 이동의 back stack 정리 기준을 `ItemSearchRoute` 타입으로 명시했습니다.

## 변경 이유
프로젝트는 이미 `@Serializable` route, `composable<Route>`, `toRoute<Route>()` 기반의 type-safe Navigation 구조를 사용하고 있습니다.

하단 탭 back stack 정리도 destination id가 아니라 route 타입으로 드러나도록 맞추면, 어떤 route를 기준으로 정리하는지 코드에서 더 명확하게 확인할 수 있습니다.

## 주요 변경 사항
- `NavControllerExtensions.navigateBottomTab()`
  - `popUpTo(graph.findStartDestination().id)`에서 `popUpTo<StartDestination>()`로 변경
- `BottomTabNavigation`
  - 하단 탭 root 이동 기준을 `popUpTo<ItemSearchRoute>()`로 변경
- `YeogiBeoryeoNavHost`
  - 즐겨찾기 수거 장소 → 지도 이동의 `popUpTo` 기준을 `ItemSearchRoute` 타입으로 변경

## 확인 사항
- 기존 `saveState`, `restoreState`, `launchSingleTop` 값은 유지했습니다.
- `app/src/main/java`, `common/src/main/java` 기준 `findStartDestination().id` 사용 위치가 남지 않는 것을 확인했습니다.

## 테스트
- `:app:compileDebugKotlin :common:compileDebugKotlin`
- `:app:testDebugUnitTest --tests com.team.yeogibeoryeo.navigation.RegionalGuideRouteNavigationPolicyTest`

## 관련 이슈
Related #191
