### PR TITLE
[Feature] 홈 분류 표시 항목 관리 추가

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
@@ -42,6 +42,11 @@ data class ItemSearchRoute(
 )
 
 @Serializable
+data class QuickCategorySettingsRoute(
+    val maxSelectedCount: Int,
+)
+
+@Serializable
 data class ItemUsefulGuideRoute(
     val guideType: String,
 )

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/BottomTabNavigation.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/BottomTabNavigation.kt
@@ -58,6 +58,7 @@ internal fun NavHostController.createBottomNavigationItems(
 
 private fun NavBackStackEntry?.isItemSearchSelected(): Boolean =
     this?.destination?.hasRoute<ItemSearchRoute>() == true ||
+        this?.destination?.hasRoute<QuickCategorySettingsRoute>() == true ||
         isItemGuideDetailSource(ItemGuideDetailSource.SEARCH)
 
 private fun NavBackStackEntry?.isFavoritesSelected(): Boolean =

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -38,6 +38,7 @@ import com.team.yeogibeoryeo.presentation.regionalguide.RegionalGuideRoute as Re
 import com.team.yeogibeoryeo.presentation.search.ItemGuideDetailRoute as ItemGuideDetailScreenRoute
 import com.team.yeogibeoryeo.presentation.search.ItemSearchRoute as ItemSearchScreenRoute
 import com.team.yeogibeoryeo.presentation.search.ItemUsefulGuideRoute as ItemUsefulGuideScreenRoute
+import com.team.yeogibeoryeo.presentation.search.QuickCategorySettingsRoute as QuickCategorySettingsScreenRoute
 import com.team.yeogibeoryeo.presentation.search.model.ItemUsefulGuideType
 
 @Composable
@@ -175,6 +176,19 @@ fun YeogiBeoryeoNavHost(
                             ),
                         )
                     },
+                    onQuickCategorySettingsClick = { maxSelectedCount ->
+                        navController.navigate(
+                            QuickCategorySettingsRoute(maxSelectedCount = maxSelectedCount),
+                        )
+                    },
+                )
+            }
+
+            composable<QuickCategorySettingsRoute> { backStackEntry ->
+                val route = backStackEntry.toRoute<QuickCategorySettingsRoute>()
+                QuickCategorySettingsScreenRoute(
+                    maxSelectedCount = route.maxSelectedCount,
+                    onBackClick = navController::popBackStack,
                 )
             }
 

--- a/data/src/main/java/com/team/yeogibeoryeo/data/item/di/ItemBindModule.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/item/di/ItemBindModule.kt
@@ -2,8 +2,10 @@ package com.team.yeogibeoryeo.data.item.di
 
 import com.team.yeogibeoryeo.data.item.local.ItemCategoryLocalDataSource
 import com.team.yeogibeoryeo.data.item.local.ItemCategoryLocalSource
+import com.team.yeogibeoryeo.data.item.repository.DataStoreHomeQuickCategoryRepository
 import com.team.yeogibeoryeo.data.item.repository.DisposalItemGuideRepositoryImpl
 import com.team.yeogibeoryeo.domain.item.repository.DisposalItemGuideRepository
+import com.team.yeogibeoryeo.domain.item.repository.HomeQuickCategoryRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -24,4 +26,10 @@ abstract class ItemBindModule {
     abstract fun bindDisposalItemGuideRepository(
         repository: DisposalItemGuideRepositoryImpl,
     ): DisposalItemGuideRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindHomeQuickCategoryRepository(
+        repository: DataStoreHomeQuickCategoryRepository,
+    ): HomeQuickCategoryRepository
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/item/di/ItemPreferencesDataModule.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/item/di/ItemPreferencesDataModule.kt
@@ -1,0 +1,33 @@
+package com.team.yeogibeoryeo.data.item.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ItemPreferencesDataStore
+
+private val Context.itemPreferencesDataStore by preferencesDataStore(
+    name = "item_preferences",
+)
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ItemPreferencesDataModule {
+
+    @Provides
+    @Singleton
+    @ItemPreferencesDataStore
+    fun provideItemPreferencesDataStore(
+        @ApplicationContext context: Context,
+    ): DataStore<Preferences> = context.itemPreferencesDataStore
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/item/repository/DataStoreHomeQuickCategoryRepository.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/item/repository/DataStoreHomeQuickCategoryRepository.kt
@@ -1,0 +1,88 @@
+package com.team.yeogibeoryeo.data.item.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.team.yeogibeoryeo.data.item.di.ItemPreferencesDataStore
+import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
+import com.team.yeogibeoryeo.domain.item.repository.HomeQuickCategoryRepository
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+
+class DataStoreHomeQuickCategoryRepository
+    @Inject
+    constructor(
+        @param:ItemPreferencesDataStore private val dataStore: DataStore<Preferences>,
+    ) : HomeQuickCategoryRepository {
+        override fun observeHomeQuickCategories(): Flow<List<DisposalCategory>> =
+            dataStore.data
+                .catch { exception ->
+                    if (exception is CancellationException) throw exception
+                    emit(emptyPreferences())
+                }
+                .map { preferences ->
+                    preferences[HOME_QUICK_CATEGORIES_KEY].toCategories()
+                }
+
+        override suspend fun toggleHomeQuickCategory(
+            category: DisposalCategory,
+            maxSelectedCount: Int,
+        ) {
+            val boundedMaxSelectedCount = maxSelectedCount.coerceAtLeast(0)
+
+            try {
+                dataStore.edit { preferences ->
+                    val current = preferences[HOME_QUICK_CATEGORIES_KEY].toCategories()
+                    val updated =
+                        if (category in current) {
+                            current - category
+                        } else if (current.size >= boundedMaxSelectedCount) {
+                            current
+                        } else {
+                            current + category
+                        }
+
+                    preferences[HOME_QUICK_CATEGORIES_KEY] = updated.joinToString(CategorySeparator) { it.name }
+                }
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                // 저장 실패 시 현재 값 유지
+            }
+        }
+
+        override suspend fun limitHomeQuickCategories(maxSelectedCount: Int) {
+            val boundedMaxSelectedCount = maxSelectedCount.coerceAtLeast(0)
+
+            try {
+                dataStore.edit { preferences ->
+                    val current = preferences[HOME_QUICK_CATEGORIES_KEY].toCategories()
+                    preferences[HOME_QUICK_CATEGORIES_KEY] =
+                        current
+                            .take(boundedMaxSelectedCount)
+                            .joinToString(CategorySeparator) { it.name }
+                }
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                // 저장 실패 시 현재 값 유지
+            }
+        }
+
+        private fun String?.toCategories(): List<DisposalCategory> =
+            this
+                ?.split(CategorySeparator)
+                ?.mapNotNull { name -> DisposalCategory.entries.firstOrNull { it.name == name } }
+                ?.distinct()
+                .orEmpty()
+
+        private companion object {
+            const val CategorySeparator = ","
+            val HOME_QUICK_CATEGORIES_KEY = stringPreferencesKey("pinned_disposal_categories")
+        }
+    }

--- a/data/src/test/java/com/team/yeogibeoryeo/data/item/repository/DataStoreHomeQuickCategoryRepositoryTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/item/repository/DataStoreHomeQuickCategoryRepositoryTest.kt
@@ -1,0 +1,92 @@
+package com.team.yeogibeoryeo.data.item.repository
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DataStoreHomeQuickCategoryRepositoryTest {
+
+    @Test
+    fun `저장된 분류가 없으면 빈 목록을 반환한다`() =
+        runBlocking {
+            withRepository { repository ->
+                assertEquals(emptyList<DisposalCategory>(), repository.observeHomeQuickCategories().first())
+            }
+        }
+
+    @Test
+    fun `분류를 토글하면 선택 상태를 저장하고 다시 토글하면 제거한다`() =
+        runBlocking {
+            withRepository { repository ->
+                repository.toggleHomeQuickCategory(DisposalCategory.BATTERY, maxSelectedCount = 2)
+
+                assertEquals(
+                    listOf(DisposalCategory.BATTERY),
+                    repository.observeHomeQuickCategories().first(),
+                )
+
+                repository.toggleHomeQuickCategory(DisposalCategory.BATTERY, maxSelectedCount = 2)
+
+                assertEquals(emptyList<DisposalCategory>(), repository.observeHomeQuickCategories().first())
+            }
+        }
+
+    @Test
+    fun `최대 개수에 도달하면 새 분류를 추가하지 않는다`() =
+        runBlocking {
+            withRepository { repository ->
+                repository.toggleHomeQuickCategory(DisposalCategory.BATTERY, maxSelectedCount = 1)
+                repository.toggleHomeQuickCategory(DisposalCategory.ELECTRONICS, maxSelectedCount = 1)
+
+                assertEquals(
+                    listOf(DisposalCategory.BATTERY),
+                    repository.observeHomeQuickCategories().first(),
+                )
+            }
+        }
+
+    @Test
+    fun `표시 개수를 제한하면 앞에서부터 지정한 개수만 유지한다`() =
+        runBlocking {
+            withRepository { repository ->
+                repository.toggleHomeQuickCategory(DisposalCategory.BATTERY, maxSelectedCount = 2)
+                repository.toggleHomeQuickCategory(DisposalCategory.ELECTRONICS, maxSelectedCount = 2)
+
+                repository.limitHomeQuickCategories(maxSelectedCount = 1)
+
+                assertEquals(
+                    listOf(DisposalCategory.BATTERY),
+                    repository.observeHomeQuickCategories().first(),
+                )
+            }
+        }
+
+    private suspend fun withRepository(
+        block: suspend (DataStoreHomeQuickCategoryRepository) -> Unit,
+    ) {
+        val file = File.createTempFile("home-quick-category", ".preferences_pb")
+        file.delete()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val dataStore =
+            PreferenceDataStoreFactory.create(
+                scope = scope,
+                produceFile = { file },
+            )
+        val repository = DataStoreHomeQuickCategoryRepository(dataStore)
+
+        try {
+            block(repository)
+        } finally {
+            scope.cancel()
+            file.delete()
+        }
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/item/repository/HomeQuickCategoryRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/item/repository/HomeQuickCategoryRepository.kt
@@ -1,0 +1,15 @@
+package com.team.yeogibeoryeo.domain.item.repository
+
+import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
+import kotlinx.coroutines.flow.Flow
+
+interface HomeQuickCategoryRepository {
+    fun observeHomeQuickCategories(): Flow<List<DisposalCategory>>
+
+    suspend fun toggleHomeQuickCategory(
+        category: DisposalCategory,
+        maxSelectedCount: Int,
+    )
+
+    suspend fun limitHomeQuickCategories(maxSelectedCount: Int)
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/item/usecase/LimitHomeQuickCategoriesUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/item/usecase/LimitHomeQuickCategoriesUseCase.kt
@@ -1,0 +1,14 @@
+package com.team.yeogibeoryeo.domain.item.usecase
+
+import com.team.yeogibeoryeo.domain.item.repository.HomeQuickCategoryRepository
+import javax.inject.Inject
+
+class LimitHomeQuickCategoriesUseCase
+    @Inject
+    constructor(
+        private val repository: HomeQuickCategoryRepository,
+    ) {
+        suspend operator fun invoke(maxSelectedCount: Int) {
+            repository.limitHomeQuickCategories(maxSelectedCount)
+        }
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/item/usecase/ObserveHomeQuickCategoriesUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/item/usecase/ObserveHomeQuickCategoriesUseCase.kt
@@ -1,0 +1,14 @@
+package com.team.yeogibeoryeo.domain.item.usecase
+
+import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
+import com.team.yeogibeoryeo.domain.item.repository.HomeQuickCategoryRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+
+class ObserveHomeQuickCategoriesUseCase
+    @Inject
+    constructor(
+        private val repository: HomeQuickCategoryRepository,
+    ) {
+        operator fun invoke(): Flow<List<DisposalCategory>> = repository.observeHomeQuickCategories()
+    }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/item/usecase/ToggleHomeQuickCategoryUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/item/usecase/ToggleHomeQuickCategoryUseCase.kt
@@ -1,0 +1,17 @@
+package com.team.yeogibeoryeo.domain.item.usecase
+
+import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
+import com.team.yeogibeoryeo.domain.item.repository.HomeQuickCategoryRepository
+import javax.inject.Inject
+
+class ToggleHomeQuickCategoryUseCase
+    @Inject
+    constructor(
+        private val repository: HomeQuickCategoryRepository,
+    ) {
+    suspend operator fun invoke(
+        category: DisposalCategory,
+        maxSelectedCount: Int,
+    ) =
+        repository.toggleHomeQuickCategory(category, maxSelectedCount)
+    }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
@@ -5,11 +5,17 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -18,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
@@ -31,8 +38,8 @@ import com.team.yeogibeoryeo.presentation.search.components.ItemUsefulGuideBanne
 import com.team.yeogibeoryeo.presentation.search.components.QuickCategoryGrid
 import com.team.yeogibeoryeo.presentation.search.model.HomeRegionalGuideSummaryUiState
 import com.team.yeogibeoryeo.presentation.search.model.ItemUsefulGuideContent
-import com.team.yeogibeoryeo.presentation.search.model.itemUsefulGuideContents
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
+import com.team.yeogibeoryeo.presentation.search.model.itemUsefulGuideContents
 
 @Composable
 fun ItemSearchInitialContent(
@@ -41,9 +48,13 @@ fun ItemSearchInitialContent(
     onSearchClick: () -> Unit,
     onUsefulGuideClick: (ItemUsefulGuideContent) -> Unit,
     regionalGuideSummaryState: HomeRegionalGuideSummaryUiState,
+    modifier: Modifier = Modifier,
     onRegionalGuideSummaryClick: (String) -> Unit = {},
     onRegionalGuideSummaryRetryClick: () -> Unit = {},
     onQuickCategoryClick: (RepresentativeGuideCategory) -> Unit,
+    onQuickCategorySettingsClick: (Int) -> Unit,
+    quickCategories: List<RepresentativeGuideCategory>,
+    selectedQuickCategories: Set<RepresentativeGuideCategory>,
     isQuickCategoryExpanded: Boolean,
     quickCategoryFixedCollapsedItemCount: Int,
     quickCategoryScrollRestoreIndex: Int,
@@ -53,9 +64,9 @@ fun ItemSearchInitialContent(
     onQuickCategoryCollapseClick: () -> Unit,
     onQuickCategoryViewportChanged: () -> Unit,
     listState: LazyListState,
-    modifier: Modifier = Modifier,
 ) {
     var viewportBottomInRootPx by rememberSaveable { mutableIntStateOf(0) }
+    var maxSelectedQuickCategoryCount by rememberSaveable { mutableIntStateOf(quickCategories.size) }
     var handledScrollRestoreVersion by rememberSaveable {
         mutableIntStateOf(quickCategoryScrollRestoreVersion)
     }
@@ -121,6 +132,14 @@ fun ItemSearchInitialContent(
             }
 
             item {
+                HomeRegionalGuideSummaryBanner(
+                    state = regionalGuideSummaryState,
+                    onClick = onRegionalGuideSummaryClick,
+                    onRetryClick = onRegionalGuideSummaryRetryClick,
+                )
+            }
+
+            item {
                 ItemSearchBar(
                     keyword = query,
                     onKeywordChange = onQueryChange,
@@ -132,24 +151,42 @@ fun ItemSearchInitialContent(
             }
 
             item {
-                HomeRegionalGuideSummaryBanner(
-                    state = regionalGuideSummaryState,
-                    onClick = onRegionalGuideSummaryClick,
-                    onRetryClick = onRegionalGuideSummaryRetryClick,
-                )
-            }
-
-            item {
                 Column(verticalArrangement = Arrangement.spacedBy(metrics.sectionVerticalSpace)) {
                     val quickCategoriesTitle = stringResource(R.string.quick_categories)
-                    KoreanLineBreakText(
-                        text = quickCategoriesTitle,
-                        style = MaterialTheme.typography.titleLarge.copy(
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface
-                        ),
-                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        KoreanLineBreakText(
+                            text = quickCategoriesTitle,
+                            style = MaterialTheme.typography.titleLarge.copy(
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onSurface
+                            ),
+                        )
+                        AssistChip(
+                            onClick = { onQuickCategorySettingsClick(maxSelectedQuickCategoryCount) },
+                            label = {
+                                Text(text = stringResource(R.string.quick_category_edit_action))
+                            },
+                            trailingIcon = {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                                    contentDescription = null,
+                                )
+                            },
+                            colors =
+                                AssistChipDefaults.assistChipColors(
+                                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                                    labelColor = MaterialTheme.colorScheme.primary,
+                                    trailingIconContentColor = MaterialTheme.colorScheme.primary,
+                                ),
+                        )
+                    }
                     QuickCategoryGrid(
+                        categories = quickCategories,
+                        selectedCategories = selectedQuickCategories,
                         onCategoryClick = onQuickCategoryClick,
                         isExpanded = isQuickCategoryExpanded,
                         fixedCollapsedItemCount = quickCategoryFixedCollapsedItemCount,
@@ -163,6 +200,7 @@ fun ItemSearchInitialContent(
                         onCollapseClick = onQuickCategoryCollapseClick,
                         screenHorizontalPadding = metrics.horizontalPadding,
                         viewportBottomInRootPx = viewportBottomInRootPx,
+                        onVisibleCategoryCountChange = { maxSelectedQuickCategoryCount = it },
                     )
                 }
             }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchLayoutDefaults.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchLayoutDefaults.kt
@@ -31,6 +31,9 @@ internal object ItemSearchSizeDefaults {
     val searchFieldHeight: Dp = 56.dp
     val categoryTile: Dp = 64.dp
     val categoryCell: Dp = 72.dp
+    val categorySelectionBadge: Dp = 18.dp
+    val categorySelectionBadgeIcon: Dp = 12.dp
+    val categorySelectionBadgeOffset: Dp = 4.dp
     val usefulGuideBannerCardHeight: Dp = 136.dp
     val usefulGuidePageIndicatorActiveWidth: Dp = 24.dp
     val usefulGuidePageIndicatorInactiveSize: Dp = 8.dp

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -44,6 +43,7 @@ fun ItemSearchRoute(
     onGuideSelected: (DisposalItemGuide) -> Unit,
     onUsefulGuideClick: (ItemUsefulGuideContent) -> Unit,
     onRegionalGuideSummaryClick: (String) -> Unit,
+    onQuickCategorySettingsClick: (Int) -> Unit,
     viewModel: ItemSearchViewModel = hiltViewModel(),
     regionalGuideSummaryViewModel: HomeRegionalGuideSummaryViewModel = hiltViewModel(),
 ) {
@@ -99,6 +99,7 @@ fun ItemSearchRoute(
         onQuickCategoryCollapseClick = viewModel::collapseQuickCategory,
         onQuickCategoryViewportChanged =
             viewModel::resetQuickCategoryFixedCollapsedItemCountIfCollapsed,
+        onQuickCategorySettingsClick = onQuickCategorySettingsClick,
         searchResultListState = searchResultListState,
         categoryListState = categoryListState,
     )
@@ -107,18 +108,19 @@ fun ItemSearchRoute(
 @Composable
 fun ItemSearchScreen(
     uiState: ItemSearchUiState,
-    regionalGuideSummaryState: HomeRegionalGuideSummaryUiState = HomeRegionalGuideSummaryUiState.NoFavorite,
     onQueryChange: (String) -> Unit,
     onSearchClick: () -> Unit,
     onGuideClick: (DisposalItemGuide) -> Unit,
+    onQuickCategoryClick: (RepresentativeGuideCategory) -> Unit,
+    modifier: Modifier = Modifier,
+    regionalGuideSummaryState: HomeRegionalGuideSummaryUiState = HomeRegionalGuideSummaryUiState.NoFavorite,
     onUsefulGuideClick: (ItemUsefulGuideContent) -> Unit = {},
     onRegionalGuideSummaryClick: (String) -> Unit = {},
     onRegionalGuideSummaryRetryClick: () -> Unit = {},
-    onQuickCategoryClick: (RepresentativeGuideCategory) -> Unit,
     onQuickCategoryMoreClick: (Int, Int, Int) -> Unit = { _, _, _ -> },
     onQuickCategoryCollapseClick: () -> Unit = {},
     onQuickCategoryViewportChanged: () -> Unit = {},
-    modifier: Modifier = Modifier,
+    onQuickCategorySettingsClick: (Int) -> Unit = {},
     searchResultListState: LazyListState = rememberLazyListState(),
     categoryListState: LazyListState = rememberLazyListState(),
 ) {
@@ -132,6 +134,9 @@ fun ItemSearchScreen(
             onRegionalGuideSummaryClick = onRegionalGuideSummaryClick,
             onRegionalGuideSummaryRetryClick = onRegionalGuideSummaryRetryClick,
             onQuickCategoryClick = onQuickCategoryClick,
+            onQuickCategorySettingsClick = onQuickCategorySettingsClick,
+            quickCategories = uiState.quickCategories,
+            selectedQuickCategories = uiState.homeQuickCategories.toSet(),
             isQuickCategoryExpanded = uiState.isQuickCategoryExpanded,
             quickCategoryFixedCollapsedItemCount =
                 uiState.quickCategoryFixedCollapsedItemCount,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchUiState.kt
@@ -2,6 +2,8 @@ package com.team.yeogibeoryeo.presentation.search
 
 import androidx.annotation.StringRes
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
+import com.team.yeogibeoryeo.presentation.search.components.orderedQuickCategories
+import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
 
 data class ItemSearchUiState(
     val query: String = "",
@@ -15,5 +17,10 @@ data class ItemSearchUiState(
     val quickCategoryScrollRestoreVersion: Int = 0,
     val isLoading: Boolean = false,
     val hasSearched: Boolean = false,
+    val homeQuickCategories: List<RepresentativeGuideCategory> = emptyList(),
     @param:StringRes val errorMessageResId: Int? = null,
-)
+) {
+    val quickCategories: List<RepresentativeGuideCategory>
+        get() =
+            orderedQuickCategories(homeQuickCategories)
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModel.kt
@@ -6,7 +6,10 @@ import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalCategoryGuidesUseCase
+import com.team.yeogibeoryeo.domain.item.usecase.LimitHomeQuickCategoriesUseCase
+import com.team.yeogibeoryeo.domain.item.usecase.ObserveHomeQuickCategoriesUseCase
 import com.team.yeogibeoryeo.domain.item.usecase.SearchDisposalItemGuidesUseCase
+import com.team.yeogibeoryeo.domain.item.usecase.ToggleHomeQuickCategoryUseCase
 import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -28,7 +31,10 @@ class ItemSearchViewModel
 constructor(
     private val searchDisposalItemGuidesUseCase: SearchDisposalItemGuidesUseCase,
     private val getDisposalCategoryGuidesUseCase: GetDisposalCategoryGuidesUseCase,
+    private val toggleHomeQuickCategoryUseCase: ToggleHomeQuickCategoryUseCase,
+    private val limitHomeQuickCategoriesUseCase: LimitHomeQuickCategoriesUseCase,
     observeFavoritesUseCase: ObserveFavoritesUseCase,
+    observeHomeQuickCategoriesUseCase: ObserveHomeQuickCategoriesUseCase,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(ItemSearchUiState())
     val uiState: StateFlow<ItemSearchUiState> = _uiState.asStateFlow()
@@ -46,6 +52,17 @@ constructor(
                                 favorites
                                     .map { it.targetId }
                                     .toSet(),
+                        )
+                    }
+                }
+        }
+        viewModelScope.launch {
+            observeHomeQuickCategoriesUseCase()
+                .collect { categories ->
+                    _uiState.update { state ->
+                        state.copy(
+                            homeQuickCategories =
+                                categories.map(RepresentativeGuideCategory::fromDisposalCategory),
                         )
                     }
                 }
@@ -187,6 +204,21 @@ constructor(
             } else {
                 it.copy(quickCategoryFixedCollapsedItemCount = 0)
             }
+        }
+    }
+
+    fun toggleHomeQuickCategory(
+        category: RepresentativeGuideCategory,
+        maxSelectedCount: Int,
+    ) {
+        viewModelScope.launch {
+            toggleHomeQuickCategoryUseCase(category.disposalCategory, maxSelectedCount)
+        }
+    }
+
+    fun limitHomeQuickCategories(maxSelectedCount: Int) {
+        viewModelScope.launch {
+            limitHomeQuickCategoriesUseCase(maxSelectedCount)
         }
     }
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/QuickCategorySettingsRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/QuickCategorySettingsRoute.kt
@@ -1,0 +1,328 @@
+package com.team.yeogibeoryeo.presentation.search
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.team.yeogibeoryeo.common.R as CommonR
+import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.search.components.containerColor
+import com.team.yeogibeoryeo.presentation.search.components.iconResId
+import com.team.yeogibeoryeo.presentation.search.components.iconTint
+import com.team.yeogibeoryeo.presentation.search.components.quickCategoryOrder
+import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
+
+@Composable
+fun QuickCategorySettingsRoute(
+    maxSelectedCount: Int,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ItemSearchViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val boundedMaxSelectedCount = maxSelectedCount.coerceAtLeast(0)
+    val selectedCategories = uiState.homeQuickCategories.take(boundedMaxSelectedCount).toSet()
+
+    LaunchedEffect(boundedMaxSelectedCount) {
+        viewModel.limitHomeQuickCategories(boundedMaxSelectedCount)
+    }
+
+    QuickCategorySettingsScreen(
+        selectedCategories = selectedCategories,
+        maxSelectedCount = boundedMaxSelectedCount,
+        onCategoryClick = { category ->
+            viewModel.toggleHomeQuickCategory(category, boundedMaxSelectedCount)
+        },
+        onBackClick = onBackClick,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun QuickCategorySettingsScreen(
+    selectedCategories: Set<RepresentativeGuideCategory>,
+    maxSelectedCount: Int,
+    onCategoryClick: (RepresentativeGuideCategory) -> Unit,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+    var keyword by rememberSaveable { mutableStateOf("") }
+    val categories =
+        quickCategoryOrder.filter { category ->
+            keyword.isBlank() ||
+                category.displayName.contains(keyword, ignoreCase = true) ||
+                category.representativeGuideName.contains(keyword, ignoreCase = true)
+        }
+
+    Scaffold(
+        modifier = modifier,
+        contentWindowInsets = WindowInsets(0.dp),
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.quick_category_settings_title),
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            painter = painterResource(id = CommonR.drawable.ic_action_back),
+                            contentDescription = stringResource(R.string.back_action),
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                ),
+            )
+        },
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(innerPadding)
+                .padding(horizontal = spacing.xl),
+            contentPadding = PaddingValues(bottom = spacing.xxl),
+            verticalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+                    Text(
+                        text = stringResource(R.string.quick_category_settings_description),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    OutlinedTextField(
+                        value = keyword,
+                        onValueChange = { keyword = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = MaterialTheme.shapes.extraLarge,
+                        placeholder = {
+                            Text(text = stringResource(R.string.quick_category_search_placeholder))
+                        },
+                        singleLine = true,
+                        trailingIcon = {
+                            Icon(
+                                imageVector = Icons.Filled.Search,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        },
+                    )
+                    SelectedCategorySummary(
+                        selectedCount = selectedCategories.size,
+                        maxSelectedCount = maxSelectedCount,
+                    )
+                }
+            }
+
+            items(categories, key = { it.name }) { category ->
+                val isSelected = category in selectedCategories
+                val canSelect = isSelected || selectedCategories.size < maxSelectedCount
+
+                QuickCategoryDisplayRow(
+                    category = category,
+                    isSelected = isSelected,
+                    enabled = canSelect,
+                    onClick = {
+                        if (canSelect) {
+                            onCategoryClick(category)
+                        }
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SelectedCategorySummary(
+    selectedCount: Int,
+    maxSelectedCount: Int,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.secondaryContainer,
+    ) {
+        Text(
+            text = stringResource(R.string.quick_category_selected_count, selectedCount, maxSelectedCount),
+            modifier = Modifier.padding(horizontal = spacing.md, vertical = spacing.xs),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+    }
+}
+
+@Composable
+private fun QuickCategoryDisplayRow(
+    category: RepresentativeGuideCategory,
+    isSelected: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spacing = ItemSearchLayoutDefaults.spacing
+    val size = ItemSearchLayoutDefaults.size
+    val colorScheme = MaterialTheme.colorScheme
+
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .toggleable(
+                value = isSelected,
+                enabled = enabled,
+                role = Role.Checkbox,
+                onValueChange = { onClick() },
+            ),
+        shape = MaterialTheme.shapes.large,
+        color =
+            if (isSelected) {
+                colorScheme.secondaryContainer
+            } else {
+                colorScheme.surface
+            },
+        border = BorderStroke(
+            width = ItemSearchLayoutDefaults.stroke.outline,
+            color =
+                if (isSelected) {
+                    colorScheme.outline
+                } else {
+                    colorScheme.outlineVariant
+                },
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(spacing.sm),
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(QuickCategoryIconContainerSize)
+                    .background(
+                        color = category.containerColor(),
+                        shape = MaterialTheme.shapes.medium,
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    painter = painterResource(id = category.iconResId),
+                    contentDescription = null,
+                    modifier = Modifier.size(size.iconStandard),
+                    tint = category.iconTint(),
+                )
+            }
+            Text(
+                text = category.displayName,
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                color =
+                    if (isSelected) {
+                        colorScheme.onSecondaryContainer
+                    } else {
+                        colorScheme.onSurface
+                    },
+            )
+            SelectionIndicator(isSelected = isSelected, enabled = enabled)
+        }
+    }
+}
+
+@Composable
+private fun SelectionIndicator(
+    isSelected: Boolean,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val colorScheme = MaterialTheme.colorScheme
+
+    Surface(
+        modifier = modifier.size(QuickCategorySelectionControlSize),
+        shape = MaterialTheme.shapes.extraLarge,
+        color =
+            if (isSelected) {
+                colorScheme.primary
+            } else {
+                colorScheme.surface
+            },
+        border =
+            if (isSelected) {
+                null
+            } else {
+                BorderStroke(
+                    width = ItemSearchLayoutDefaults.stroke.outline,
+                    color =
+                        if (enabled) {
+                            colorScheme.outline
+                        } else {
+                            colorScheme.outlineVariant
+                        },
+                )
+            },
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            if (isSelected) {
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = null,
+                    modifier = Modifier.size(ItemSearchLayoutDefaults.size.iconSmall),
+                    tint = colorScheme.onPrimary,
+                )
+            }
+        }
+    }
+}
+
+private val QuickCategoryIconContainerSize = 44.dp
+private val QuickCategorySelectionControlSize = 28.dp

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
@@ -1,5 +1,6 @@
 package com.team.yeogibeoryeo.presentation.search.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.relocation.BringIntoViewRequester
@@ -9,13 +10,17 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -47,15 +52,17 @@ import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCatego
 
 @Composable
 fun QuickCategoryGrid(
-    categories: List<RepresentativeGuideCategory> = quickCategoryOrder,
     onCategoryClick: (RepresentativeGuideCategory) -> Unit,
     modifier: Modifier = Modifier,
+    categories: List<RepresentativeGuideCategory> = quickCategoryOrder,
+    selectedCategories: Set<RepresentativeGuideCategory> = emptySet(),
     screenHorizontalPadding: Dp = 0.dp,
     viewportBottomInRootPx: Int = 0,
     isExpanded: Boolean = true,
     fixedCollapsedItemCount: Int = 0,
     onMoreClick: (Int) -> Unit = {},
     onCollapseClick: () -> Unit = {},
+    onVisibleCategoryCountChange: (Int) -> Unit = {},
     itemContent: @Composable (
         category: RepresentativeGuideCategory,
         onClick: () -> Unit,
@@ -63,6 +70,7 @@ fun QuickCategoryGrid(
         QuickCategoryItem(
             category = category,
             name = category.quickCategoryLabel,
+            isSelected = category in selectedCategories,
             onClick = onClick,
         )
     },
@@ -117,6 +125,16 @@ fun QuickCategoryGrid(
             } else {
                 categories
             }
+        val collapsedVisibleCategoryCount =
+            if (categories.size > collapseLayout.collapsedItemCount) {
+                (collapseLayout.collapsedItemCount - 1).coerceAtLeast(0)
+            } else {
+                categories.size
+            }
+
+        LaunchedEffect(collapsedVisibleCategoryCount) {
+            onVisibleCategoryCountChange(collapsedVisibleCategoryCount)
+        }
         val gridItems =
             buildList {
                 addAll(visibleCategories.map(QuickCategoryGridItem::Category))
@@ -296,10 +314,10 @@ private sealed interface QuickCategoryGridItem {
 internal fun QuickCategoryItem(
     category: RepresentativeGuideCategory,
     name: String,
+    isSelected: Boolean = false,
     onClick: () -> Unit,
     onLabelTextLayout: (TextLayoutResult) -> Unit = {},
 ) {
-    val spacing = ItemSearchLayoutDefaults.spacing
     val size = ItemSearchLayoutDefaults.size
     val metrics = LocalQuickCategoryGridMetrics.current
     val clickActionLabel = stringResource(R.string.quick_category_click_action)
@@ -335,6 +353,32 @@ internal fun QuickCategoryItem(
                 modifier = Modifier.size(metrics.iconSize),
                 tint = category.iconTint()
             )
+            if (isSelected) {
+                Surface(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .offset(
+                            x = size.categorySelectionBadgeOffset,
+                            y = -size.categorySelectionBadgeOffset,
+                        )
+                        .size(size.categorySelectionBadge),
+                    shape = MaterialTheme.shapes.extraLarge,
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    border = BorderStroke(
+                        width = ItemSearchLayoutDefaults.stroke.outline,
+                        color = MaterialTheme.colorScheme.primary,
+                    ),
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            imageVector = Icons.Filled.Check,
+                            contentDescription = null,
+                            modifier = Modifier.size(size.categorySelectionBadgeIcon),
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                }
+            }
         }
         Text(
             text = name.withKoreanLineBreakOpportunities(),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridOrder.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridOrder.kt
@@ -24,3 +24,11 @@ internal val quickCategoryOrder =
         RepresentativeGuideCategory.HAZARDOUS,
         RepresentativeGuideCategory.OTHER,
     )
+
+internal fun orderedQuickCategories(
+    selectedCategories: List<RepresentativeGuideCategory>,
+): List<RepresentativeGuideCategory> {
+    val selected = selectedCategories.distinct().filter { it in quickCategoryOrder }
+
+    return selected + quickCategoryOrder.filterNot { it in selected }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/model/RepresentativeGuideCategory.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/model/RepresentativeGuideCategory.kt
@@ -34,26 +34,6 @@ enum class RepresentativeGuideCategory(
             entries.firstOrNull { it.representativeGuideName == name }
 
         fun fromDisposalCategory(category: DisposalCategory): RepresentativeGuideCategory =
-            when (category) {
-                DisposalCategory.PAPER -> PAPER
-                DisposalCategory.PAPER_PACK -> PAPER_PACK
-                DisposalCategory.COLORLESS_PET -> COLORLESS_PET
-                DisposalCategory.GLASS -> GLASS
-                DisposalCategory.METAL -> METAL
-                DisposalCategory.PLASTIC -> PLASTIC
-                DisposalCategory.STYROFOAM -> STYROFOAM
-                DisposalCategory.VINYL -> VINYL
-                DisposalCategory.FOOD_WASTE -> FOOD_WASTE
-                DisposalCategory.LARGE_WASTE -> LARGE_WASTE
-                DisposalCategory.ELECTRONICS -> ELECTRONICS
-                DisposalCategory.BATTERY -> BATTERY
-                DisposalCategory.LIGHTING -> LIGHTING
-                DisposalCategory.CLOTHING -> CLOTHING
-                DisposalCategory.HAZARDOUS -> HAZARDOUS
-                DisposalCategory.NON_COMBUSTIBLE -> NON_COMBUSTIBLE
-                DisposalCategory.CONSTRUCTION_WASTE -> CONSTRUCTION_WASTE
-                DisposalCategory.GENERAL -> GENERAL
-                DisposalCategory.OTHER -> OTHER
-            }
+            entries.first { it.disposalCategory == category }
     }
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -11,6 +11,11 @@
     <string name="quick_categories">분리배출 분류</string>
     <string name="quick_category_more_action">더보기</string>
     <string name="quick_category_collapse_action">접기</string>
+    <string name="quick_category_edit_action">표시 항목 관리</string>
+    <string name="quick_category_settings_title">분리배출 분류 편집</string>
+    <string name="quick_category_settings_description">홈에 표시할 분리배출 분류를 선택하세요.</string>
+    <string name="quick_category_search_placeholder">분류 또는 품목 검색</string>
+    <string name="quick_category_selected_count">홈에 표시할 분류 %1$d/%2$d개 선택됨</string>
     <string name="item_useful_guide_section_title">안내 사항</string>
     <string name="item_useful_guide_small_e_waste_label">지도</string>
     <string name="item_useful_guide_small_e_waste_title">중소형 폐가전 수거함 안내</string>

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModelTest.kt
@@ -8,9 +8,14 @@ import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
 import com.team.yeogibeoryeo.domain.item.model.DisposalInstruction
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.domain.item.repository.DisposalItemGuideRepository
+import com.team.yeogibeoryeo.domain.item.repository.HomeQuickCategoryRepository
 import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalCategoryGuidesUseCase
+import com.team.yeogibeoryeo.domain.item.usecase.LimitHomeQuickCategoriesUseCase
+import com.team.yeogibeoryeo.domain.item.usecase.ObserveHomeQuickCategoriesUseCase
 import com.team.yeogibeoryeo.domain.item.usecase.SearchDisposalItemGuidesUseCase
+import com.team.yeogibeoryeo.domain.item.usecase.ToggleHomeQuickCategoryUseCase
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.search.components.quickCategoryOrder
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
@@ -331,14 +336,130 @@ class ItemSearchViewModelTest {
             assertEquals(setOf("유리병"), viewModel.uiState.value.favoriteGuideIds)
         }
 
+    @Test
+    fun `홈 표시 분류를 상태에 반영한다`() =
+        runTest {
+            val homeQuickCategoryRepository =
+                FakeHomeQuickCategoryRepository(
+                    initialCategories = listOf(DisposalCategory.ELECTRONICS),
+                )
+            val viewModel = createViewModel(
+                repository = FakeRepository(),
+                homeQuickCategoryRepository = homeQuickCategoryRepository,
+            )
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(RepresentativeGuideCategory.ELECTRONICS),
+                viewModel.uiState.value.homeQuickCategories,
+            )
+        }
+
+    @Test
+    fun `선택한 분류가 없으면 홈 빠른 분류는 기본 순서를 노출한다`() {
+        val uiState = ItemSearchUiState()
+
+        assertEquals(quickCategoryOrder, uiState.quickCategories)
+    }
+
+    @Test
+    fun `선택한 분류가 있으면 홈 빠른 분류는 선택한 분류를 앞에 노출한다`() {
+        val selectedCategories =
+            listOf(
+                RepresentativeGuideCategory.ELECTRONICS,
+                RepresentativeGuideCategory.BATTERY,
+            )
+
+        val uiState = ItemSearchUiState(homeQuickCategories = selectedCategories)
+
+        assertEquals(selectedCategories, uiState.quickCategories.take(selectedCategories.size))
+        assertEquals(quickCategoryOrder.size, uiState.quickCategories.size)
+    }
+
+    @Test
+    fun `홈 표시 분류 토글 시 저장소에 분류를 전달한다`() =
+        runTest {
+            val homeQuickCategoryRepository = FakeHomeQuickCategoryRepository()
+            val viewModel = createViewModel(
+                repository = FakeRepository(),
+                homeQuickCategoryRepository = homeQuickCategoryRepository,
+            )
+
+            viewModel.toggleHomeQuickCategory(
+                category = RepresentativeGuideCategory.BATTERY,
+                maxSelectedCount = 1,
+            )
+            advanceUntilIdle()
+
+            assertEquals(listOf(DisposalCategory.BATTERY), homeQuickCategoryRepository.toggledHomeQuickCategories)
+            assertEquals(
+                listOf(RepresentativeGuideCategory.BATTERY),
+                viewModel.uiState.value.homeQuickCategories,
+            )
+        }
+
+    @Test
+    fun `홈 표시 분류 토글 시 최대 개수 이상 추가하지 않는다`() =
+        runTest {
+            val homeQuickCategoryRepository =
+                FakeHomeQuickCategoryRepository(
+                    initialCategories = listOf(DisposalCategory.BATTERY),
+                )
+            val viewModel = createViewModel(
+                repository = FakeRepository(),
+                homeQuickCategoryRepository = homeQuickCategoryRepository,
+            )
+            advanceUntilIdle()
+
+            viewModel.toggleHomeQuickCategory(
+                category = RepresentativeGuideCategory.ELECTRONICS,
+                maxSelectedCount = 1,
+            )
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(RepresentativeGuideCategory.BATTERY),
+                viewModel.uiState.value.homeQuickCategories,
+            )
+        }
+
+    @Test
+    fun `홈 표시 분류 제한 시 앞에서부터 최대 개수만 유지한다`() =
+        runTest {
+            val homeQuickCategoryRepository =
+                FakeHomeQuickCategoryRepository(
+                    initialCategories = listOf(
+                        DisposalCategory.BATTERY,
+                        DisposalCategory.ELECTRONICS,
+                    ),
+                )
+            val viewModel = createViewModel(
+                repository = FakeRepository(),
+                homeQuickCategoryRepository = homeQuickCategoryRepository,
+            )
+            advanceUntilIdle()
+
+            viewModel.limitHomeQuickCategories(maxSelectedCount = 1)
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(RepresentativeGuideCategory.BATTERY),
+                viewModel.uiState.value.homeQuickCategories,
+            )
+        }
+
     private fun createViewModel(
         repository: FakeRepository,
         favoriteRepository: FakeFavoriteRepository = FakeFavoriteRepository(),
+        homeQuickCategoryRepository: FakeHomeQuickCategoryRepository = FakeHomeQuickCategoryRepository(),
     ) =
         ItemSearchViewModel(
             SearchDisposalItemGuidesUseCase(repository),
             GetDisposalCategoryGuidesUseCase(repository),
+            ToggleHomeQuickCategoryUseCase(homeQuickCategoryRepository),
+            LimitHomeQuickCategoriesUseCase(homeQuickCategoryRepository),
             ObserveFavoritesUseCase(favoriteRepository),
+            ObserveHomeQuickCategoriesUseCase(homeQuickCategoryRepository),
         )
 
     private fun sampleGuide(name: String): DisposalItemGuide =
@@ -422,6 +543,33 @@ class ItemSearchViewModelTest {
         ) {
             favorites.value =
                 favorites.value.filterNot { it.type == type && it.targetId == targetId }
+        }
+    }
+
+    private class FakeHomeQuickCategoryRepository(
+        initialCategories: List<DisposalCategory> = emptyList(),
+    ) : HomeQuickCategoryRepository {
+        private val categories = MutableStateFlow(initialCategories)
+        val toggledHomeQuickCategories = mutableListOf<DisposalCategory>()
+
+        override fun observeHomeQuickCategories(): Flow<List<DisposalCategory>> = categories
+
+        override suspend fun toggleHomeQuickCategory(
+            category: DisposalCategory,
+            maxSelectedCount: Int,
+        ) {
+            toggledHomeQuickCategories += category
+            if (category in categories.value) {
+                categories.value = categories.value - category
+            } else if (categories.value.size >= maxSelectedCount.coerceAtLeast(0)) {
+                return
+            } else {
+                categories.value = categories.value + category
+            }
+        }
+
+        override suspend fun limitHomeQuickCategories(maxSelectedCount: Int) {
+            categories.value = categories.value.take(maxSelectedCount.coerceAtLeast(0))
         }
     }
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridOrderTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridOrderTest.kt
@@ -1,0 +1,38 @@
+package com.team.yeogibeoryeo.presentation.search.components
+
+import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class QuickCategoryGridOrderTest {
+
+    @Test
+    fun `홈 표시 분류를 기존 순서보다 앞에 배치한다`() {
+        val categories =
+            orderedQuickCategories(
+                listOf(
+                    RepresentativeGuideCategory.ELECTRONICS,
+                    RepresentativeGuideCategory.BATTERY,
+                ),
+            )
+
+        assertEquals(RepresentativeGuideCategory.ELECTRONICS, categories[0])
+        assertEquals(RepresentativeGuideCategory.BATTERY, categories[1])
+        assertEquals(quickCategoryOrder.size, categories.size)
+    }
+
+    @Test
+    fun `중복 홈 표시 분류는 한 번만 배치한다`() {
+        val categories =
+            orderedQuickCategories(
+                listOf(
+                    RepresentativeGuideCategory.BATTERY,
+                    RepresentativeGuideCategory.BATTERY,
+                ),
+            )
+
+        assertEquals(RepresentativeGuideCategory.BATTERY, categories[0])
+        assertEquals(1, categories.count { it == RepresentativeGuideCategory.BATTERY })
+        assertEquals(quickCategoryOrder.size, categories.size)
+    }
+}


### PR DESCRIPTION
## 관련 이슈

Related #188

## 작업 내용

- 홈 빠른 분류 표시 항목을 저장하는 DataStore 기반 저장소를 추가했습니다.
- 홈 빠른 분류 편집 화면을 추가하고, 선택한 분류를 홈 빠른 분류 앞쪽에 노출하도록 연결했습니다.
- 화면에서 실제로 보이는 분류 개수에 맞춰 선택 가능한 최대 개수를 제한했습니다.
- 선택 상태 표시와 분류 정렬, 저장소 동작을 테스트로 보호했습니다.

## 변경 이유

PR #187에서 홈 빠른 분류의 adaptive 노출 흐름이 정리되어, 이번 PR에서는 사용자가 홈에 우선 표시할 분류를 직접 관리할 수 있도록 별도 설정 흐름과 저장 상태를 추가했습니다.

## 확인 사항

- 고정 분류가 없으면 기존 대표 분류 순서를 유지합니다.
- 고정 분류가 있으면 선택한 분류를 먼저 보여주고, 남은 항목은 기존 대표 분류 순서로 채웁니다.
- 홈 빠른 분류 편집 화면의 디자인과 선택 흐름을 함께 확인해 주세요.

https://github.com/user-attachments/assets/c21bf248-d9c1-4a6c-b4ab-19b0b2edae8a


## 테스트

- `:data:testDebugUnitTest`
- `:presentation:testDebugUnitTest`
- `:presentation:compileDebugKotlin`
- `:app:compileDebugKotlin`
- `:data:compileDebugKotlin`
- `:domain:compileKotlin`
- `git diff --check`




