### PR TITLE
feat: 지역 가이드 도로명 주소 직접 검색 지원

### DIFF
--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ClassifyRegionSearchInputUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/usecase/ClassifyRegionSearchInputUseCase.kt
@@ -1,0 +1,109 @@
+package com.team.yeogibeoryeo.domain.region.usecase
+
+import javax.inject.Inject
+
+class ClassifyRegionSearchInputUseCase @Inject constructor() {
+
+    operator fun invoke(input: String): RegionSearchInputType {
+        val tokens = input
+            .trim()
+            .split(WHITESPACE_REGEX)
+            .map { token -> token.cleanToken() }
+            .filter { token -> token.isNotBlank() }
+
+        if (tokens.isEmpty()) return RegionSearchInputType.REGION_KEYWORD
+
+        val hasSido = tokens.any { token -> token.isSidoLike() }
+        val sigunguCount = tokens.count { token -> token.isSigunguLike() }
+        val hasCompoundSigungu = tokens
+            .zipWithNext()
+            .any { (current, next) -> current.endsWith("시") && next.endsWith("구") }
+        val hasAddressNumber = tokens.any { token -> token.hasAddressNumber() }
+        val hasRoadName = tokens.any { token -> token.isRoadNameLike() }
+        val hasRegionScope = (hasSido && sigunguCount > 0) || hasCompoundSigungu
+
+        return if (hasRegionScope && (hasAddressNumber || hasRoadName)) {
+            RegionSearchInputType.ADDRESS
+        } else {
+            RegionSearchInputType.REGION_KEYWORD
+        }
+    }
+
+    private fun String.cleanToken(): String =
+        trim().trim('(', ')', '[', ']', ',', '.', ' ')
+
+    private fun String.isSidoLike(): Boolean =
+        this in SIDO_NAMES || this in SIDO_ALIASES
+
+    private fun String.isSigunguLike(): Boolean =
+        endsWith("시") || endsWith("군") || endsWith("구")
+
+    private fun String.isRoadNameLike(): Boolean {
+        val nameWithoutNumbers = replace(DIGIT_REGEX, "")
+        return nameWithoutNumbers.endsWith("로") || nameWithoutNumbers.endsWith("길")
+    }
+
+    private fun String.hasAddressNumber(): Boolean =
+        ADDRESS_NUMBER_REGEX.matches(this)
+
+    private companion object {
+        private val WHITESPACE_REGEX = "\\s+".toRegex()
+        private val DIGIT_REGEX = "\\d+".toRegex()
+        private val ADDRESS_NUMBER_REGEX = """\d+(-\d+)?""".toRegex()
+
+        private val SIDO_NAMES = setOf(
+            "서울특별시",
+            "부산광역시",
+            "대구광역시",
+            "인천광역시",
+            "광주광역시",
+            "대전광역시",
+            "울산광역시",
+            "세종특별자치시",
+            "경기도",
+            "강원특별자치도",
+            "강원도",
+            "충청북도",
+            "충청남도",
+            "전북특별자치도",
+            "전라북도",
+            "전라남도",
+            "경상북도",
+            "경상남도",
+            "제주특별자치도",
+            "제주도"
+        )
+
+        private val SIDO_ALIASES = setOf(
+            "서울",
+            "서울시",
+            "부산",
+            "부산시",
+            "대구",
+            "대구시",
+            "인천",
+            "인천시",
+            "광주",
+            "대전",
+            "대전시",
+            "울산",
+            "울산시",
+            "세종",
+            "세종시",
+            "경기",
+            "강원",
+            "충북",
+            "충남",
+            "전북",
+            "전남",
+            "경북",
+            "경남",
+            "제주"
+        )
+    }
+}
+
+enum class RegionSearchInputType {
+    ADDRESS,
+    REGION_KEYWORD
+}

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/region/usecase/ClassifyRegionSearchInputUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/region/usecase/ClassifyRegionSearchInputUseCaseTest.kt
@@ -1,0 +1,65 @@
+package com.team.yeogibeoryeo.domain.region.usecase
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClassifyRegionSearchInputUseCaseTest {
+
+    private val useCase = ClassifyRegionSearchInputUseCase()
+
+    @Test
+    fun `도로명 주소는 주소 입력으로 분류한다`() {
+        val result = useCase("서울시 중구 남대문로 63")
+
+        assertEquals(RegionSearchInputType.ADDRESS, result)
+    }
+
+    @Test
+    fun `괄호와 건물명이 포함된 도로명 주소는 주소 입력으로 분류한다`() {
+        val result = useCase("서울시 중구 남대문로 63 (남대문로2가한진빌딩)")
+
+        assertEquals(RegionSearchInputType.ADDRESS, result)
+    }
+
+    @Test
+    fun `읍면동 없이 시도와 시군구와 상세 주소가 있으면 주소 입력으로 분류한다`() {
+        val result = useCase("서울특별시 중구 63")
+
+        assertEquals(RegionSearchInputType.ADDRESS, result)
+    }
+
+    @Test
+    fun `지번 주소 형태는 주소 입력으로 분류한다`() {
+        val result = useCase("서울특별시 중구 남대문로2가 123-4")
+
+        assertEquals(RegionSearchInputType.ADDRESS, result)
+    }
+
+    @Test
+    fun `시도와 시군구만 있는 입력은 지역명 검색으로 분류한다`() {
+        val result = useCase("경기도 성남시")
+
+        assertEquals(RegionSearchInputType.REGION_KEYWORD, result)
+    }
+
+    @Test
+    fun `행정구 포함 시군구만 있는 입력은 지역명 검색으로 분류한다`() {
+        val result = useCase("수원시 장안구")
+
+        assertEquals(RegionSearchInputType.REGION_KEYWORD, result)
+    }
+
+    @Test
+    fun `숫자가 포함된 읍면동 이름은 주소로 분류하지 않는다`() {
+        val result = useCase("온양1동")
+
+        assertEquals(RegionSearchInputType.REGION_KEYWORD, result)
+    }
+
+    @Test
+    fun `지역 범위 없이 숫자만 포함된 입력은 주소로 분류하지 않는다`() {
+        val result = useCase("남대문로 63")
+
+        assertEquals(RegionSearchInputType.REGION_KEYWORD, result)
+    }
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
@@ -9,6 +9,7 @@ import com.team.yeogibeoryeo.domain.favorite.usecase.GetRegionalGuideFavoriteSna
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoriteUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.ToggleRegionalGuideFavoriteUseCase
 import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.region.usecase.ClassifyRegionSearchInputUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.ExtractRegionFromAddressUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.GetEupmyeondongOptionsUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.GetSidoOptionsUseCase
@@ -16,6 +17,7 @@ import com.team.yeogibeoryeo.domain.region.usecase.GetSigunguOptionsUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.NormalizeRegionForRegionalGuideUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.ResolveRegionFromKeywordUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.ResolveRegionFromKeywordResult
+import com.team.yeogibeoryeo.domain.region.usecase.RegionSearchInputType
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideFailureReason
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideLookupResult
@@ -38,6 +40,7 @@ import kotlinx.coroutines.launch
 
 @HiltViewModel
 class RegionalGuideViewModel @Inject constructor(
+    private val classifyRegionSearchInputUseCase: ClassifyRegionSearchInputUseCase,
     private val resolveRegionFromKeywordUseCase: ResolveRegionFromKeywordUseCase,
     private val extractRegionFromAddressUseCase: ExtractRegionFromAddressUseCase,
     private val getRegionalDisposalGuideUseCase: GetRegionalDisposalGuideUseCase,
@@ -261,6 +264,11 @@ class RegionalGuideViewModel @Inject constructor(
             return
         }
 
+        if (classifyRegionSearchInputUseCase(trimmedKeyword) == RegionSearchInputType.ADDRESS) {
+            loadByAddress(trimmedKeyword)
+            return
+        }
+
         lastRequest = RegionalGuideRequest.Keyword(trimmedKeyword)
 
         guideLookupJob = viewModelScope.launch {
@@ -321,6 +329,7 @@ class RegionalGuideViewModel @Inject constructor(
         lastRequest = RegionalGuideRequest.Address(trimmedAddress)
 
         guideLookupJob = viewModelScope.launch {
+            clearSelectedRegion()
             _uiState.value = RegionalGuideUiState.Loading(query = trimmedAddress)
 
             try {

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModelTest.kt
@@ -14,6 +14,7 @@ import com.team.yeogibeoryeo.domain.favorite.usecase.ToggleRegionalGuideFavorite
 import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.region.repository.RegionOptionsRepository
 import com.team.yeogibeoryeo.domain.region.repository.RegionRepository
+import com.team.yeogibeoryeo.domain.region.usecase.ClassifyRegionSearchInputUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.ExtractRegionFromAddressUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.GetEupmyeondongOptionsUseCase
 import com.team.yeogibeoryeo.domain.region.usecase.GetSidoOptionsUseCase
@@ -640,6 +641,192 @@ class RegionalGuideViewModelTest {
     }
 
     @Test
+    fun `keyword search with road address uses address lookup and keeps original input`() = runTest {
+        val regionRepository = FakeRegionRepository(
+            extractedRegion = Region(
+                sido = "서울특별시",
+                sigungu = "중구",
+                eupmyeondong = null
+            )
+        )
+        val regionalGuideRepository = FakeRegionalDisposalGuideRepository(
+            candidates = listOf(
+                sampleGuide(
+                    sido = "서울특별시",
+                    sigungu = "중구",
+                    targetRegionName = "중구 전체"
+                )
+            )
+        )
+        val viewModel = createViewModel(
+            regionRepository = regionRepository,
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                sigunguOptionsBySido = mapOf(
+                    "서울특별시" to listOf("중구")
+                )
+            ),
+            regionalGuideRepository = regionalGuideRepository
+        )
+        advanceUntilIdle()
+
+        val address = "서울시 중구 남대문로 63"
+        viewModel.onSearchKeywordChanged(address)
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        assertEquals(listOf(address), regionRepository.extractedAddresses)
+        assertEquals(emptyList<String>(), regionRepository.resolvedKeywords)
+        assertEquals(address, viewModel.searchKeyword.value)
+        assertEquals("중구", regionalGuideRepository.queries.single().sigunguQuery)
+
+        with(viewModel.regionSelectorUiState.value) {
+            assertEquals("서울특별시", selectedSido)
+            assertEquals("중구", selectedSigungu)
+            assertNull(selectedEupmyeondong)
+        }
+    }
+
+    @Test
+    fun `keyword search with parenthesized road address uses address lookup`() = runTest {
+        val regionRepository = FakeRegionRepository(
+            extractedRegion = Region(
+                sido = "서울특별시",
+                sigungu = "중구",
+                eupmyeondong = null
+            )
+        )
+        val viewModel = createViewModel(
+            regionRepository = regionRepository,
+            regionalGuideRepository = FakeRegionalDisposalGuideRepository(
+                candidates = listOf(
+                    sampleGuide(
+                        sido = "서울특별시",
+                        sigungu = "중구",
+                        targetRegionName = "중구 전체"
+                    )
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        val address = "서울시 중구 남대문로 63 (남대문로2가한진빌딩)"
+        viewModel.onSearchKeywordChanged(address)
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        assertEquals(listOf(address), regionRepository.extractedAddresses)
+        assertTrue(viewModel.uiState.value is RegionalGuideUiState.Success)
+    }
+
+    @Test
+    fun `retry after address keyword search uses last address lookup`() = runTest {
+        val regionRepository = FakeRegionRepository(
+            extractedRegion = Region(
+                sido = "서울특별시",
+                sigungu = "중구"
+            )
+        )
+        val regionalGuideRepository = FakeRegionalDisposalGuideRepository(
+            candidates = listOf(
+                sampleGuide(
+                    sido = "서울특별시",
+                    sigungu = "중구",
+                    targetRegionName = "중구 전체"
+                )
+            )
+        )
+        val viewModel = createViewModel(
+            regionRepository = regionRepository,
+            regionalGuideRepository = regionalGuideRepository
+        )
+        advanceUntilIdle()
+
+        val address = "서울시 중구 남대문로 63"
+        viewModel.onSearchKeywordChanged(address)
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("새검색")
+        viewModel.retryLastRequest()
+        advanceUntilIdle()
+
+        assertEquals(listOf(address, address), regionRepository.extractedAddresses)
+        assertEquals(2, regionalGuideRepository.queries.size)
+        assertEquals("새검색", viewModel.searchKeyword.value)
+    }
+
+    @Test
+    fun `address-like keyword search without parsed region fails safely`() = runTest {
+        val regionRepository = FakeRegionRepository(extractedRegion = null)
+        val viewModel = createViewModel(
+            regionRepository = regionRepository,
+            regionalGuideRepository = FakeRegionalDisposalGuideRepository(
+                candidates = listOf(
+                    sampleGuide(
+                        sido = "경기도",
+                        sigungu = "수원시",
+                        targetRegionName = "수원시 전체"
+                    )
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onRegionCandidateSelected(
+            RegionSearchCandidateUiModel(
+                sido = "경기도",
+                sigungu = "수원시",
+                eupmyeondong = null
+            )
+        )
+        advanceUntilIdle()
+
+        assertEquals("수원시", viewModel.regionSelectorUiState.value.selectedSigungu)
+
+        val address = "서울시 중구 남대문로 63"
+        viewModel.onSearchKeywordChanged(address)
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        assertEquals(listOf(address), regionRepository.extractedAddresses)
+        assertTrue(viewModel.uiState.value is RegionalGuideUiState.Empty)
+        assertEquals(address, viewModel.searchKeyword.value)
+
+        with(viewModel.regionSelectorUiState.value) {
+            assertNull(selectedSido)
+            assertNull(selectedSigungu)
+            assertNull(selectedEupmyeondong)
+        }
+    }
+
+    @Test
+    fun `region keyword with sigungu only keeps keyword search flow`() = runTest {
+        val regionRepository = FakeRegionRepository(
+            resolvedRegion = Region(
+                sigungu = "중구"
+            )
+        )
+        val viewModel = createViewModel(
+            regionRepository = regionRepository,
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                keywordRegions = listOf(
+                    Region(sido = "서울특별시", sigungu = "중구"),
+                    Region(sido = "대구광역시", sigungu = "중구")
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("중구")
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        assertEquals(listOf("중구"), regionRepository.resolvedKeywords)
+        assertEquals(emptyList<String>(), regionRepository.extractedAddresses)
+        assertTrue(viewModel.uiState.value is RegionalGuideUiState.Ambiguous)
+    }
+
+    @Test
     fun `keyword not found clears previous selected region`() = runTest {
         val viewModel = createViewModel(
             regionRepository = FakeRegionRepository(
@@ -1012,6 +1199,7 @@ class RegionalGuideViewModelTest {
             ),
     ): RegionalGuideViewModel {
         return RegionalGuideViewModel(
+            classifyRegionSearchInputUseCase = ClassifyRegionSearchInputUseCase(),
             resolveRegionFromKeywordUseCase = ResolveRegionFromKeywordUseCase(
                 repository = regionRepository,
                 regionOptionsRepository = regionOptionsRepository
@@ -1054,9 +1242,18 @@ class RegionalGuideViewModelTest {
         private val resolvedRegion: Region? = null,
         private val extractedRegion: Region? = null
     ) : RegionRepository {
-        override fun extractRegionFromAddress(address: String): Region? = extractedRegion
+        val extractedAddresses = mutableListOf<String>()
+        val resolvedKeywords = mutableListOf<String>()
 
-        override suspend fun resolveRegionFromKeyword(keyword: String): Region? = resolvedRegion
+        override fun extractRegionFromAddress(address: String): Region? {
+            extractedAddresses += address
+            return extractedRegion
+        }
+
+        override suspend fun resolveRegionFromKeyword(keyword: String): Region? {
+            resolvedKeywords += keyword
+            return resolvedRegion
+        }
 
         override suspend fun resolveRegionFromCoordinate(
             latitude: Double,


### PR DESCRIPTION
## 작업 내용

- 지역 가이드 검색창에서 시도 / 시군구가 포함된 도로명 주소를 직접 검색할 수 있도록 했습니다.
- 검색 입력을 주소 형태와 일반 지역명으로 분류하는 `ClassifyRegionSearchInputUseCase`를 추가했습니다.
- 주소 입력은 기존 `loadByAddress()` 흐름을 재사용해 조회하고, 일반 지역명은 기존 검색 흐름을 유지했습니다.
- 주소에서 추출한 지역을 `RegionSelectorUiState`와 compact 지역 표시 영역에 반영했습니다.
- 주소 검색 후에도 검색창에는 사용자가 입력한 원본 문자열을 유지했습니다.
- 주소 검색 실패 후 retry 시 마지막 주소 검색을 다시 실행하도록 처리했습니다.
- 주소 파싱 실패 시 이전 선택 지역이 compact 영역에 남지 않도록 정리했습니다.

## 지원 범위

- `서울시 중구 남대문로`
- `서울시 중구 남대문로 63`
- `서울시 중구 남대문로 63 (남대문로2가한진빌딩)`
- 읍면동이 없는 주소는 시도 / 시군구 기준으로 조회

## 기존 흐름 유지

- 일반 지역명 검색
- 자동 후보 추천
- 다중 후보 선택 UX
- 선택형 UI 조회
- 지도에서 전달된 주소 기반 `loadByAddress()` 진입
- Favorites 지역 가이드 재진입
- #159 검색창 원본 유지 정책
- #151 키보드 / focus 처리 정책

## 제외 범위

- `남대문로 63`처럼 시도 / 시군구가 없는 축약 도로명 주소 처리
- 외부 주소 검색 API 신규 연계
- geocoding / reverse geocoding 기반 행정구역 추론
- 주소 자동완성 UI
- 지도 검색 기능 변경
- `/info` API 호출 방식 변경
- 행정구역 가공 JSON 추가 또는 수정
- 법정동 / 행정동 매핑 JSON 의존성 확장

이번 PR은 기존 주소 파싱 / `loadByAddress()` / `/info` 조회 흐름을 재사용하며, #168 답변이 필요한 행정구역 가공 JSON 변경은 포함하지 않습니다.

`남대문로 63`처럼 시도 / 시군구 없이 도로명과 건물번호만 있는 입력은 현재 로컬 주소 파싱만으로 행정구역을 안전하게 확정할 수 없어 이번 PR 범위에서 제외했습니다.

## 테스트

- [x] `./gradlew :domain:test`
- [x] `./gradlew :presentation:testDebugUnitTest`
- [x] `./gradlew :presentation:compileDebugKotlin`
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `git diff --check`

## 스크린샷

| 도로명 주소 검색 | 괄호 포함 주소 검색 |
| --- | --- |
| <img width="260" alt="서울시 중구 남대문로 63 주소 검색 결과" src="https://github.com/user-attachments/assets/59c62400-df02-450a-bf03-885252b02830" /> | <img width="260" alt="괄호와 건물명이 포함된 주소 검색 결과" src="https://github.com/user-attachments/assets/6a0afd8e-3d8d-4fdf-8300-ce0babb1fdf8" /> |

## 수동 확인

- [x] `서울시 중구 남대문로` 직접 검색
- [x] `서울시 중구 남대문로 63` 직접 검색
- [x] `서울시 중구 남대문로 63 (남대문로2가한진빌딩)` 직접 검색
- [x] 주소 검색 후 compact 지역 표시 확인
- [x] 주소 검색 후 검색창 원본 유지 확인
- [x] `중구` 다중 후보 지역명 검색 회귀 확인

## 관련 이슈

- Related #152  
- Related #61  
- Related #159