### PR TITLE
refactor: 지도 수거 장소 geocoding 성능 개선

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/core/di/CoroutineDispatcherModule.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/core/di/CoroutineDispatcherModule.kt
@@ -1,0 +1,22 @@
+package com.team.yeogibeoryeo.data.core.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class IoDispatcher
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CoroutineDispatcherModule {
+
+    @Provides
+    @IoDispatcher
+    fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+}

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/geocoder/SpotGeocoder.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/geocoder/SpotGeocoder.kt
@@ -1,39 +1,45 @@
 package com.team.yeogibeoryeo.data.spot.geocoder
 
-import androidx.annotation.RequiresApi
 import android.content.Context
 import android.location.Geocoder
 import android.os.Build
+import androidx.annotation.RequiresApi
+import com.team.yeogibeoryeo.data.core.di.IoDispatcher
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.coroutines.resume
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 
 interface SpotGeocoder {
     suspend fun geocode(address: String): Coordinate?
 }
 
 class AndroidSpotGeocoder @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : SpotGeocoder {
 
     override suspend fun geocode(address: String): Coordinate? {
         if (address.isBlank()) return null
 
-        val geocoder = Geocoder(context, Locale.KOREA)
+        return withContext(ioDispatcher) {
+            val geocoder = Geocoder(context, Locale.KOREA)
 
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            geocodeForTiramisuAndAbove(
-                geocoder = geocoder,
-                address = address,
-            )
-        } else {
-            geocodeForBelowTiramisu(
-                geocoder = geocoder,
-                address = address,
-            )
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                geocodeForTiramisuAndAbove(
+                    geocoder = geocoder,
+                    address = address,
+                )
+            } else {
+                geocodeForBelowTiramisu(
+                    geocoder = geocoder,
+                    address = address,
+                )
+            }
         }
     }
 

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/geocoder/SpotGeocoder.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/geocoder/SpotGeocoder.kt
@@ -1,6 +1,7 @@
 package com.team.yeogibeoryeo.data.spot.geocoder
 
 import android.content.Context
+import android.location.Address
 import android.location.Geocoder
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -49,20 +50,28 @@ class AndroidSpotGeocoder @Inject constructor(
         address: String,
     ): Coordinate? {
         return suspendCancellableCoroutine { continuation ->
-            geocoder.getFromLocationName(
-                address,
-                MAX_RESULT_COUNT,
-            ) { addresses ->
-                val firstAddress = addresses.firstOrNull()
+            runCatching {
+                geocoder.getFromLocationName(
+                    address,
+                    MAX_RESULT_COUNT,
+                    object : Geocoder.GeocodeListener {
+                        override fun onGeocode(addresses: MutableList<Address>) {
+                            if (continuation.isActive) {
+                                continuation.resume(addresses.firstOrNull().toCoordinate())
+                            }
+                        }
 
-                continuation.resume(
-                    firstAddress?.let {
-                        Coordinate(
-                            latitude = it.latitude,
-                            longitude = it.longitude,
-                        )
+                        override fun onError(errorMessage: String?) {
+                            if (continuation.isActive) {
+                                continuation.resume(null)
+                            }
+                        }
                     },
                 )
+            }.onFailure {
+                if (continuation.isActive) {
+                    continuation.resume(null)
+                }
             }
         }
     }
@@ -87,5 +96,14 @@ class AndroidSpotGeocoder @Inject constructor(
 
     private companion object {
         const val MAX_RESULT_COUNT = 1
+    }
+}
+
+private fun Address?.toCoordinate(): Coordinate? {
+    return this?.let {
+        Coordinate(
+            latitude = it.latitude,
+            longitude = it.longitude,
+        )
     }
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
@@ -9,6 +9,13 @@ import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.supervisorScope
 
 class CollectionSpotRepositoryImpl @Inject constructor(
     private val remoteDataSource: SpotRemoteDataSource,
@@ -73,8 +80,59 @@ class CollectionSpotRepositoryImpl @Inject constructor(
     }
 
     private suspend fun List<CollectionSpot>.geocodeAll(): List<CollectionSpot> {
-        return map { spot ->
-            geocodeSpot(spot)
+        if (isEmpty()) return this
+
+        return supervisorScope {
+            val geocodeJobsByAddress = LinkedHashMap<String, Deferred<Coordinate?>>()
+            val geocodeSemaphore = Semaphore(MAX_CONCURRENT_GEOCODING_COUNT)
+
+            forEach { spot ->
+                val addressKey = spot.address.toGeocodeKey() ?: return@forEach
+
+                geocodeJobsByAddress.getOrPut(addressKey) {
+                    async {
+                        geocodeSafely(
+                            address = addressKey,
+                            semaphore = geocodeSemaphore,
+                        )
+                    }
+                }
+            }
+
+            geocodeJobsByAddress.values.awaitAll()
+
+            map { spot ->
+                val addressKey = spot.address.toGeocodeKey()
+                    ?: return@map spot
+                val coordinate = geocodeJobsByAddress[addressKey]?.await()
+
+                spot.copy(
+                    coordinate = coordinate,
+                )
+            }
         }
+    }
+
+    private suspend fun geocodeSafely(
+        address: String,
+        semaphore: Semaphore,
+    ): Coordinate? {
+        return semaphore.withPermit {
+            runCatching {
+                spotGeocoder.geocode(address)
+            }.getOrElse { exception ->
+                if (exception is CancellationException) throw exception
+
+                null
+            }
+        }
+    }
+
+    private fun String.toGeocodeKey(): String? {
+        return trim().takeIf { it.isNotBlank() }
+    }
+
+    private companion object {
+        const val MAX_CONCURRENT_GEOCODING_COUNT = 3
     }
 }

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImplTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImplTest.kt
@@ -16,6 +16,7 @@ import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class CollectionSpotRepositoryImplTest {
@@ -102,13 +103,109 @@ class CollectionSpotRepositoryImplTest {
         assertEquals(emptyList<Any>(), result)
     }
 
+    @Test
+    fun `같은 주소는 한 번만 geocoding하고 기존 순서를 유지한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createDuplicateAddressResponse(),
+        )
+        val spotGeocoder = FakeSpotGeocoder(
+            coordinatesByAddress = mapOf(
+                "서울특별시 영등포구 문래동" to Coordinate(
+                    latitude = 37.5,
+                    longitude = 126.9,
+                ),
+                "서울특별시 구로구 구로동" to Coordinate(
+                    latitude = 37.4,
+                    longitude = 126.8,
+                ),
+            ),
+        )
+        val repository = createRepository(
+            apiService = apiService,
+            spotGeocoder = spotGeocoder,
+        )
+
+        val result = repository.searchByKeyword(
+            keyword = "문래동",
+        )
+
+        assertEquals(
+            listOf(
+                "폐건전지 수거함",
+                "폐건전지 수거함 2",
+                "재활용센터",
+            ),
+            result.map { it.name },
+        )
+        assertEquals(
+            listOf(
+                "서울특별시 영등포구 문래동",
+                "서울특별시 구로구 구로동",
+            ),
+            spotGeocoder.requestedAddresses,
+        )
+        assertEquals(result[0].coordinate, result[1].coordinate)
+        assertEquals(37.4, result[2].coordinate?.latitude)
+    }
+
+    @Test
+    fun `공백 주소는 geocoding하지 않고 좌표 없이 유지한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createBlankAddressResponse(),
+        )
+        val spotGeocoder = FakeSpotGeocoder()
+        val repository = createRepository(
+            apiService = apiService,
+            spotGeocoder = spotGeocoder,
+        )
+
+        val result = repository.searchByKeyword(
+            keyword = "문래동",
+        )
+
+        assertEquals(1, result.size)
+        assertNull(result.first().coordinate)
+        assertEquals(emptyList<String>(), spotGeocoder.requestedAddresses)
+    }
+
+    @Test
+    fun `일부 geocoding 실패가 전체 검색 결과를 실패시키지 않는다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createNormalResponse(),
+        )
+        val spotGeocoder = FakeSpotGeocoder(
+            coordinatesByAddress = mapOf(
+                "서울특별시 구로구 구로동" to Coordinate(
+                    latitude = 37.4,
+                    longitude = 126.8,
+                ),
+            ),
+            failureAddresses = setOf("서울특별시 영등포구 문래동"),
+        )
+        val repository = createRepository(
+            apiService = apiService,
+            spotGeocoder = spotGeocoder,
+        )
+
+        val result = repository.searchByKeyword(
+            keyword = "문래동",
+        )
+
+        assertEquals(2, result.size)
+        assertEquals("폐건전지 수거함", result[0].name)
+        assertNull(result[0].coordinate)
+        assertEquals("재활용센터", result[1].name)
+        assertEquals(37.4, result[1].coordinate?.latitude)
+    }
+
     private fun createRepository(
         apiService: FakeSpotApiService,
+        spotGeocoder: SpotGeocoder = FakeSpotGeocoder(),
     ): CollectionSpotRepositoryImpl {
         return CollectionSpotRepositoryImpl(
             remoteDataSource = SpotRemoteDataSource(apiService),
             spotMapper = SpotMapper(),
-            spotGeocoder = FakeSpotGeocoder(),
+            spotGeocoder = spotGeocoder,
             publicDataKeyProvider = FakePublicDataKeyProvider(),
         )
     }
@@ -118,9 +215,21 @@ class CollectionSpotRepositoryImplTest {
         override val naverClientId: String = "naver-client-id"
     }
 
-    private class FakeSpotGeocoder : SpotGeocoder {
-        override suspend fun geocode(address: String): Coordinate {
-            return Coordinate(
+    private class FakeSpotGeocoder(
+        private val coordinatesByAddress: Map<String, Coordinate> = emptyMap(),
+        private val failureAddresses: Set<String> = emptySet(),
+    ) : SpotGeocoder {
+
+        val requestedAddresses = mutableListOf<String>()
+
+        override suspend fun geocode(address: String): Coordinate? {
+            requestedAddresses += address
+
+            if (address in failureAddresses) {
+                error("geocoding failed")
+            }
+
+            return coordinatesByAddress[address] ?: Coordinate(
                 latitude = 37.5,
                 longitude = 126.9,
             )
@@ -185,6 +294,60 @@ class CollectionSpotRepositoryImplTest {
                                     spotNm = "재활용센터",
                                     addrBase = "서울특별시 구로구 구로동",
                                     addrDtl = "센터 입구",
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        }
+
+        fun createDuplicateAddressResponse(): SpotResponseDto {
+            return SpotResponseDto(
+                response = SpotResponseBodyDto(
+                    header = SpotHeaderDto(
+                        resultCode = "00",
+                        resultMsg = "NORMAL SERVICE",
+                    ),
+                    body = SpotBodyDto(
+                        items = SpotItemsDto(
+                            item = listOf(
+                                SpotItemDto(
+                                    spotNm = "폐건전지 수거함",
+                                    addrBase = "서울특별시 영등포구 문래동",
+                                    addrDtl = "주민센터 앞",
+                                ),
+                                SpotItemDto(
+                                    spotNm = "폐건전지 수거함 2",
+                                    addrBase = " 서울특별시 영등포구 문래동 ",
+                                    addrDtl = "학교 앞",
+                                ),
+                                SpotItemDto(
+                                    spotNm = "재활용센터",
+                                    addrBase = "서울특별시 구로구 구로동",
+                                    addrDtl = "센터 입구",
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        }
+
+        fun createBlankAddressResponse(): SpotResponseDto {
+            return SpotResponseDto(
+                response = SpotResponseBodyDto(
+                    header = SpotHeaderDto(
+                        resultCode = "00",
+                        resultMsg = "NORMAL SERVICE",
+                    ),
+                    body = SpotBodyDto(
+                        items = SpotItemsDto(
+                            item = listOf(
+                                SpotItemDto(
+                                    spotNm = "주소 없는 수거함",
+                                    addrBase = " ",
+                                    addrDtl = "상세 위치",
                                 ),
                             ),
                         ),


### PR DESCRIPTION
## 작업 내용

Related #194

지도 검색 결과 표시 전 수행되는 geocoding 병목을 줄이기 위해 `/getSpot` 응답 후처리 흐름을 개선했습니다.

기존에는 검색 결과 목록을 순차적으로 geocoding하고 있었고, Android 13 미만에서는 `Geocoder.getFromLocationName()`이 동기 호출로 동작할 수 있어 결과가 많을수록 로딩 시간이 길어질 수 있었습니다.

## 주요 변경 사항

| 구분 | 변경 내용 |
| --- | --- |
| Dispatcher | Android `Geocoder` 호출을 IO dispatcher에서 실행하도록 정리 |
| 병렬 처리 | `geocodeAll()`을 순차 처리에서 제한된 병렬 처리로 개선 |
| 동시성 제한 | 과도한 geocoding 요청을 막기 위해 동시 실행 개수를 3개로 제한 |
| 중복 주소 처리 | 단일 검색 내 동일 주소는 한 번만 geocoding하도록 per-search 메모리 캐시 적용 |
| 실패 방어 | 일부 주소 geocoding 실패 시 전체 검색 결과를 실패시키지 않고 해당 장소만 좌표 없이 유지 |
| 공백 주소 처리 | 공백 주소는 geocoding하지 않고 좌표 없이 유지 |
| 순서 보존 | geocoding 병렬 처리 후에도 기존 검색 결과 순서를 유지 |
| Cancellation | `CancellationException`은 삼키지 않고 정상 전파되도록 처리 |
| 테스트 | repository 단위 테스트 보강 |

## 유지한 정책

| 항목 | 유지 여부 |
| --- | --- |
| `/getSpot` API 호출 구조 | 유지 |
| 기존 현재 위치 검색 정책 | 유지 |
| 기존 현 지도 검색 정책 | 유지 |
| 즐겨찾기 장소 주변 검색 정책 | 유지 |
| 검색 결과 정렬 정책 | 유지 |
| #174 거리 표시 정책 | 유지 |
| BottomSheet UX | 유지 |
| 지도 마커 UI | 유지 |
| 즐겨찾기 저장 구조 | 유지 |
| Room 기반 좌표 캐시 | 도입하지 않음 |

## 테스트

```bash
./gradlew.bat :data:testDebugUnitTest --tests com.team.yeogibeoryeo.data.spot.repository.CollectionSpotRepositoryImplTest
./gradlew.bat :data:compileDebugKotlin
./gradlew.bat :domain:test :data:testDebugUnitTest :presentation:testDebugUnitTest :presentation:compileDebugKotlin :app:assembleDebug
git diff --check
```
## 추가한 테스트

| 테스트 | 내용 |
| --- | --- |
| 동일 주소 geocoding | 같은 주소는 한 번만 geocoding하고 기존 순서를 유지하는지 확인 |
| 공백 주소 처리 | 공백 주소는 geocoding하지 않고 좌표 없이 유지하는지 확인 |
| 일부 실패 방어 | 일부 geocoding 실패가 전체 검색 결과를 실패시키지 않는지 확인 |

## 수동 검증

| 환경 | 항목 | 결과 |
| --- | --- | --- |
| 실기기 | 내 주변 검색 | 기존 약 10초 이상 → 개선 후 약 6초 |
| 실기기 | 현 지도에서 검색 | 약 4초 |
| 실기기 | 강남역 주변 현 지도 검색 | 현 지도 검색 수준으로 빠르게 표시 |
| 실기기 | 즐겨찾기 장소 주변 목록 | 약 4~5초 |
| 에뮬레이터 | 현 지도에서 검색 | 최초 약 8초, 이후 다른 위치 검색 시 약 4초 |
| 에뮬레이터 | 즐겨찾기 장소 주변 목록 | 약 4초 |
| 에뮬레이터 | 현재 위치 기준 검색 | 환경상 직접 검증 어려움 |

## 참고

에뮬레이터 첫 검색은 `Geocoder` / 위치 / 네트워크 상태 영향으로 실기기보다 느릴 수 있어 참고 수치로만 확인했습니다.

이번 PR은 검색 UX 자체를 바꾸는 작업이 아니라, `/getSpot` 응답 이후 지도 표시 전 geocoding 후처리 성능을 개선하는 리팩토링입니다.
