### PR TITLE
fix: 지역 가이드 없음 후보 표시 및 정렬 보완

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
@@ -26,6 +26,7 @@ import com.team.yeogibeoryeo.presentation.regionalguide.mapper.toUiModel
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideCandidateUiModel
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionSearchCandidateUiModel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.regionalGuideCandidateDisplayComparator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
@@ -649,7 +650,7 @@ class RegionalGuideViewModel @Inject constructor(
                         sigungu = guide.region.sigungu,
                         eupmyeondong = guide.region.eupmyeondong
                     )
-                }
+                }.sortedWith(regionalGuideCandidateDisplayComparator)
             )
 
             RegionalGuideLookupResult.NotFound -> RegionalGuideUiState.Empty(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSummaryCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideSummaryCard.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalWasteScheduleUiModel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.takeIfRegionalGuideDisplayValue
 import com.team.yeogibeoryeo.common.R as CommonR
 
 @Composable
@@ -78,14 +79,14 @@ fun RegionalGuideSummaryCard(
                 }
             }
 
-            guide.managementZoneName?.let { managementZoneName ->
+            guide.managementZoneName.takeIfRegionalGuideDisplayValue()?.let { managementZoneName ->
                 RegionalGuideInfoRow(
                     title = "관리구역",
                     value = managementZoneName
                 )
             }
 
-            guide.targetRegionName?.let { targetRegionName ->
+            guide.targetRegionName.takeIfRegionalGuideDisplayValue()?.let { targetRegionName ->
                 RegionalGuideInfoRow(
                     title = "대상지역",
                     value = targetRegionName

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/mapper/RegionalGuideUiMapper.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/mapper/RegionalGuideUiMapper.kt
@@ -5,12 +5,13 @@ import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteSchedule
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteType
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalWasteScheduleUiModel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.takeIfRegionalGuideDisplayValue
 
 fun RegionalDisposalGuide.toUiModel(): RegionalGuideUiModel {
     return RegionalGuideUiModel(
         regionName = displayRegionName(),
-        managementZoneName = managementZoneName.takeIfNotBlank(),
-        targetRegionName = targetRegionName.takeIfNotBlank(),
+        managementZoneName = managementZoneName,
+        targetRegionName = targetRegionName,
         disposalPlaceType = disposalPlaceType.takeIfNotBlank(),
         disposalPlaceDescription = disposalPlaceDescription.takeIfNotBlank(),
         schedules = schedules
@@ -50,8 +51,8 @@ private fun RegionalDisposalGuide.displayRegionName(): String {
         .joinToString(" ")
 
     return regionName.ifBlank {
-        targetRegionName
-            ?: managementZoneName
+        targetRegionName.takeIfRegionalGuideDisplayValue()
+            ?: managementZoneName.takeIfRegionalGuideDisplayValue()
             ?: "지역 정보"
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
@@ -7,20 +7,90 @@ data class RegionalGuideCandidateUiModel(
     val eupmyeondong: String?
 ) {
     val displayText: String =
-        listOfNotNull(
-            guide.managementZoneName.takeIfNotBlank(),
-            guide.targetRegionName.takeIfNotBlank()
-        )
+        primaryDisplayParts()
+            .ifEmpty { fallbackDisplayParts() }
             .distinct()
             .joinToString(CANDIDATE_LABEL_SEPARATOR)
-            .ifBlank { guide.regionName }
 
-    private fun String?.takeIfNotBlank(): String? =
-        this
-            ?.trim()
-            ?.takeIf { value -> value.isNotBlank() }
+    internal val sortText: String =
+        primaryDisplayParts().let { parts ->
+            when {
+                parts.size >= 2 -> listOf(parts[1], parts[0])
+                parts.isNotEmpty() -> parts
+                else -> listOf(displayText)
+            }
+        }.joinToString(CANDIDATE_LABEL_SEPARATOR)
+
+    private fun primaryDisplayParts(): List<String> =
+        listOfNotNull(
+            guide.managementZoneName.takeIfRegionalGuideDisplayValue(),
+            guide.targetRegionName.takeIfRegionalGuideDisplayValue()
+        )
+
+    private fun fallbackDisplayParts(): List<String> =
+        listOfNotNull(
+            regionalGuideRegionFallbackText(sido, sigungu, eupmyeondong),
+            guide.disposalPlaceType.takeIfRegionalGuideDisplayValue()
+                ?: guide.disposalPlaceDescription.takeIfRegionalGuideDisplayValue()
+                ?: guide.schedules.firstNotNullOfOrNull { schedule ->
+                    schedule.toCandidateSummary()
+                },
+        )
+
+    private fun RegionalWasteScheduleUiModel.toCandidateSummary(): String? {
+        val criterion =
+            disposalDays.takeIfRegionalGuideDisplayValue()
+                ?: disposalTime.takeIfRegionalGuideDisplayValue()
+                ?: disposalMethod.takeIfRegionalGuideDisplayValue()
+
+        return listOfNotNull(
+            wasteTypeName.takeIfRegionalGuideDisplayValue(),
+            criterion,
+        )
+            .joinToString(SCHEDULE_SUMMARY_SEPARATOR)
+            .takeIf { summary -> summary.isNotBlank() }
+    }
 
     private companion object {
         const val CANDIDATE_LABEL_SEPARATOR = " / "
+        const val SCHEDULE_SUMMARY_SEPARATOR = " "
+    }
+}
+
+internal val regionalGuideCandidateDisplayComparator: Comparator<RegionalGuideCandidateUiModel> =
+    Comparator { left, right ->
+        compareNaturalText(left.sortText, right.sortText)
+            .takeIf { comparison -> comparison != 0 }
+            ?: compareNaturalText(left.displayText, right.displayText)
+    }
+
+private val naturalSortTokenRegex = Regex("\\d+|\\D+")
+
+private fun compareNaturalText(left: String, right: String): Int {
+    val leftTokens = left.naturalSortTokens()
+    val rightTokens = right.naturalSortTokens()
+    val minSize = minOf(leftTokens.size, rightTokens.size)
+
+    for (index in 0 until minSize) {
+        val comparison = compareNaturalToken(leftTokens[index], rightTokens[index])
+        if (comparison != 0) return comparison
+    }
+
+    return leftTokens.size.compareTo(rightTokens.size)
+}
+
+private fun String.naturalSortTokens(): List<String> =
+    naturalSortTokenRegex.findAll(this).map { match -> match.value }.toList()
+
+private fun compareNaturalToken(left: String, right: String): Int {
+    val leftNumber = left.toLongOrNull()
+    val rightNumber = right.toLongOrNull()
+
+    return if (leftNumber != null && rightNumber != null) {
+        leftNumber.compareTo(rightNumber)
+            .takeIf { comparison -> comparison != 0 }
+            ?: left.length.compareTo(right.length)
+    } else {
+        left.compareTo(right)
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideUiModel.kt
@@ -10,3 +10,27 @@ data class RegionalGuideUiModel(
     val uncollectedDays: String?,
     val departmentInfo: String?
 )
+
+internal fun String?.takeIfRegionalGuideDisplayValue(): String? =
+    this
+        ?.trim()
+        ?.takeIf { value ->
+            value.isNotBlank() && value != NO_REGIONAL_GUIDE_VALUE
+        }
+
+internal fun regionalGuideRegionFallbackText(
+    sido: String?,
+    sigungu: String?,
+    eupmyeondong: String? = null,
+): String =
+    listOfNotNull(
+        sido.takeIfRegionalGuideDisplayValue(),
+        sigungu.takeIfRegionalGuideDisplayValue(),
+        eupmyeondong.takeIfRegionalGuideDisplayValue(),
+    )
+        .joinToString(REGION_FALLBACK_SEPARATOR)
+        .ifBlank { DEFAULT_REGION_FALLBACK_TEXT }
+
+private const val NO_REGIONAL_GUIDE_VALUE = "없음"
+private const val REGION_FALLBACK_SEPARATOR = " > "
+private const val DEFAULT_REGION_FALLBACK_TEXT = "지역 정보"

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateSelectionViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateSelectionViewModelTest.kt
@@ -49,8 +49,11 @@ class RegionalGuideCandidateSelectionViewModelTest {
         assertEquals("울주군", state.query)
         assertEquals(2, state.candidates.size)
         assertEquals(
-            "범서, 온양, 웅촌, 언양, 삼남, 상북, 온산, 청량, 서생",
-            state.candidates.first().displayText
+            listOf(
+                "두동, 두서, 삼동",
+                "범서, 온양, 웅촌, 언양, 삼남, 상북, 온산, 청량, 서생"
+            ),
+            state.candidates.map { candidate -> candidate.displayText }
         )
     }
 
@@ -127,7 +130,7 @@ class RegionalGuideCandidateSelectionViewModelTest {
         assertEquals("울주군", viewModel.searchKeyword.value)
         assertEquals("울주군", state.query)
         assertEquals(
-            "범서, 온양, 웅촌, 언양, 삼남, 상북, 온산, 청량, 서생",
+            "두동, 두서, 삼동",
             state.guide.targetRegionName
         )
 

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideFavoriteViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideFavoriteViewModelTest.kt
@@ -156,6 +156,59 @@ class RegionalGuideFavoriteViewModelTest {
     }
 
     @Test
+    fun `favorite click after guide candidate selection keeps original none zone values in snapshot`() = runTest {
+        val region = Region(sido = "경기도", sigungu = "성남시")
+        val doorToDoorGuide =
+            RegionalDisposalGuide(
+                region = region,
+                managementZoneName = "없음",
+                targetRegionName = "없음",
+                disposalPlaceType = "문전수거",
+                schedules = emptyList(),
+            )
+        val basePointGuide =
+            RegionalDisposalGuide(
+                region = region,
+                managementZoneName = "없음",
+                targetRegionName = "없음",
+                disposalPlaceType = "거점수거",
+                schedules = emptyList(),
+            )
+        val favoriteRepository = FakeFavoriteRepository()
+        val snapshotRepository = FakeRegionalGuideFavoriteSnapshotRepository()
+        val viewModel =
+            createViewModel(
+                regionRepository = FakeRegionRepository(resolvedRegion = region),
+                regionalGuideRepository =
+                    FakeRegionalDisposalGuideRepository(candidates = listOf(doorToDoorGuide, basePointGuide)),
+                favoriteRepository = favoriteRepository,
+                regionalGuideSnapshotRepository = snapshotRepository,
+                regionalGuideFavoriteRepository =
+                    FakeRegionalGuideFavoriteRepository(
+                        favoriteRepository = favoriteRepository,
+                        snapshotRepository = snapshotRepository,
+                    ),
+            )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("성남시")
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        val candidate = (viewModel.uiState.value as RegionalGuideUiState.GuideCandidates)
+            .candidates
+            .first { candidate -> candidate.displayText.contains("문전수거") }
+
+        viewModel.onRegionalGuideCandidateSelected(candidate)
+        viewModel.onFavoriteClick()
+        advanceUntilIdle()
+
+        val expectedSnapshot = doorToDoorGuide.toFavoriteSnapshot()
+        assertEquals(true, favoriteRepository.isFavorite(FavoriteTargetType.REGIONAL_GUIDE, expectedSnapshot.targetId))
+        assertEquals(expectedSnapshot, snapshotRepository.getSnapshot(expectedSnapshot.targetId))
+    }
+
+    @Test
     fun `legacy regional guide favorite key is observed and removed with current snapshot`() = runTest {
         val region = Region(sido = "Sido", sigungu = "Sigungu", eupmyeondong = "Dong")
         val guide =

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/mapper/RegionalGuideUiMapperTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/mapper/RegionalGuideUiMapperTest.kt
@@ -1,0 +1,58 @@
+package com.team.yeogibeoryeo.presentation.regionalguide.mapper
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RegionalGuideUiMapperTest {
+
+    @Test
+    fun `관리구역명과 대상지역명이 없음이어도 UI 모델에는 원본 값을 유지한다`() {
+        val guide = RegionalDisposalGuide(
+            region = Region(sido = "경기도", sigungu = "성남시"),
+            managementZoneName = "없음",
+            targetRegionName = "없음",
+            schedules = emptyList()
+        )
+
+        val uiModel = guide.toUiModel()
+
+        assertEquals("없음", uiModel.managementZoneName)
+        assertEquals("없음", uiModel.targetRegionName)
+        assertEquals("경기도 성남시", uiModel.regionName)
+        assertEquals("없음", guide.managementZoneName)
+        assertEquals("없음", guide.targetRegionName)
+    }
+
+    @Test
+    fun `관리구역명과 대상지역명이 공백이어도 UI 모델에는 원본 값을 유지한다`() {
+        val guide = RegionalDisposalGuide(
+            region = Region(sido = "경기도", sigungu = "성남시"),
+            managementZoneName = " ",
+            targetRegionName = "",
+            schedules = emptyList()
+        )
+
+        val uiModel = guide.toUiModel()
+
+        assertEquals(" ", uiModel.managementZoneName)
+        assertEquals("", uiModel.targetRegionName)
+        assertEquals("경기도 성남시", uiModel.regionName)
+    }
+
+    @Test
+    fun `의미 있는 관리구역명과 대상지역명은 UI 모델에 유지한다`() {
+        val guide = RegionalDisposalGuide(
+            region = Region(sido = "대전광역시", sigungu = "유성구"),
+            managementZoneName = "노은2동",
+            targetRegionName = "반석동 일부지역",
+            schedules = emptyList()
+        )
+
+        val uiModel = guide.toUiModel()
+
+        assertEquals("노은2동", uiModel.managementZoneName)
+        assertEquals("반석동 일부지역", uiModel.targetRegionName)
+    }
+}

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModelTest.kt
@@ -46,34 +46,157 @@ class RegionalGuideCandidateUiModelTest {
     }
 
     @Test
-    fun `관리구역명과 대상지역명이 모두 비어 있으면 지역명을 표시한다`() {
+    fun `관리구역명과 대상지역명이 모두 비어 있으면 시도 시군구 fallback을 표시한다`() {
         val candidate = candidate(
             regionName = "대전광역시 유성구",
             managementZoneName = " ",
             targetRegionName = ""
         )
 
-        assertEquals("대전광역시 유성구", candidate.displayText)
+        assertEquals("대전광역시 > 유성구", candidate.displayText)
+    }
+
+    @Test
+    fun `관리구역명과 대상지역명이 모두 없음이면 시도 시군구 fallback을 표시한다`() {
+        val candidate = candidate(
+            sido = "경기도",
+            sigungu = "성남시",
+            managementZoneName = " 없음 ",
+            targetRegionName = "없음"
+        )
+
+        assertEquals("경기도 > 성남시", candidate.displayText)
+    }
+
+    @Test
+    fun `관리구역명만 없음이면 의미 있는 대상지역명을 표시한다`() {
+        val candidate = candidate(
+            managementZoneName = "없음",
+            targetRegionName = "대가야읍"
+        )
+
+        assertEquals("대가야읍", candidate.displayText)
+    }
+
+    @Test
+    fun `대상지역명만 없음이면 의미 있는 관리구역명을 표시한다`() {
+        val candidate = candidate(
+            managementZoneName = "온천1동",
+            targetRegionName = "없음"
+        )
+
+        assertEquals("온천1동", candidate.displayText)
+    }
+
+    @Test
+    fun `관리구역명과 대상지역명이 모두 없음이면 배출장소 유형으로 fallback 후보를 구분한다`() {
+        val candidate = candidate(
+            sido = "경기도",
+            sigungu = "성남시",
+            managementZoneName = "없음",
+            targetRegionName = "없음",
+            disposalPlaceType = "문전수거"
+        )
+
+        assertEquals("경기도 > 성남시 / 문전수거", candidate.displayText)
+    }
+
+    @Test
+    fun `배출장소 유형이 없으면 배출장소 설명으로 fallback 후보를 구분한다`() {
+        val candidate = candidate(
+            sido = "경상북도",
+            sigungu = "성주군",
+            managementZoneName = "없음",
+            targetRegionName = "없음",
+            disposalPlaceDescription = "거점수거함 배출"
+        )
+
+        assertEquals("경상북도 > 성주군 / 거점수거함 배출", candidate.displayText)
+    }
+
+    @Test
+    fun `배출장소 정보가 없으면 첫 배출 일정 요약으로 fallback 후보를 구분한다`() {
+        val candidate = candidate(
+            sido = "대구광역시",
+            sigungu = "군위군",
+            managementZoneName = "없음",
+            targetRegionName = "없음",
+            schedules = listOf(
+                RegionalWasteScheduleUiModel(
+                    wasteTypeName = "일반쓰레기",
+                    disposalDays = "월, 수, 금",
+                    disposalTime = "정보 없음",
+                    disposalMethod = "종량제봉투 배출"
+                )
+            )
+        )
+
+        assertEquals("대구광역시 > 군위군 / 일반쓰레기 월, 수, 금", candidate.displayText)
+    }
+
+    @Test
+    fun `관리구역명과 대상지역명이 함께 있으면 대상지역명 기준으로 정렬한다`() {
+        val candidates = listOf(
+            candidate(managementZoneName = "2권역", targetRegionName = "문덕2리"),
+            candidate(managementZoneName = "2권역", targetRegionName = "고산리"),
+            candidate(managementZoneName = "2권역", targetRegionName = "월곡2리"),
+            candidate(managementZoneName = "2권역", targetRegionName = "월곡1리"),
+            candidate(managementZoneName = "2권역", targetRegionName = "소성리")
+        )
+
+        val sorted = candidates.sortedWith(regionalGuideCandidateDisplayComparator)
+
+        assertEquals(
+            listOf(
+                "2권역 / 고산리",
+                "2권역 / 문덕2리",
+                "2권역 / 소성리",
+                "2권역 / 월곡1리",
+                "2권역 / 월곡2리"
+            ),
+            sorted.map { candidate -> candidate.displayText }
+        )
+    }
+
+    @Test
+    fun `숫자가 포함된 대상지역명은 자연 순서로 정렬한다`() {
+        val candidates = listOf(
+            candidate(managementZoneName = "2권역", targetRegionName = "월곡10리"),
+            candidate(managementZoneName = "2권역", targetRegionName = "월곡2리"),
+            candidate(managementZoneName = "2권역", targetRegionName = "월곡1리")
+        )
+
+        val sorted = candidates.sortedWith(regionalGuideCandidateDisplayComparator)
+
+        assertEquals(
+            listOf("2권역 / 월곡1리", "2권역 / 월곡2리", "2권역 / 월곡10리"),
+            sorted.map { candidate -> candidate.displayText }
+        )
     }
 
     private fun candidate(
         regionName: String = "대전광역시 유성구",
+        sido: String = "대전광역시",
+        sigungu: String = "유성구",
         managementZoneName: String?,
-        targetRegionName: String?
+        targetRegionName: String?,
+        disposalPlaceType: String? = null,
+        disposalPlaceDescription: String? = null,
+        schedules: List<RegionalWasteScheduleUiModel> = emptyList()
     ): RegionalGuideCandidateUiModel =
         RegionalGuideCandidateUiModel(
             guide = RegionalGuideUiModel(
                 regionName = regionName,
                 managementZoneName = managementZoneName,
                 targetRegionName = targetRegionName,
-                disposalPlaceType = null,
-                disposalPlaceDescription = null,
-                schedules = emptyList(),
+                disposalPlaceType = disposalPlaceType,
+                disposalPlaceDescription = disposalPlaceDescription,
+                schedules = schedules,
                 uncollectedDays = null,
                 departmentInfo = null
             ),
-            sido = "대전광역시",
-            sigungu = "유성구",
+            sido = sido,
+            sigungu = sigungu,
             eupmyeondong = null
         )
 }


### PR DESCRIPTION
## 작업 내용

지역 가이드 후보 목록과 상세 카드에서 `/info` 응답의 관리구역명/대상지역명이 `없음`, 빈 값, `null`인 경우 의미 없는 값이 그대로 노출되지 않도록 presentation 표시 정책을 보완했습니다.

원본 `/info` 값은 유지하고, 실제 화면에 표시되는 문자열에서만 fallback을 적용합니다.

## 변경 사항

- `null`, blank, trim된 `없음` 값을 UI 표시에서 제외
- `managementZoneName`과 `targetRegionName` 표시 정책 정리
  - 둘 다 의미 있고 서로 다르면 `관리구역명 / 대상지역명` 표시
  - 두 값이 같으면 한 번만 표시
  - 하나만 의미 있으면 해당 값만 표시
  - 둘 다 의미 없으면 `시도 > 시군구` fallback 표시
- 동일 fallback 후보는 배출장소 유형, 배출장소 설명, 일정 요약 순으로 보조 문구 표시
- 상세 카드에서 `관리구역: 없음`, `대상지역: 없음` row가 노출되지 않도록 정리
- 후보 목록 정렬 개선
  - `/` 뒤 대상지역명 우선 정렬
  - 숫자가 포함된 지역명 자연 정렬
- 원본 `managementZoneName`, `targetRegionName` 값은 유지해 후보 선택과 Favorites snapshot/key 정합성 보존
- 표시 fallback, 정렬, 원본 값 보존 테스트 보강

## 기존 정책 유지

- domain 후보 선택 정책은 변경하지 않았습니다.
- 원본 `/info` 응답 데이터와 domain model 값은 변경하지 않았습니다.
- 직접 매칭 후보 1개일 때 바로 조회하는 흐름을 유지했습니다.
- 직접 매칭 후보 여러 개일 때 후보 목록을 보여주는 흐름을 유지했습니다.
- 여러 후보 중 첫 번째 후보를 임의 선택하지 않는 정책을 유지했습니다.
- Favorites key 및 재진입 후보 구분 흐름을 변경하지 않았습니다.
- #152 주소 검색, #159 검색창 입력값 분리, #151 focus/키보드 흐름에 영향을 주지 않도록 유지했습니다.

## 제외한 범위

- 장소명만 다른 API row의 실제 후보 병합
- 후보 선택 domain 정책 변경
- `/info` pagination 전체 조회
- `pageNo`, `numOfRows` 조회 정책 변경
- 행정구역 JSON 또는 법정동/행정동 매핑 변경

장소명만 다른 row 병합은 선택되는 원본 candidate가 달라질 수 있어 후속 이슈로 분리합니다.  
`totalCount > numOfRows` 지역의 후보 누락 가능성도 확인했지만, 전체 페이지 조회는 data/API 정책 변경에 가까워 후속 이슈로 분리합니다.

## 테스트

- [x] `./gradlew :presentation:testDebugUnitTest`
- [x] `./gradlew :presentation:compileDebugKotlin`
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `./gradlew :domain:test`
- [x] `git diff --check`

## 스크린샷

| 후보 목록 fallback | 상세 카드 |
| --- | --- |
| <img width="720" height="1520" alt="후보 목록 fallback" src="https://github.com/user-attachments/assets/dae93969-45ad-4b17-9ca6-cb789d365eb8" /> | <img width="720" height="1520" alt="거점수거 - 상세 카드" src="https://github.com/user-attachments/assets/b8879dd1-1b6f-4687-a2fa-30212822fffd" /> |

## 관련 이슈

- Related #158