### PR TITLE
fix: 지도 바텀시트 하단 겹침 및 높이 보정

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -2,6 +2,9 @@ package com.team.yeogibeoryeo.navigation
 
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
@@ -23,6 +26,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -46,8 +51,10 @@ fun YeogiBeoryeoNavHost(
     navController: NavHostController = rememberNavController(),
 ) {
     val currentContext by rememberUpdatedState(LocalContext.current)
+    val layoutDirection = LocalLayoutDirection.current
     val currentBackStackEntry = navController.currentBackStackEntryAsState().value
     val currentDestination = currentBackStackEntry?.destination
+    val isMapScreen = currentDestination?.hasRoute<MapRoute>() == true
     val isItemDetailScreen = currentDestination?.hasRoute<ItemGuideDetailRoute>() == true
     val isUsefulGuideScreen = currentDestination?.hasRoute<ItemUsefulGuideRoute>() == true
     val hidesBottomBarOnScroll = isItemDetailScreen || isUsefulGuideScreen
@@ -88,10 +95,21 @@ fun YeogiBeoryeoNavHost(
             }
         },
     ) { innerPadding ->
+        val navHostPadding = if (isMapScreen && !isBottomBarVisible) {
+            PaddingValues(
+                start = innerPadding.calculateStartPadding(layoutDirection),
+                top = 0.dp,
+                end = innerPadding.calculateEndPadding(layoutDirection),
+                bottom = 0.dp,
+            )
+        } else {
+            innerPadding
+        }
+
         NavHost(
             navController = navController,
             startDestination = ItemSearchRoute(),
-            modifier = Modifier.padding(innerPadding),
+            modifier = Modifier.padding(navHostPadding),
         ) {
             composable<MapRoute> { backStackEntry ->
                 val route = backStackEntry.toRoute<MapRoute>()
@@ -99,7 +117,7 @@ fun YeogiBeoryeoNavHost(
                     initialSpotType = route.toInitialCollectionSpotTypeOrNull(),
                     favoriteSpotMoveRequest = route.toFavoriteSpotMapMoveRequest(),
                     onBottomBarVisibilityChanged = { isVisible ->
-                        if (currentDestination?.hasRoute<MapRoute>() == true) {
+                        if (isMapScreen) {
                             isBottomBarVisible = isVisible
                         }
                     },

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -4,7 +4,9 @@ import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -18,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -229,6 +232,11 @@ private fun CollectionSpotMapContent(
     BoxWithConstraints(
         modifier = modifier.fillMaxSize(),
     ) {
+        val density = LocalDensity.current
+        val navigationBarBottomPadding = with(density) {
+            WindowInsets.navigationBars.getBottom(density).toDp()
+        }
+
         CollectionSpotNaverMap(
             spots = uiState.spots,
             selectedSpot = uiState.selectedSpot,
@@ -338,6 +346,7 @@ private fun CollectionSpotMapContent(
                 onSheetLevelChanged = { level ->
                     sheetLevel = level
                 },
+                bottomInset = navigationBarBottomPadding,
                 modifier = Modifier.align(Alignment.BottomCenter),
             ) {
                 when {
@@ -351,6 +360,7 @@ private fun CollectionSpotMapContent(
                                 mapUiMode = MapUiMode.ResultList
                                 sheetLevel = MapSheetLevel.Peek
                             },
+                            bottomContentPadding = navigationBarBottomPadding,
                         )
                     }
 
@@ -374,6 +384,7 @@ private fun CollectionSpotMapContent(
                                 sheetRevealRequest += 1
                                 onSpotClick(spot)
                             },
+                            bottomContentPadding = navigationBarBottomPadding,
                         )
                     }
                 }
@@ -407,6 +418,7 @@ private fun myLocationButtonBottomPadding(
         MapSheetLevel.Hidden -> MyLocationButtonBottomPadding
         MapSheetLevel.Peek -> MapResultBottomSheetPeekHeight + MyLocationButtonBottomPadding
         MapSheetLevel.Medium -> MapSpotDetailBottomSheetPeekHeight + MyLocationButtonBottomPadding
+        MapSheetLevel.Half,
         MapSheetLevel.Expanded -> MyLocationButtonBottomPadding
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -346,7 +346,6 @@ private fun CollectionSpotMapContent(
                 onSheetLevelChanged = { level ->
                     sheetLevel = level
                 },
-                bottomInset = navigationBarBottomPadding,
                 modifier = Modifier.align(Alignment.BottomCenter),
             ) {
                 when {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomList.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomList.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
@@ -23,11 +24,12 @@ fun SpotBottomList(
     onSpotClick: (CollectionSpot) -> Unit,
     onSpotFavoriteClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
+    bottomContentPadding: Dp = 0.dp,
     contentPadding: PaddingValues = PaddingValues(
         start = 16.dp,
         top = 12.dp,
         end = 16.dp,
-        bottom = 96.dp,
+        bottom = 96.dp + bottomContentPadding,
     ),
 ) {
     val listState = rememberLazyListState()

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -18,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
@@ -39,13 +41,14 @@ fun SpotBottomSheetContent(
     onSpotClick: (CollectionSpot) -> Unit,
     onSpotFavoriteClick: (CollectionSpot) -> Unit,
     modifier: Modifier = Modifier,
+    bottomContentPadding: Dp = 0.dp,
 ) {
     val hasNoticeOrError = locationNotice != null ||
         locationNoticeMessage != null ||
         errorMessage != null
 
     Column(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxSize(),
     ) {
         SpotBottomSheetHeader(
             resultCount = spots.size,
@@ -101,9 +104,10 @@ fun SpotBottomSheetContent(
                     selectedSpot = selectedSpot,
                     onSpotClick = onSpotClick,
                     onSpotFavoriteClick = onSpotFavoriteClick,
+                    bottomContentPadding = bottomContentPadding,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .heightIn(max = SpotBottomSheetListMaxHeight),
+                        .weight(1f),
                 )
             }
         }
@@ -158,12 +162,13 @@ fun SpotDetailBottomSheetContent(
     onRegionalGuideClick: (String) -> Unit = {},
     onCloseClick: () -> Unit,
     modifier: Modifier = Modifier,
+    bottomContentPadding: Dp = 0.dp,
 ) {
     Column(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 20.dp)
-            .padding(top = 16.dp, bottom = 8.dp),
+            .padding(top = 16.dp, bottom = 8.dp + bottomContentPadding),
     ) {
         SpotBottomCard(
             spot = spot,
@@ -346,8 +351,6 @@ private fun sampleSpotBottomSheetSpots(): List<CollectionSpot> {
         ),
     )
 }
-
-private val SpotBottomSheetListMaxHeight = 560.dp
 
 private fun MapLocationNoticeAction.toActionLabel(): String {
     return when (this) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/ThreeStepMapBottomSheet.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/ThreeStepMapBottomSheet.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -29,15 +30,17 @@ fun ThreeStepMapBottomSheet(
     sheetLevel: MapSheetLevel,
     revealKey: Any?,
     onSheetLevelChanged: (MapSheetLevel) -> Unit,
+    bottomInset: Dp = 0.dp,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
         val density = LocalDensity.current
         val coroutineScope = rememberCoroutineScope()
+        val sheetBottomInset = bottomInset.coerceAtLeast(0.dp)
         val sheetHeight = maxHeight - MapSheetTopMargin
         val sheetHeightPx = with(density) {
-            sheetHeight.toPx().coerceAtLeast(1f)
+            sheetHeight.toPx()
         }
         val hiddenOffset = with(density) {
             (sheetHeight - Dp.Hairline).toPx().coerceIn(0f, sheetHeightPx)
@@ -48,12 +51,15 @@ fun ThreeStepMapBottomSheet(
         val mediumOffset = with(density) {
             (sheetHeight - MapSpotDetailBottomSheetPeekHeight).toPx().coerceIn(0f, hiddenOffset)
         }
+        val halfOffset = (sheetHeightPx * (1f - MapSheetHalfVisibleRatio))
+            .coerceIn(0f, hiddenOffset)
         val expandedOffset = 0f
         fun offsetFor(level: MapSheetLevel): Float =
             when (level) {
                 MapSheetLevel.Hidden -> hiddenOffset
                 MapSheetLevel.Peek -> peekOffset
                 MapSheetLevel.Medium -> mediumOffset
+                MapSheetLevel.Half -> halfOffset
                 MapSheetLevel.Expanded -> expandedOffset
             }
 
@@ -74,7 +80,7 @@ fun ThreeStepMapBottomSheet(
                 .offset {
                     IntOffset(x = 0, y = sheetOffset.value.roundToInt())
                 }
-                .pointerInput(sheetHeightPx, hiddenOffset, peekOffset, mediumOffset) {
+                .pointerInput(sheetHeightPx, hiddenOffset, peekOffset, mediumOffset, halfOffset) {
                     detectVerticalDragGestures(
                         onVerticalDrag = { change, dragAmount ->
                             change.consume()
@@ -103,7 +109,11 @@ fun ThreeStepMapBottomSheet(
             color = MaterialTheme.colorScheme.surface,
             shadowElevation = 4.dp,
         ) {
-            Box(modifier = Modifier.fillMaxSize()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(bottom = sheetBottomInset),
+            ) {
                 content()
             }
         }
@@ -114,9 +124,11 @@ enum class MapSheetLevel {
     Hidden,
     Peek,
     Medium,
+    Half,
     Expanded,
 }
 
 private val MapSheetTopMargin = 72.dp
+private const val MapSheetHalfVisibleRatio = 0.55f
 val MapResultBottomSheetPeekHeight = 144.dp
 val MapSpotDetailBottomSheetPeekHeight = 220.dp

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/ThreeStepMapBottomSheet.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/ThreeStepMapBottomSheet.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -30,14 +29,12 @@ fun ThreeStepMapBottomSheet(
     sheetLevel: MapSheetLevel,
     revealKey: Any?,
     onSheetLevelChanged: (MapSheetLevel) -> Unit,
-    bottomInset: Dp = 0.dp,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
         val density = LocalDensity.current
         val coroutineScope = rememberCoroutineScope()
-        val sheetBottomInset = bottomInset.coerceAtLeast(0.dp)
         val sheetHeight = maxHeight - MapSheetTopMargin
         val sheetHeightPx = with(density) {
             sheetHeight.toPx()
@@ -109,11 +106,7 @@ fun ThreeStepMapBottomSheet(
             color = MaterialTheme.colorScheme.surface,
             shadowElevation = 4.dp,
         ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(bottom = sheetBottomInset),
-            ) {
+            Box(modifier = Modifier.fillMaxSize()) {
                 content()
             }
         }


### PR DESCRIPTION
## 작업 내용

Refs #175

지도 화면 바텀시트가 일부 기기에서 앱 하단탭 / 시스템 navigation bar 영역과 겹쳐 보이던 문제를 보정했습니다.

| 구분 | 내용 |
| --- | --- |
| 하단 겹침 보정 | 바텀시트 컨테이너를 직접 위로 띄우지 않고, 내부 콘텐츠 padding에 navigation bar inset을 반영 |
| 리스트 높이 보정 | `SpotBottomList`의 고정 높이 제한을 제거하고 남은 영역을 자연스럽게 채우도록 수정 |
| 상세 시트 보정 | 상세 바텀시트 하단 padding을 보정해 `목록으로` 버튼이 가려지지 않도록 개선 |
| 단계 보정 | 기존 Peek / Medium / Expanded 흐름에 Half 중간 스냅 단계를 추가 |
| 기존 동작 유지 | 지도 검색, 현재 위치 검색, 현 지도 검색, 마커 선택, 카드 선택, 즐겨찾기 토글 동작 유지 |

## 주요 변경 사항

| 파일 | 변경 내용 |
| --- | --- |
| `ThreeStepMapBottomSheet` | 바텀시트 위치 보정 방식 정리, Half 스냅 단계 추가 |
| `CollectionSpotMapScreen` | 하단 inset 전달 및 FAB padding 계산 정리 |
| `SpotBottomSheetContent` | 상세/리스트 콘텐츠 하단 padding 전달 |
| `SpotBottomList` | 고정 max height 제거, 확장 시 리스트 영역을 채우도록 변경 |

## 하단 영역 관련 정리

바텀시트 컨테이너 자체를 `navigationBar` inset만큼 위로 올리면 기기별로 시트가 공중에 뜨거나 앱 BottomNavigationBar 뒤에서 일부 보이는 문제가 생길 수 있어, 이번 PR에서는 컨테이너 위치는 하단 기준으로 유지했습니다.

대신 시스템 navigation bar 보정은 리스트 / 상세 콘텐츠 내부 padding에 반영했습니다.

단말기에서는 시스템 navigation bar 영역 때문에 확장 상태에서 마지막 카드 일부가 살짝 보일 수 있지만, 리스트가 스크롤 가능한 영역 안에서 다음 카드가 일부 노출되는 상태이며 주요 콘텐츠가 하단탭에 가려지는 문제는 해소했습니다.

## 검증

| 항목 | 결과 |
| --- | --- |
| 에뮬레이터에서 접힘 상태 시 앱 하단탭 뒤로 바텀시트가 보이지 않는지 | 확인 |
| 실제 단말에서 접힘 상태 시 앱 하단탭과 바텀시트가 겹치지 않는지 | 확인 |
| 바텀시트 Half 중간 스냅 동작 | 확인 |
| Expanded 상태에서 리스트가 자연스럽게 표시되는지 | 확인 |
| 상세 바텀시트 `목록으로` 버튼 노출 | 확인 |
| 지도 클릭 시 바텀시트 접힘 동작 | 확인 |
| 지도 검색 / 현재 위치 검색 / 현 지도 검색 동작 | 확인 |
| 마커 선택 / 카드 선택 / 즐겨찾기 토글 동작 | 확인 |

## 테스트

```bash
./gradlew.bat :presentation:compileDebugKotlin
```

## 스크린샷

### 에뮬레이터

| 초기 위치 | 중간 위치 | 확장 위치 |
| --- | --- | --- |
| <img width="240" alt="에뮬레이터 바텀시트 초기 화면" src="https://github.com/user-attachments/assets/472606d9-5b9b-4db8-8b54-6fe0e5a7bbda" /> | <img width="240" alt="에뮬레이터 바텀시트 중간 위치" src="https://github.com/user-attachments/assets/d1d35a65-8b38-4242-8dfd-8d46d51b174c" /> | <img width="240" alt="에뮬레이터 바텀시트 확장 위치" src="https://github.com/user-attachments/assets/8c38ca5b-9059-4942-b653-7641fbea96af" /> |

### 실제 단말

| 초기 위치 | 중간 위치 | 확장 위치 |
| --- | --- | --- |
| <img width="240" alt="단말기 바텀시트 초기 화면" src="https://github.com/user-attachments/assets/68256656-6e1f-4897-82c1-b624eaa81965" /> | <img width="240" alt="단말기 바텀시트 중간 위치" src="https://github.com/user-attachments/assets/aec7feb2-603b-429f-93ec-45e0a9f25a36" /> | <img width="240" alt="단말기 바텀시트 확장 위치" src="https://github.com/user-attachments/assets/f9fbd2e0-3749-41f2-b86d-47d18095bba2" /> |