### PR TITLE
feat: 지도 선택 상세 뒤로가기 UX 개선

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -371,6 +371,7 @@ private fun CollectionSpotMapContent(
                             onFavoriteClick = onSpotFavoriteClick,
                             onRegionalGuideClick = onRegionalGuideClick,
                             onCloseClick = {
+                                onSpotDetailDismiss()
                                 mapUiMode = MapUiMode.ResultList
                                 sheetLevel = MapSheetLevel.Peek
                             },

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -3,6 +3,7 @@ package com.team.yeogibeoryeo.presentation.map
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -116,6 +117,7 @@ fun CollectionSpotMapScreen(
         },
         onTypeClick = viewModel::onSpotTypeClick,
         onSpotClick = viewModel::onSpotClick,
+        onSpotDetailDismiss = viewModel::clearSelectedSpot,
         onSpotFavoriteClick = viewModel::onSpotFavoriteClick,
         onBottomBarVisibilityChanged = onBottomBarVisibilityChanged,
         onRegionalGuideClick = onRegionalGuideClick,
@@ -136,6 +138,7 @@ private fun CollectionSpotMapContent(
     onLocationNoticeActionClick: (MapLocationNoticeAction) -> Unit,
     onTypeClick: (CollectionSpotType) -> Unit,
     onSpotClick: (CollectionSpot) -> Unit,
+    onSpotDetailDismiss: () -> Unit,
     onSpotFavoriteClick: (CollectionSpot) -> Unit,
     onBottomBarVisibilityChanged: (Boolean) -> Unit,
     onRegionalGuideClick: (String) -> Unit,
@@ -162,6 +165,18 @@ private fun CollectionSpotMapContent(
         !isLocationPermissionGranted -> LocationTrackingMode.None
         locationTrackingMode == LocationTrackingMode.None -> LocationTrackingMode.NoFollow
         else -> locationTrackingMode
+    }
+    val hasResultListToReturn = uiState.hasSearched || uiState.spots.isNotEmpty()
+
+    BackHandler(enabled = mapUiMode == MapUiMode.SpotDetail && selectedSpot != null) {
+        onSpotDetailDismiss()
+        mapUiMode = if (hasResultListToReturn) {
+            sheetLevel = MapSheetLevel.Peek
+            MapUiMode.ResultList
+        } else {
+            sheetLevel = MapSheetLevel.Hidden
+            MapUiMode.Browsing
+        }
     }
 
     LaunchedEffect(isLocationPermissionGranted) {
@@ -442,6 +457,7 @@ private fun CollectionSpotMapContentPreview() {
                 onLocationNoticeActionClick = {},
                 onTypeClick = {},
                 onSpotClick = {},
+                onSpotDetailDismiss = {},
                 onSpotFavoriteClick = {},
                 onBottomBarVisibilityChanged = {},
                 onRegionalGuideClick = {},

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -278,6 +278,12 @@ class CollectionSpotMapViewModel @Inject constructor(
         }
     }
 
+    fun clearSelectedSpot() {
+        _uiState.update {
+            it.copy(selectedSpot = null)
+        }
+    }
+
     fun showFavoriteSpot(request: FavoriteSpotMapMoveRequest) {
         if (!consumedFavoriteSpotMoveRequestIds.add(request.requestId)) return
 

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -371,6 +371,61 @@ class CollectionSpotMapViewModelTest {
         }
 
     @Test
+    fun `선택 상세를 닫으면 선택된 장소만 해제하고 검색 결과와 필터 상태는 유지한다`() =
+        runTest {
+            val selectedSpot = sampleSpot("1", CollectionSpotType.STANDARD_BAG_STORE)
+            val filteredOutSpot = sampleSpot("2", CollectionSpotType.RECYCLING_CENTER)
+            val repository = FakeCollectionSpotRepository(
+                locationSpots = listOf(selectedSpot, filteredOutSpot),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+            )
+
+            viewModel.searchByCurrentLocation()
+            viewModel.onSpotTypeClick(CollectionSpotType.STANDARD_BAG_STORE)
+            viewModel.onSpotClick(selectedSpot)
+
+            viewModel.clearSelectedSpot()
+
+            assertNull(viewModel.uiState.value.selectedSpot)
+            assertEquals(setOf(CollectionSpotType.STANDARD_BAG_STORE), viewModel.uiState.value.selectedTypes)
+            assertEquals(
+                listOf(selectedSpot).withDistanceFrom(Coordinate(latitude = 37.5666102, longitude = 126.9783881)),
+                viewModel.uiState.value.spots,
+            )
+            assertEquals(MapSearchMode.CURRENT_LOCATION, viewModel.uiState.value.searchMode)
+            assertEquals(true, viewModel.uiState.value.hasSearched)
+        }
+
+    @Test
+    fun `검색 결과 없이 선택된 즐겨찾기 장소 상세를 닫아도 앱이 깨지지 않고 선택만 해제한다`() =
+        runTest {
+            val request = FavoriteSpotMapMoveRequest(
+                requestId = "request-1",
+                targetId = "favorite-spot",
+                name = "즐겨찾기 수거함",
+                type = CollectionSpotType.STANDARD_BAG_STORE,
+                address = "서울특별시 성동구 용답동",
+                detailLocation = null,
+                coordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+            )
+            val viewModel = createViewModel(
+                repository = FakeCollectionSpotRepository(),
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.showFavoriteSpot(request)
+            viewModel.clearSelectedSpot()
+
+            assertNull(viewModel.uiState.value.selectedSpot)
+            assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
+        }
+
+    @Test
     fun `현재 위치 검색 중 키워드 검색을 실행하면 최신 키워드 검색 결과를 유지한다`() =
         runTest {
             val locationResult = CompletableDeferred<CurrentLocationResult>()


### PR DESCRIPTION
## 작업 내용

Related #195

지도 화면에서 마커 또는 카드 선택으로 장소 상세 BottomSheet가 표시된 상태에서 시스템 뒤로가기를 눌렀을 때, 앱이 바로 홈 화면으로 이동하지 않고 지도 내부 선택 상태를 먼저 해제하도록 개선했습니다.

| 구분 | 내용 |
| --- | --- |
| BackHandler 추가 | `SpotDetail` 상태이면서 `selectedSpot`이 있을 때만 시스템 뒤로가기를 consume |
| 선택 상태 해제 | 뒤로가기 시 `selectedSpot`을 해제해 선택된 마커 / 카드 강조 상태 제거 |
| 결과 목록 복귀 | 검색 결과가 있으면 `ResultList + Peek` 상태로 복귀 |
| 기본 상태 복귀 | 검색 결과가 없으면 `Browsing + Hidden` 상태로 복귀 |
| 기존 Navigation 유지 | 내부에서 처리할 선택 상태가 없으면 기존 Navigation back 동작 유지 |

## 주요 변경 사항

| 파일 | 변경 내용 |
| --- | --- |
| `CollectionSpotMapScreen` | 상세 선택 상태 전용 `BackHandler` 추가 |
| `CollectionSpotMapViewModel` | 선택 상태 해제 이벤트 `clearSelectedSpot()` 추가 |
| `CollectionSpotMapViewModelTest` | 선택 해제 시 검색 결과 / 필터 상태 유지 테스트 추가 |

## 유지한 정책

- 앱 전체 Navigation 구조 변경 없음
- BottomNavigation 구조 변경 없음
- 기존 지도 검색 / 현재 위치 검색 / 현 지도 검색 동작 유지
- 기존 마커 선택 / 카드 선택 / BottomSheet 드래그 동작 유지
- 기존 필터 chip 동작 유지
- 기존 즐겨찾기 토글 동작 유지
- #174 거리 표시 정책 유지
- #175 BottomSheet inset / Half 스냅 단계 유지
- #194 geocoding 성능 개선 코드 변경 없음

## 검증

| 항목 | 결과 |
| --- | --- |
| 마커 선택 후 시스템 뒤로가기 시 상세만 닫히는지 | 확인 |
| 카드 선택 후 시스템 뒤로가기 시 결과 목록으로 복귀하는지 | 확인 |
| 다시 뒤로가기 시 기존 Navigation 동작으로 홈 화면 이동하는지 | 확인 |
| 선택된 마커 / 카드 강조 상태가 해제되는지 | 확인 |
| 기존 검색 / 필터 / 즐겨찾기 동작이 유지되는지 | 확인 |
| BottomSheet Peek / Medium / Half / Expanded 동작이 유지되는지 | 확인 |

## 테스트

```bash
./gradlew.bat :presentation:testDebugUnitTest --tests com.team.yeogibeoryeo.presentation.map.CollectionSpotMapViewModelTest :presentation:compileDebugKotlin
./gradlew.bat :presentation:testDebugUnitTest :app:assembleDebug
git diff --check
```
## 스크린샷

| 목록 BottomSheet | 마커 선택 상세 |
| --- | --- |
| <img width="260" alt="지도 목록 BottomSheet 화면" src="https://github.com/user-attachments/assets/292c43e7-eee4-4680-8f63-5c84847f1cbb" /> | <img width="260" alt="마커 선택 상세 BottomSheet 화면" src="https://github.com/user-attachments/assets/e71f4d59-a171-4215-8e59-fecaea3d5ec5" /> |

| 뒤로가기 1회: 목록 복귀 | 뒤로가기 2회: 홈 이동 |
| --- | --- |
| <img width="260" alt="뒤로가기 1회 후 결과 목록 복귀 화면" src="https://github.com/user-attachments/assets/48525ef2-3040-4bfc-b543-cccefbf98e62" /> | <img width="260" alt="뒤로가기 2회 후 홈 화면 이동" src="https://github.com/user-attachments/assets/86e6945f-04fb-4e94-a02d-bd232583d52c" /> |