### PR TITLE
fix: 위치 상태 변경 후 지도 안내 문구 갱신

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -12,10 +12,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -25,6 +27,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.naver.maps.map.compose.LocationTrackingMode
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
@@ -55,6 +60,7 @@ fun CollectionSpotMapScreen(
     viewModel: CollectionSpotMapViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val hasFineLocationPermission = rememberFineLocationPermissionGranted()
     var hasGrantedLocationPermissionInSession by rememberSaveable {
@@ -65,6 +71,8 @@ fun CollectionSpotMapScreen(
     }
     val isLocationPermissionGranted =
         hasFineLocationPermission || hasGrantedLocationPermissionInSession
+    val currentLocationNotice by rememberUpdatedState(uiState.locationNotice)
+    val currentHasFineLocationPermission by rememberUpdatedState(hasFineLocationPermission)
     var locationTrackingMode by remember {
         mutableStateOf(LocationTrackingMode.None)
     }
@@ -78,6 +86,26 @@ fun CollectionSpotMapScreen(
             viewModel.searchByCurrentLocation()
         }
         previousFineLocationPermission = hasFineLocationPermission
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (
+                event == Lifecycle.Event.ON_RESUME &&
+                currentHasFineLocationPermission &&
+                currentLocationNotice.shouldRetryCurrentLocationSearchOnResume()
+            ) {
+                hasGrantedLocationPermissionInSession = true
+                previousFineLocationPermission = true
+                locationTrackingMode = LocationTrackingMode.NoFollow
+                viewModel.searchByCurrentLocation()
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
     }
 
     val requestCurrentLocationSearch = rememberCurrentLocationSearchRequester(
@@ -492,4 +520,10 @@ private fun MapLocationNoticeAction.toIntent(packageName: String): Intent {
             Settings.ACTION_LOCATION_SOURCE_SETTINGS,
         )
     }
+}
+
+private fun MapLocationNotice?.shouldRetryCurrentLocationSearchOnResume(): Boolean {
+    return this == MapLocationNotices.PermissionDenied ||
+        this == MapLocationNotices.LocationServiceDisabled ||
+        this == MapLocationNotices.CurrentLocationUnavailable
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTest.kt
@@ -515,6 +515,39 @@ class CollectionSpotMapViewModelTest {
         }
 
     @Test
+    fun `현재 위치 검색 실패 안내 후 재시도에 성공하면 이전 notice를 정리하고 결과를 표시한다`() =
+        runTest {
+            val currentCoordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881)
+            val locationSpot = sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)
+            var currentLocationResult: CurrentLocationResult = CurrentLocationResult.LocationServiceDisabled
+            val repository = FakeCollectionSpotRepository(
+                locationSpots = listOf(locationSpot),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationProvider = FakeCurrentLocationProvider {
+                    currentLocationResult
+                },
+            )
+
+            viewModel.searchByCurrentLocation()
+            advanceUntilIdle()
+
+            assertEquals("위치 서비스가 꺼져 있습니다.", viewModel.uiState.value.locationNotice?.title)
+
+            currentLocationResult = CurrentLocationResult.Found(currentCoordinate)
+            viewModel.searchByCurrentLocation()
+            advanceUntilIdle()
+
+            assertEquals(listOf(locationSpot).withDistanceFrom(currentCoordinate), viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.CURRENT_LOCATION, viewModel.uiState.value.searchMode)
+            assertNull(viewModel.uiState.value.locationNotice)
+            assertNull(viewModel.uiState.value.locationNoticeMessage)
+            assertNull(viewModel.uiState.value.errorMessage)
+            assertFalse(viewModel.uiState.value.isLoading)
+        }
+
+    @Test
     fun `키워드 검색 후 현재 위치 검색을 실행하면 검색어를 유지하고 현재 위치 결과를 반영한다`() =
         runTest {
             val keywordSpot = sampleSpot("keyword", CollectionSpotType.OTHER)


### PR DESCRIPTION
## 작업 내용

Related #196

지도 화면에서 위치 권한 또는 위치 서비스 상태가 변경된 뒤에도 기존 위치 안내 문구가 남아 있는 문제를 개선했습니다.

기존에는 `위치 권한이 필요합니다`, `위치 서비스가 꺼져 있습니다`, `현재 위치를 확인하지 못했습니다` 같은 안내가 표시된 뒤 설정 화면에서 상태를 바꾸고 돌아와도, 일부 환경에서는 이전 안내가 그대로 남을 수 있었습니다.

이번 작업에서는 Map 화면 복귀 시점에 기존 위치 안내 상태를 확인하고, 위치 권한이 허용된 상태라면 현재 위치 검색을 다시 시도하도록 연결했습니다.

## 주요 변경 사항

| 구분 | 내용 |
| --- | --- |
| lifecycle 처리 | Map 화면 `ON_RESUME` 시 기존 위치 안내 상태 확인 |
| 재시도 조건 | 위치 권한이 허용되어 있고, 현재 notice가 재시도 대상인 경우 현재 위치 검색 재시도 |
| 재시도 대상 notice | `PermissionDenied`, `LocationServiceDisabled`, `CurrentLocationUnavailable` |
| 책임 분리 | Screen은 lifecycle 이벤트 연결만 담당하고, ViewModel은 기존 현재 위치 검색 상태 갱신 흐름 유지 |
| 안내 상태 정리 | 현재 위치 검색 재시도 성공 시 `locationNotice` / `locationNoticeMessage` 정리 |
| 테스트 | 재시도 성공 시 기존 notice가 정리되고 현재 위치 결과가 표시되는 ViewModel 테스트 추가 |

## 정책

| 항목 | 정책 |
| --- | --- |
| 권한 허용 후 복귀 | 기존 권한 안내를 정리하고 현재 위치 검색 재시도 |
| 위치 서비스 설정 후 복귀 | 권한이 있고 기존 안내가 위치 관련 notice라면 현재 위치 검색 재시도 |
| 위치 좌표 미확인 | 재시도 후에도 좌표를 가져오지 못하면 기존처럼 `현재 위치를 확인하지 못했습니다` 안내 표시 |
| 에뮬레이터 | 실제 좌표가 주입되지 않으면 권한 허용 상태여도 현재 위치 검색이 실패할 수 있음 |
| 실기기 | 기존 권한 허용 후 복귀 흐름 유지 |

## 검증

| 항목 | 결과 |
| --- | --- |
| 실기기에서 위치 권한 허용 후 복귀 시 기존 안내 정리 | 확인 |
| 에뮬레이터에서 위치 권한 거부 안내 표시 | 확인 |
| 에뮬레이터에서 바텀시트 설정 이동 후 권한 허용 시 안내 갱신 | 확인 |
| 에뮬레이터에서 백그라운드 설정 화면에서 권한 허용 후 복귀 시 안내 정리 | 확인 |
| 기존 현재 위치 검색 동작 | 확인 |
| 기존 BottomSheet / 지도 overlay 동작 | 확인 |

## 테스트

```bash
./gradlew.bat :presentation:testDebugUnitTest --tests com.team.yeogibeoryeo.presentation.map.CollectionSpotMapViewModelTest :presentation:compileDebugKotlin
./gradlew.bat :presentation:testDebugUnitTest :app:assembleDebug
git diff --check

```

## 스크린샷

에뮬레이터에서 재현되던 stale notice 정리 흐름을 기준으로 확인했습니다.  
실기기는 기존에도 권한 허용 후 복귀 흐름이 정상 동작했기 때문에, 이번 PR에서는 문제가 확인되던 에뮬레이터 흐름을 중심으로 첨부합니다.

| 위치 권한 거부 안내 | 앱 설정 화면 이동 |
| --- | --- |
| <img width="260" alt="위치 권한 거부 안내" src="https://github.com/user-attachments/assets/064030d5-1917-46f2-b57d-50d8bda9c77f" /> | <img width="260" alt="앱 설정 화면" src="https://github.com/user-attachments/assets/6fc1d4af-ffbe-43fe-97c5-e11c453febe5" /> |

| 백그라운드 설정 화면에서 권한 허용 | 지도 복귀 후 안내 문구 정리 |
| --- | --- |
| <img width="260" alt="백그라운드 설정 화면에서 위치 권한 허용" src="https://github.com/user-attachments/assets/54fd79b2-fe73-4164-ad15-a0c4dd87b5f3" /> | <img width="260" alt="지도 화면 복귀 후 위치 권한 안내 문구 정리" src="https://github.com/user-attachments/assets/208c569c-6f24-402c-9a9e-18b7c587df48" /> |

## 참고

에뮬레이터는 위치 권한을 허용해도 실제 위치 좌표가 주입되지 않으면 현재 위치 검색 결과가 표시되지 않을 수 있습니다.  
이 경우는 이번 stale notice 문제와 별개로, 에뮬레이터 위치 좌표 주입 여부에 따른 정상 제약으로 봤습니다.