### PR TITLE
[Feature] 설정 화면 UI 추가

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
@@ -51,8 +51,19 @@ data object SettingsRoute
 
 @Serializable
 data class SettingsDetailRoute(
-    val detailType: String,
+    val detailType: SettingsDetailRouteType,
 )
+
+@Serializable
+enum class SettingsDetailRouteType {
+    Notice,
+    Contact,
+    AppInfo,
+    LocationPermission,
+    Terms,
+    Sources,
+    Cache,
+}
 
 @Serializable
 data class ItemUsefulGuideRoute(

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/AppRoute.kt
@@ -47,6 +47,14 @@ data class QuickCategorySettingsRoute(
 )
 
 @Serializable
+data object SettingsRoute
+
+@Serializable
+data class SettingsDetailRoute(
+    val detailType: String,
+)
+
+@Serializable
 data class ItemUsefulGuideRoute(
     val guideType: String,
 )

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/BottomTabNavigation.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/BottomTabNavigation.kt
@@ -58,6 +58,8 @@ internal fun NavHostController.createBottomNavigationItems(
 private fun NavBackStackEntry?.isItemSearchSelected(): Boolean =
     this?.destination?.hasRoute<ItemSearchRoute>() == true ||
         this?.destination?.hasRoute<QuickCategorySettingsRoute>() == true ||
+        this?.destination?.hasRoute<SettingsRoute>() == true ||
+        this?.destination?.hasRoute<SettingsDetailRoute>() == true ||
         isItemGuideDetailSource(ItemGuideDetailSource.SEARCH)
 
 private fun NavBackStackEntry?.isFavoritesSelected(): Boolean =

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -220,7 +220,7 @@ fun YeogiBeoryeoNavHost(
                 SettingsScreenRoute(
                     onBackClick = navController::popBackStack,
                     onDetailClick = { detailType ->
-                        navController.navigate(SettingsDetailRoute(detailType.routeValue))
+                        navController.navigate(SettingsDetailRoute(detailType.toRouteType()))
                     },
                 )
             }
@@ -228,7 +228,7 @@ fun YeogiBeoryeoNavHost(
             composable<SettingsDetailRoute> { backStackEntry ->
                 val route = backStackEntry.toRoute<SettingsDetailRoute>()
                 SettingsDetailScreenRoute(
-                    detailType = SettingsDetailType.fromRouteValue(route.detailType),
+                    detailType = route.detailType.toScreenType(),
                     onBackClick = navController::popBackStack,
                     onOpenAppSettingsClick = {
                         currentContext.openAppSettings()
@@ -299,6 +299,28 @@ fun YeogiBeoryeoNavHost(
 }
 
 private const val FreePickupGuideUrl = "https://www.15990903.or.kr/portal/cnts/userGuide.do"
+
+private fun SettingsDetailType.toRouteType(): SettingsDetailRouteType =
+    when (this) {
+        SettingsDetailType.Notice -> SettingsDetailRouteType.Notice
+        SettingsDetailType.Contact -> SettingsDetailRouteType.Contact
+        SettingsDetailType.AppInfo -> SettingsDetailRouteType.AppInfo
+        SettingsDetailType.LocationPermission -> SettingsDetailRouteType.LocationPermission
+        SettingsDetailType.Terms -> SettingsDetailRouteType.Terms
+        SettingsDetailType.Sources -> SettingsDetailRouteType.Sources
+        SettingsDetailType.Cache -> SettingsDetailRouteType.Cache
+    }
+
+private fun SettingsDetailRouteType.toScreenType(): SettingsDetailType =
+    when (this) {
+        SettingsDetailRouteType.Notice -> SettingsDetailType.Notice
+        SettingsDetailRouteType.Contact -> SettingsDetailType.Contact
+        SettingsDetailRouteType.AppInfo -> SettingsDetailType.AppInfo
+        SettingsDetailRouteType.LocationPermission -> SettingsDetailType.LocationPermission
+        SettingsDetailRouteType.Terms -> SettingsDetailType.Terms
+        SettingsDetailRouteType.Sources -> SettingsDetailType.Sources
+        SettingsDetailRouteType.Cache -> SettingsDetailType.Cache
+    }
 
 private fun android.content.Context.openAppSettings() {
     val uri = Uri.fromParts("package", packageName, null)

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -235,6 +235,7 @@ fun YeogiBeoryeoNavHost(
                     onOpenAppSettingsClick = {
                         currentContext.openAppSettings()
                     },
+                    onClearLocationCacheClick = ::clearLocationCache,
                 )
             }
 
@@ -331,3 +332,5 @@ private fun android.content.Context.openAppSettings() {
         startActivity(intent)
     }
 }
+
+private fun clearLocationCache() = Unit

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -2,6 +2,7 @@ package com.team.yeogibeoryeo.navigation
 
 import android.content.Intent
 import android.net.Uri
+import android.provider.Settings
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
@@ -44,6 +45,9 @@ import com.team.yeogibeoryeo.presentation.search.ItemSearchRoute as ItemSearchSc
 import com.team.yeogibeoryeo.presentation.search.ItemUsefulGuideRoute as ItemUsefulGuideScreenRoute
 import com.team.yeogibeoryeo.presentation.search.QuickCategorySettingsRoute as QuickCategorySettingsScreenRoute
 import com.team.yeogibeoryeo.presentation.search.model.ItemUsefulGuideType
+import com.team.yeogibeoryeo.presentation.settings.SettingsDetailRoute as SettingsDetailScreenRoute
+import com.team.yeogibeoryeo.presentation.settings.SettingsDetailType
+import com.team.yeogibeoryeo.presentation.settings.SettingsRoute as SettingsScreenRoute
 
 @Composable
 fun YeogiBeoryeoNavHost(
@@ -198,6 +202,9 @@ fun YeogiBeoryeoNavHost(
                             QuickCategorySettingsRoute(maxSelectedCount = maxSelectedCount),
                         )
                     },
+                    onSettingsClick = {
+                        navController.navigate(SettingsRoute)
+                    },
                 )
             }
 
@@ -206,6 +213,26 @@ fun YeogiBeoryeoNavHost(
                 QuickCategorySettingsScreenRoute(
                     maxSelectedCount = route.maxSelectedCount,
                     onBackClick = navController::popBackStack,
+                )
+            }
+
+            composable<SettingsRoute> {
+                SettingsScreenRoute(
+                    onBackClick = navController::popBackStack,
+                    onDetailClick = { detailType ->
+                        navController.navigate(SettingsDetailRoute(detailType.routeValue))
+                    },
+                )
+            }
+
+            composable<SettingsDetailRoute> { backStackEntry ->
+                val route = backStackEntry.toRoute<SettingsDetailRoute>()
+                SettingsDetailScreenRoute(
+                    detailType = SettingsDetailType.fromRouteValue(route.detailType),
+                    onBackClick = navController::popBackStack,
+                    onOpenAppSettingsClick = {
+                        currentContext.openAppSettings()
+                    },
                 )
             }
 
@@ -272,3 +299,11 @@ fun YeogiBeoryeoNavHost(
 }
 
 private const val FreePickupGuideUrl = "https://www.15990903.or.kr/portal/cnts/userGuide.do"
+
+private fun android.content.Context.openAppSettings() {
+    val uri = Uri.fromParts("package", packageName, null)
+    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, uri)
+    runCatching {
+        startActivity(intent)
+    }
+}

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -36,6 +36,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
+import com.team.yeogibeoryeo.BuildConfig
 import com.team.yeogibeoryeo.common.navigation.AppBottomNavigationBar
 import com.team.yeogibeoryeo.presentation.favorites.FavoritesRoute as FavoritesScreenRoute
 import com.team.yeogibeoryeo.presentation.map.CollectionSpotMapScreen
@@ -229,6 +230,7 @@ fun YeogiBeoryeoNavHost(
                 val route = backStackEntry.toRoute<SettingsDetailRoute>()
                 SettingsDetailScreenRoute(
                     detailType = route.detailType.toScreenType(),
+                    appVersionName = BuildConfig.VERSION_NAME,
                     onBackClick = navController::popBackStack,
                     onOpenAppSettingsClick = {
                         currentContext.openAppSettings()

--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -54,6 +54,7 @@ import com.team.yeogibeoryeo.presentation.settings.SettingsRoute as SettingsScre
 fun YeogiBeoryeoNavHost(
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
+    onClearLocationCacheClick: () -> Unit = {},
 ) {
     val currentContext by rememberUpdatedState(LocalContext.current)
     val layoutDirection = LocalLayoutDirection.current
@@ -235,7 +236,7 @@ fun YeogiBeoryeoNavHost(
                     onOpenAppSettingsClick = {
                         currentContext.openAppSettings()
                     },
-                    onClearLocationCacheClick = ::clearLocationCache,
+                    onClearLocationCacheClick = onClearLocationCacheClick,
                 )
             }
 
@@ -332,5 +333,3 @@ private fun android.content.Context.openAppSettings() {
         startActivity(intent)
     }
 }
-
-private fun clearLocationCache() = Unit

--- a/common/src/main/res/drawable/ic_action_settings.xml
+++ b/common/src/main/res/drawable/ic_action_settings.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M10.325,4.317c0.426,-1.756 2.924,-1.756 3.35,0a1.724,1.724 0,0 0,2.573 1.066c1.543,-0.94 3.31,0.826 2.37,2.37a1.724,1.724 0,0 0,1.065 2.572c1.756,0.426 1.756,2.924 0,3.35a1.724,1.724 0,0 0,-1.066 2.573c0.94,1.543 -0.826,3.31 -2.37,2.37a1.724,1.724 0,0 0,-2.572 1.065c-0.426,1.756 -2.924,1.756 -3.35,0a1.724,1.724 0,0 0,-2.573 -1.066c-1.543,0.94 -3.31,-0.826 -2.37,-2.37a1.724,1.724 0,0 0,-1.065 -2.572c-1.756,-0.426 -1.756,-2.924 0,-3.35a1.724,1.724 0,0 0,1.066 -2.573c-0.94,-1.543 0.826,-3.31 2.37,-2.37c1,0.608 2.296,0.07 2.572,-1.065"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M9,12a3,3 0,1 0,6 0a3,3 0,0 0,-6 0"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+</vector>

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Icon
@@ -30,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import com.team.yeogibeoryeo.presentation.R
@@ -42,6 +42,7 @@ import com.team.yeogibeoryeo.presentation.search.model.HomeRegionalGuideSummaryU
 import com.team.yeogibeoryeo.presentation.search.model.ItemUsefulGuideContent
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
 import com.team.yeogibeoryeo.presentation.search.model.itemUsefulGuideContents
+import com.team.yeogibeoryeo.common.R as CommonR
 
 @Composable
 fun ItemSearchInitialContent(
@@ -242,7 +243,7 @@ fun ItemSearchHeader(
         if (onSettingsClick != null) {
             IconButton(onClick = onSettingsClick) {
                 Icon(
-                    imageVector = Icons.Filled.Settings,
+                    painter = painterResource(id = CommonR.drawable.ic_action_settings),
                     contentDescription = stringResource(R.string.settings_action),
                     tint = MaterialTheme.colorScheme.onSurface,
                 )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
@@ -66,7 +66,7 @@ fun ItemSearchInitialContent(
     onQuickCategoryMoreClick: (Int, Int, Int) -> Unit,
     onQuickCategoryCollapseClick: () -> Unit,
     onQuickCategoryViewportChanged: () -> Unit,
-    onSettingsClick: () -> Unit,
+    onSettingsClick: (() -> Unit)?,
     listState: LazyListState,
 ) {
     var viewportBottomInRootPx by rememberSaveable { mutableIntStateOf(0) }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
@@ -13,9 +13,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -63,6 +65,7 @@ fun ItemSearchInitialContent(
     onQuickCategoryMoreClick: (Int, Int, Int) -> Unit,
     onQuickCategoryCollapseClick: () -> Unit,
     onQuickCategoryViewportChanged: () -> Unit,
+    onSettingsClick: () -> Unit,
     listState: LazyListState,
 ) {
     var viewportBottomInRootPx by rememberSaveable { mutableIntStateOf(0) }
@@ -112,7 +115,7 @@ fun ItemSearchInitialContent(
             verticalArrangement = Arrangement.spacedBy(metrics.screenVerticalSpace),
         ) {
             item {
-                ItemSearchHeader()
+                ItemSearchHeader(onSettingsClick = onSettingsClick)
             }
 
             item {
@@ -211,23 +214,39 @@ fun ItemSearchInitialContent(
 @Composable
 fun ItemSearchHeader(
     modifier: Modifier = Modifier,
+    onSettingsClick: (() -> Unit)? = null,
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
 
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(spacing.xs),
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        verticalAlignment = Alignment.Top,
     ) {
-        Text(
-            text = stringResource(R.string.item_search_title),
-            style = MaterialTheme.typography.headlineLarge,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-        Text(
-            text = stringResource(R.string.item_search_description),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(spacing.xs),
+        ) {
+            Text(
+                text = stringResource(R.string.item_search_title),
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(R.string.item_search_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (onSettingsClick != null) {
+            IconButton(onClick = onSettingsClick) {
+                Icon(
+                    imageVector = Icons.Filled.Settings,
+                    contentDescription = stringResource(R.string.settings_action),
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+        }
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -123,7 +123,7 @@ fun ItemSearchScreen(
     onQuickCategoryCollapseClick: () -> Unit = {},
     onQuickCategoryViewportChanged: () -> Unit = {},
     onQuickCategorySettingsClick: (Int) -> Unit = {},
-    onSettingsClick: () -> Unit = {},
+    onSettingsClick: (() -> Unit)? = null,
     searchResultListState: LazyListState = rememberLazyListState(),
     categoryListState: LazyListState = rememberLazyListState(),
 ) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -44,6 +44,7 @@ fun ItemSearchRoute(
     onUsefulGuideClick: (ItemUsefulGuideContent) -> Unit,
     onRegionalGuideSummaryClick: (String) -> Unit,
     onQuickCategorySettingsClick: (Int) -> Unit,
+    onSettingsClick: () -> Unit,
     viewModel: ItemSearchViewModel = hiltViewModel(),
     regionalGuideSummaryViewModel: HomeRegionalGuideSummaryViewModel = hiltViewModel(),
 ) {
@@ -100,6 +101,7 @@ fun ItemSearchRoute(
         onQuickCategoryViewportChanged =
             viewModel::resetQuickCategoryFixedCollapsedItemCountIfCollapsed,
         onQuickCategorySettingsClick = onQuickCategorySettingsClick,
+        onSettingsClick = onSettingsClick,
         searchResultListState = searchResultListState,
         categoryListState = categoryListState,
     )
@@ -121,6 +123,7 @@ fun ItemSearchScreen(
     onQuickCategoryCollapseClick: () -> Unit = {},
     onQuickCategoryViewportChanged: () -> Unit = {},
     onQuickCategorySettingsClick: (Int) -> Unit = {},
+    onSettingsClick: () -> Unit = {},
     searchResultListState: LazyListState = rememberLazyListState(),
     categoryListState: LazyListState = rememberLazyListState(),
 ) {
@@ -146,6 +149,7 @@ fun ItemSearchScreen(
             onQuickCategoryMoreClick = onQuickCategoryMoreClick,
             onQuickCategoryCollapseClick = onQuickCategoryCollapseClick,
             onQuickCategoryViewportChanged = onQuickCategoryViewportChanged,
+            onSettingsClick = onSettingsClick,
             listState = categoryListState,
             modifier = modifier,
         )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/SettingsRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/SettingsRoute.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
@@ -83,6 +84,7 @@ fun SettingsDetailRoute(
     appVersionName: String,
     onBackClick: () -> Unit,
     onOpenAppSettingsClick: () -> Unit,
+    onClearLocationCacheClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     SettingsScaffold(
@@ -112,7 +114,9 @@ fun SettingsDetailRoute(
                 }
                 SettingsDetailType.Terms -> item { TermsDetail() }
                 SettingsDetailType.Sources -> item { SourcesDetail() }
-                SettingsDetailType.Cache -> item { CacheDetail() }
+                SettingsDetailType.Cache -> item {
+                    CacheDetail(onClearLocationCacheClick = onClearLocationCacheClick)
+                }
             }
         }
     }
@@ -165,7 +169,10 @@ private fun SettingsListItem(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick),
+            .clickable(
+                role = Role.Button,
+                onClick = onClick,
+            ),
     ) {
         Row(
             modifier = Modifier
@@ -305,13 +312,15 @@ private fun SourcesDetail() {
 }
 
 @Composable
-private fun CacheDetail() {
+private fun CacheDetail(
+    onClearLocationCacheClick: () -> Unit,
+) {
     SettingsDetailContent {
         SettingsSection(
             title = stringResource(R.string.settings_cache_detail_title),
             description = stringResource(R.string.settings_cache_confirm_description),
         )
-        Button(onClick = {}) {
+        Button(onClick = onClearLocationCacheClick) {
             Text(text = stringResource(R.string.settings_cache_delete_action))
         }
     }
@@ -410,5 +419,5 @@ private object SettingsLayoutDefaults {
     val detailItemSpacing: Dp = 24.dp
     val detailContentSpacing: Dp = 20.dp
     val sectionSpacing: Dp = 8.dp
-    val infoRowSpacing: Dp = 6.dp
+    val infoRowSpacing: Dp = 8.dp
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/SettingsRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/SettingsRoute.kt
@@ -34,22 +34,15 @@ import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.presentation.R
 
 enum class SettingsDetailType(
-    val routeValue: String,
     @param:StringRes val titleResId: Int,
 ) {
-    Notice("notice", R.string.settings_notice_title),
-    Contact("contact", R.string.settings_contact_title),
-    AppInfo("app_info", R.string.settings_app_info_title),
-    LocationPermission("location_permission", R.string.settings_location_permission_title),
-    Terms("terms", R.string.settings_terms_title),
-    Sources("sources", R.string.settings_sources_title),
-    Cache("cache", R.string.settings_cache_title),
-    ;
-
-    companion object {
-        fun fromRouteValue(routeValue: String): SettingsDetailType =
-            values().firstOrNull { detailType -> detailType.routeValue == routeValue } ?: AppInfo
-    }
+    Notice(R.string.settings_notice_title),
+    Contact(R.string.settings_contact_title),
+    AppInfo(R.string.settings_app_info_title),
+    LocationPermission(R.string.settings_location_permission_title),
+    Terms(R.string.settings_terms_title),
+    Sources(R.string.settings_sources_title),
+    Cache(R.string.settings_cache_title),
 }
 
 @Composable

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/SettingsRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/SettingsRoute.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.presentation.R
 
@@ -61,7 +62,10 @@ fun SettingsRoute(
                 .fillMaxSize()
                 .padding(contentPadding)
                 .background(MaterialTheme.colorScheme.background),
-            contentPadding = PaddingValues(horizontal = 40.dp, vertical = 16.dp),
+            contentPadding = PaddingValues(
+                horizontal = SettingsLayoutDefaults.listHorizontalPadding,
+                vertical = SettingsLayoutDefaults.listVerticalPadding,
+            ),
         ) {
             items(SettingsMenuItems) { item ->
                 SettingsListItem(
@@ -76,6 +80,7 @@ fun SettingsRoute(
 @Composable
 fun SettingsDetailRoute(
     detailType: SettingsDetailType,
+    appVersionName: String,
     onBackClick: () -> Unit,
     onOpenAppSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -90,13 +95,18 @@ fun SettingsDetailRoute(
                 .fillMaxSize()
                 .padding(contentPadding)
                 .background(MaterialTheme.colorScheme.background),
-            contentPadding = PaddingValues(horizontal = 24.dp, vertical = 24.dp),
-            verticalArrangement = Arrangement.spacedBy(24.dp),
+            contentPadding = PaddingValues(
+                horizontal = SettingsLayoutDefaults.detailHorizontalPadding,
+                vertical = SettingsLayoutDefaults.detailVerticalPadding,
+            ),
+            verticalArrangement = Arrangement.spacedBy(SettingsLayoutDefaults.detailItemSpacing),
         ) {
             when (detailType) {
                 SettingsDetailType.Notice -> item { NoticeDetail() }
                 SettingsDetailType.Contact -> item { ContactDetail() }
-                SettingsDetailType.AppInfo -> item { AppInfoDetail() }
+                SettingsDetailType.AppInfo -> item {
+                    AppInfoDetail(appVersionName = appVersionName)
+                }
                 SettingsDetailType.LocationPermission -> item {
                     LocationPermissionDetail(onOpenAppSettingsClick = onOpenAppSettingsClick)
                 }
@@ -123,7 +133,7 @@ private fun SettingsScaffold(
                 title = {
                     Text(
                         text = title,
-                        style = MaterialTheme.typography.titleLarge,
+                        style = MaterialTheme.typography.headlineSmall,
                         fontWeight = FontWeight.Bold,
                     )
                 },
@@ -160,7 +170,7 @@ private fun SettingsListItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 24.dp),
+                .padding(vertical = SettingsLayoutDefaults.listItemVerticalPadding),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
@@ -176,118 +186,147 @@ private fun SettingsListItem(
 
 @Composable
 private fun NoticeDetail() {
-    SettingsSection(
-        title = stringResource(R.string.settings_notice_empty_title),
-        description = stringResource(R.string.settings_notice_empty_description),
-    )
+    SettingsDetailContent {
+        SettingsSection(
+            title = stringResource(R.string.settings_notice_empty_title),
+            description = stringResource(R.string.settings_notice_empty_description),
+        )
+    }
 }
 
 @Composable
 private fun ContactDetail() {
-    Text(
-        text = stringResource(R.string.settings_contact_email_label),
-        style = MaterialTheme.typography.titleMedium,
-        fontWeight = FontWeight.SemiBold,
-        color = MaterialTheme.colorScheme.onSurface,
-    )
+    SettingsDetailContent {
+        Text(
+            text = stringResource(R.string.settings_contact_email_label),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
 }
 
 @Composable
-private fun AppInfoDetail() {
-    SettingsSection(
-        title = stringResource(R.string.settings_app_info_title),
-        description = stringResource(R.string.settings_app_info_description),
-    )
-    SettingsInfoRow(
-        label = stringResource(R.string.settings_app_info_version_label),
-        value = stringResource(R.string.settings_app_info_version_name),
-    )
-    SettingsInfoRow(
-        label = stringResource(R.string.settings_app_info_features_label),
-        value = stringResource(R.string.settings_app_info_features),
-    )
+private fun AppInfoDetail(
+    appVersionName: String,
+) {
+    SettingsDetailContent {
+        SettingsSection(
+            title = stringResource(R.string.settings_app_info_title),
+            description = stringResource(R.string.settings_app_info_description),
+        )
+        SettingsInfoRow(
+            label = stringResource(R.string.settings_app_info_version_label),
+            value = appVersionName,
+        )
+        SettingsInfoRow(
+            label = stringResource(R.string.settings_app_info_features_label),
+            value = stringResource(R.string.settings_app_info_features),
+        )
+    }
 }
 
 @Composable
 private fun LocationPermissionDetail(
     onOpenAppSettingsClick: () -> Unit,
 ) {
-    SettingsSection(
-        title = stringResource(R.string.settings_location_permission_title),
-        description = stringResource(R.string.settings_location_permission_description),
-    )
-    SettingsInfoRow(
-        label = stringResource(R.string.settings_location_permission_used_permissions_label),
-        value = stringResource(R.string.settings_location_permission_used_permissions),
-    )
-    SettingsInfoRow(
-        label = stringResource(R.string.settings_location_permission_stored_info_label),
-        value = stringResource(R.string.settings_location_permission_stored_info),
-    )
-    Button(onClick = onOpenAppSettingsClick) {
-        Text(text = stringResource(R.string.settings_open_app_settings))
+    SettingsDetailContent {
+        SettingsSection(
+            title = stringResource(R.string.settings_location_permission_title),
+            description = stringResource(R.string.settings_location_permission_description),
+        )
+        SettingsInfoRow(
+            label = stringResource(R.string.settings_location_permission_used_permissions_label),
+            value = stringResource(R.string.settings_location_permission_used_permissions),
+        )
+        SettingsInfoRow(
+            label = stringResource(R.string.settings_location_permission_stored_info_label),
+            value = stringResource(R.string.settings_location_permission_stored_info),
+        )
+        Button(onClick = onOpenAppSettingsClick) {
+            Text(text = stringResource(R.string.settings_open_app_settings))
+        }
     }
 }
 
 @Composable
 private fun TermsDetail() {
-    SettingsSection(
-        title = stringResource(R.string.settings_terms_title),
-        description = stringResource(R.string.settings_terms_service_description),
-    )
-    SettingsParagraph(text = stringResource(R.string.settings_terms_info))
-    SettingsParagraph(text = stringResource(R.string.settings_terms_location))
-    SettingsParagraph(text = stringResource(R.string.settings_terms_responsibility))
-    SettingsParagraph(text = stringResource(R.string.settings_terms_privacy))
+    SettingsDetailContent {
+        SettingsSection(
+            title = stringResource(R.string.settings_terms_title),
+            description = stringResource(R.string.settings_terms_service_description),
+        )
+        SettingsParagraph(text = stringResource(R.string.settings_terms_info))
+        SettingsParagraph(text = stringResource(R.string.settings_terms_location))
+        SettingsParagraph(text = stringResource(R.string.settings_terms_responsibility))
+        SettingsParagraph(text = stringResource(R.string.settings_terms_privacy))
+    }
 }
 
 @Composable
 private fun SourcesDetail() {
-    SettingsSection(
-        title = stringResource(R.string.settings_sources_title),
-        description = stringResource(R.string.settings_sources_data_description),
-    )
-    SettingsInfoRow(
-        label = stringResource(R.string.settings_source_disposal_home_title),
-        value = stringResource(R.string.settings_source_disposal_home_description),
-    )
-    SettingsInfoRow(
-        label = stringResource(R.string.settings_source_recycling_api_title),
-        value = stringResource(R.string.settings_source_recycling_api_description),
-    )
-    SettingsInfoRow(
-        label = stringResource(R.string.settings_source_household_api_title),
-        value = stringResource(R.string.settings_source_household_api_description),
-    )
-    SettingsInfoRow(
-        label = stringResource(R.string.settings_source_admin_region_title),
-        value = stringResource(R.string.settings_source_admin_region_description),
-    )
-    SettingsParagraph(text = stringResource(R.string.settings_sources_usage_condition_description))
-    SettingsSection(
-        title = stringResource(R.string.settings_open_source_title),
-        description = stringResource(R.string.settings_tabler_usage_description),
-    )
-    SettingsInfoRow(
-        label = stringResource(R.string.settings_tabler_icons_title),
-        value = stringResource(R.string.settings_tabler_usage_title),
-    )
-    Text(
-        text = stringResource(R.string.settings_tabler_license_text),
-        style = MaterialTheme.typography.bodySmall,
-        fontFamily = FontFamily.Monospace,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
+    SettingsDetailContent {
+        SettingsSection(
+            title = stringResource(R.string.settings_sources_title),
+            description = stringResource(R.string.settings_sources_data_description),
+        )
+        SettingsInfoRow(
+            label = stringResource(R.string.settings_source_disposal_home_title),
+            value = stringResource(R.string.settings_source_disposal_home_description),
+        )
+        SettingsInfoRow(
+            label = stringResource(R.string.settings_source_recycling_api_title),
+            value = stringResource(R.string.settings_source_recycling_api_description),
+        )
+        SettingsInfoRow(
+            label = stringResource(R.string.settings_source_household_api_title),
+            value = stringResource(R.string.settings_source_household_api_description),
+        )
+        SettingsInfoRow(
+            label = stringResource(R.string.settings_source_admin_region_title),
+            value = stringResource(R.string.settings_source_admin_region_description),
+        )
+        SettingsParagraph(text = stringResource(R.string.settings_sources_usage_condition_description))
+        SettingsSection(
+            title = stringResource(R.string.settings_open_source_title),
+            description = stringResource(R.string.settings_tabler_usage_description),
+        )
+        SettingsInfoRow(
+            label = stringResource(R.string.settings_tabler_icons_title),
+            value = stringResource(R.string.settings_tabler_usage_title),
+        )
+        Text(
+            text = stringResource(R.string.settings_tabler_license_text),
+            style = MaterialTheme.typography.bodySmall,
+            fontFamily = FontFamily.Monospace,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
 }
 
 @Composable
 private fun CacheDetail() {
-    SettingsSection(
-        title = stringResource(R.string.settings_cache_detail_title),
-        description = stringResource(R.string.settings_cache_confirm_description),
-    )
-    Button(onClick = {}) {
-        Text(text = stringResource(R.string.settings_cache_delete_action))
+    SettingsDetailContent {
+        SettingsSection(
+            title = stringResource(R.string.settings_cache_detail_title),
+            description = stringResource(R.string.settings_cache_confirm_description),
+        )
+        Button(onClick = {}) {
+            Text(text = stringResource(R.string.settings_cache_delete_action))
+        }
+    }
+}
+
+@Composable
+private fun SettingsDetailContent(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(SettingsLayoutDefaults.detailContentSpacing),
+    ) {
+        content()
     }
 }
 
@@ -299,11 +338,11 @@ private fun SettingsSection(
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(SettingsLayoutDefaults.sectionSpacing),
     ) {
         Text(
             text = title,
-            style = MaterialTheme.typography.titleLarge,
+            style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,
         )
@@ -323,7 +362,7 @@ private fun SettingsInfoRow(
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(SettingsLayoutDefaults.infoRowSpacing),
     ) {
         Text(
             text = label,
@@ -361,3 +400,15 @@ private val SettingsMenuItems = listOf(
     SettingsDetailType.Sources,
     SettingsDetailType.Cache,
 )
+
+private object SettingsLayoutDefaults {
+    val listHorizontalPadding: Dp = 24.dp
+    val listVerticalPadding: Dp = 16.dp
+    val listItemVerticalPadding: Dp = 24.dp
+    val detailHorizontalPadding: Dp = 24.dp
+    val detailVerticalPadding: Dp = 24.dp
+    val detailItemSpacing: Dp = 24.dp
+    val detailContentSpacing: Dp = 20.dp
+    val sectionSpacing: Dp = 8.dp
+    val infoRowSpacing: Dp = 6.dp
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/SettingsRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/SettingsRoute.kt
@@ -1,0 +1,370 @@
+package com.team.yeogibeoryeo.presentation.settings
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.presentation.R
+
+enum class SettingsDetailType(
+    val routeValue: String,
+    @param:StringRes val titleResId: Int,
+) {
+    Notice("notice", R.string.settings_notice_title),
+    Contact("contact", R.string.settings_contact_title),
+    AppInfo("app_info", R.string.settings_app_info_title),
+    LocationPermission("location_permission", R.string.settings_location_permission_title),
+    Terms("terms", R.string.settings_terms_title),
+    Sources("sources", R.string.settings_sources_title),
+    Cache("cache", R.string.settings_cache_title),
+    ;
+
+    companion object {
+        fun fromRouteValue(routeValue: String): SettingsDetailType =
+            values().firstOrNull { detailType -> detailType.routeValue == routeValue } ?: AppInfo
+    }
+}
+
+@Composable
+fun SettingsRoute(
+    onBackClick: () -> Unit,
+    onDetailClick: (SettingsDetailType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingsScaffold(
+        title = stringResource(R.string.settings_title),
+        onBackClick = onBackClick,
+        modifier = modifier,
+    ) { contentPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(contentPadding)
+                .background(MaterialTheme.colorScheme.background),
+            contentPadding = PaddingValues(horizontal = 40.dp, vertical = 16.dp),
+        ) {
+            items(SettingsMenuItems) { item ->
+                SettingsListItem(
+                    title = stringResource(item.titleResId),
+                    onClick = { onDetailClick(item) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun SettingsDetailRoute(
+    detailType: SettingsDetailType,
+    onBackClick: () -> Unit,
+    onOpenAppSettingsClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingsScaffold(
+        title = stringResource(detailType.titleResId),
+        onBackClick = onBackClick,
+        modifier = modifier,
+    ) { contentPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(contentPadding)
+                .background(MaterialTheme.colorScheme.background),
+            contentPadding = PaddingValues(horizontal = 24.dp, vertical = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp),
+        ) {
+            when (detailType) {
+                SettingsDetailType.Notice -> item { NoticeDetail() }
+                SettingsDetailType.Contact -> item { ContactDetail() }
+                SettingsDetailType.AppInfo -> item { AppInfoDetail() }
+                SettingsDetailType.LocationPermission -> item {
+                    LocationPermissionDetail(onOpenAppSettingsClick = onOpenAppSettingsClick)
+                }
+                SettingsDetailType.Terms -> item { TermsDetail() }
+                SettingsDetailType.Sources -> item { SourcesDetail() }
+                SettingsDetailType.Cache -> item { CacheDetail() }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SettingsScaffold(
+    title: String,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back_action),
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.onSurface,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
+                ),
+            )
+        },
+        content = content,
+    )
+}
+
+@Composable
+private fun SettingsListItem(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 24.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+    }
+}
+
+@Composable
+private fun NoticeDetail() {
+    SettingsSection(
+        title = stringResource(R.string.settings_notice_empty_title),
+        description = stringResource(R.string.settings_notice_empty_description),
+    )
+}
+
+@Composable
+private fun ContactDetail() {
+    Text(
+        text = stringResource(R.string.settings_contact_email_label),
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+}
+
+@Composable
+private fun AppInfoDetail() {
+    SettingsSection(
+        title = stringResource(R.string.settings_app_info_title),
+        description = stringResource(R.string.settings_app_info_description),
+    )
+    SettingsInfoRow(
+        label = stringResource(R.string.settings_app_info_version_label),
+        value = stringResource(R.string.settings_app_info_version_name),
+    )
+    SettingsInfoRow(
+        label = stringResource(R.string.settings_app_info_features_label),
+        value = stringResource(R.string.settings_app_info_features),
+    )
+}
+
+@Composable
+private fun LocationPermissionDetail(
+    onOpenAppSettingsClick: () -> Unit,
+) {
+    SettingsSection(
+        title = stringResource(R.string.settings_location_permission_title),
+        description = stringResource(R.string.settings_location_permission_description),
+    )
+    SettingsInfoRow(
+        label = stringResource(R.string.settings_location_permission_used_permissions_label),
+        value = stringResource(R.string.settings_location_permission_used_permissions),
+    )
+    SettingsInfoRow(
+        label = stringResource(R.string.settings_location_permission_stored_info_label),
+        value = stringResource(R.string.settings_location_permission_stored_info),
+    )
+    Button(onClick = onOpenAppSettingsClick) {
+        Text(text = stringResource(R.string.settings_open_app_settings))
+    }
+}
+
+@Composable
+private fun TermsDetail() {
+    SettingsSection(
+        title = stringResource(R.string.settings_terms_title),
+        description = stringResource(R.string.settings_terms_service_description),
+    )
+    SettingsParagraph(text = stringResource(R.string.settings_terms_info))
+    SettingsParagraph(text = stringResource(R.string.settings_terms_location))
+    SettingsParagraph(text = stringResource(R.string.settings_terms_responsibility))
+    SettingsParagraph(text = stringResource(R.string.settings_terms_privacy))
+}
+
+@Composable
+private fun SourcesDetail() {
+    SettingsSection(
+        title = stringResource(R.string.settings_sources_title),
+        description = stringResource(R.string.settings_sources_data_description),
+    )
+    SettingsInfoRow(
+        label = stringResource(R.string.settings_source_disposal_home_title),
+        value = stringResource(R.string.settings_source_disposal_home_description),
+    )
+    SettingsInfoRow(
+        label = stringResource(R.string.settings_source_recycling_api_title),
+        value = stringResource(R.string.settings_source_recycling_api_description),
+    )
+    SettingsInfoRow(
+        label = stringResource(R.string.settings_source_household_api_title),
+        value = stringResource(R.string.settings_source_household_api_description),
+    )
+    SettingsInfoRow(
+        label = stringResource(R.string.settings_source_admin_region_title),
+        value = stringResource(R.string.settings_source_admin_region_description),
+    )
+    SettingsParagraph(text = stringResource(R.string.settings_sources_usage_condition_description))
+    SettingsSection(
+        title = stringResource(R.string.settings_open_source_title),
+        description = stringResource(R.string.settings_tabler_usage_description),
+    )
+    SettingsInfoRow(
+        label = stringResource(R.string.settings_tabler_icons_title),
+        value = stringResource(R.string.settings_tabler_usage_title),
+    )
+    Text(
+        text = stringResource(R.string.settings_tabler_license_text),
+        style = MaterialTheme.typography.bodySmall,
+        fontFamily = FontFamily.Monospace,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun CacheDetail() {
+    SettingsSection(
+        title = stringResource(R.string.settings_cache_detail_title),
+        description = stringResource(R.string.settings_cache_confirm_description),
+    )
+    Button(onClick = {}) {
+        Text(text = stringResource(R.string.settings_cache_delete_action))
+    }
+}
+
+@Composable
+private fun SettingsSection(
+    title: String,
+    description: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun SettingsInfoRow(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun SettingsParagraph(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        modifier = modifier.fillMaxWidth(),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+private val SettingsMenuItems = listOf(
+    SettingsDetailType.Notice,
+    SettingsDetailType.Contact,
+    SettingsDetailType.AppInfo,
+    SettingsDetailType.LocationPermission,
+    SettingsDetailType.Terms,
+    SettingsDetailType.Sources,
+    SettingsDetailType.Cache,
+)

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -119,7 +119,6 @@
     <string name="settings_contact_email_label">문의할 이메일 주소:</string>
     <string name="settings_app_info_description">내 위치 기반 맞춤형 분리수거 가이드와 수거 장소 안내 서비스입니다.</string>
     <string name="settings_app_info_version_label">버전</string>
-    <string name="settings_app_info_version_name">1.0</string>
     <string name="settings_app_info_features_label">제공 기능</string>
     <string name="settings_app_info_features">품목별 배출 방법 검색, 즐겨찾기, 근처 수거 장소 찾기, 지역별 배출 안내를 제공합니다.</string>
     <string name="settings_location_permission_description">현재 위치를 기준으로 가까운 수거 장소를 찾을 때 위치 권한을 사용합니다.</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -131,7 +131,7 @@
     <string name="settings_terms_info">앱에서 제공하는 품목 정보와 지역별 안내는 공공데이터와 공식 안내를 바탕으로 구성됩니다.</string>
     <string name="settings_terms_location">위치 기반 기능은 사용자가 가까운 수거 장소를 찾을 때만 사용됩니다.</string>
     <string name="settings_terms_responsibility">지역별 배출 기준은 지방자치단체 정책에 따라 달라질 수 있습니다. 실제 배출 전에는 해당 지자체 안내를 함께 확인해 주세요.</string>
-    <string name="settings_terms_privacy">앱은 문의 기능에서 이메일 주소가 확정되기 전까지 별도 문의 전송 정보를 수집하지 않습니다.</string>
+    <string name="settings_terms_privacy">앱은 문의 화면에서 별도의 입력 정보를 수집하지 않습니다.</string>
     <string name="settings_sources_data_description">앱의 안내 정보는 공공데이터포털 Open API와 공식 분리배출 안내 자료를 바탕으로 제공합니다.</string>
     <string name="settings_source_disposal_home_title">생활폐기물 분리배출 누리집</string>
     <string name="settings_source_disposal_home_description">품목별 배출 방법, 대표 분류별 안내</string>
@@ -141,7 +141,7 @@
     <string name="settings_source_household_api_description">행정안전부 생활쓰레기배출정보 조회서비스</string>
     <string name="settings_source_admin_region_title">행정안전부 행정구역 데이터</string>
     <string name="settings_source_admin_region_description">지역 검색과 지역별 안내 매칭</string>
-    <string name="settings_sources_usage_condition_description">출처 표시와 배포 가능 범위는 제공기관 답변에 맞춰 앱과 저장소 문서에 반영합니다.</string>
+    <string name="settings_sources_usage_condition_description">앱에서 사용하는 정보의 출처는 각 제공기관의 이용 조건에 따라 표시합니다.</string>
     <string name="settings_open_source_title">오픈소스 라이선스</string>
     <string name="settings_tabler_icons_title">Tabler Icons</string>
     <string name="settings_tabler_usage_title">MIT License</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="item_search_query_label">무엇을 버리시나요?</string>
     <string name="item_search_title">여기 버려</string>
     <string name="item_search_description">품목 검색, 수거 장소, 지역별 배출 정보를 한 곳에서 확인하세요.</string>
@@ -104,4 +104,70 @@
     <string name="item_card_favorite_saved_state">즐겨찾기됨</string>
     <string name="item_card_favorite_not_saved_state">즐겨찾기 안 됨</string>
     <string name="quick_category_click_action">배출 방법 보기</string>
+    <string name="settings_action">설정</string>
+    <string name="settings_title">설정</string>
+    <string name="settings_notice_title">공지사항</string>
+    <string name="settings_contact_title">문의하기</string>
+    <string name="settings_app_info_title">앱 정보</string>
+    <string name="settings_location_permission_title">위치 권한</string>
+    <string name="settings_terms_title">이용약관</string>
+    <string name="settings_sources_title">출처 및 이용조건</string>
+    <string name="settings_cache_title">캐시 삭제</string>
+    <string name="settings_cache_detail_title">위치 캐시 삭제</string>
+    <string name="settings_notice_empty_title">등록된 공지사항이 없습니다</string>
+    <string name="settings_notice_empty_description">서비스 변경, 데이터 업데이트, 주요 오류 안내가 생기면 이곳에 표시됩니다.</string>
+    <string name="settings_contact_email_label">문의할 이메일 주소:</string>
+    <string name="settings_app_info_description">내 위치 기반 맞춤형 분리수거 가이드와 수거 장소 안내 서비스입니다.</string>
+    <string name="settings_app_info_version_label">버전</string>
+    <string name="settings_app_info_version_name">1.0</string>
+    <string name="settings_app_info_features_label">제공 기능</string>
+    <string name="settings_app_info_features">품목별 배출 방법 검색, 즐겨찾기, 근처 수거 장소 찾기, 지역별 배출 안내를 제공합니다.</string>
+    <string name="settings_location_permission_description">현재 위치를 기준으로 가까운 수거 장소를 찾을 때 위치 권한을 사용합니다.</string>
+    <string name="settings_location_permission_used_permissions_label">사용 권한</string>
+    <string name="settings_location_permission_used_permissions">정확한 위치, 대략적인 위치</string>
+    <string name="settings_location_permission_stored_info_label">저장 정보</string>
+    <string name="settings_location_permission_stored_info">위치 권한 상태와 지도 검색에 필요한 임시 위치 캐시만 사용합니다.</string>
+    <string name="settings_open_app_settings">앱 설정 열기</string>
+    <string name="settings_terms_service_description">여기버려는 생활폐기물 분리배출 정보를 더 쉽게 확인할 수 있도록 돕는 안내 서비스입니다.</string>
+    <string name="settings_terms_info">앱에서 제공하는 품목 정보와 지역별 안내는 공공데이터와 공식 안내를 바탕으로 구성됩니다.</string>
+    <string name="settings_terms_location">위치 기반 기능은 사용자가 가까운 수거 장소를 찾을 때만 사용됩니다.</string>
+    <string name="settings_terms_responsibility">지역별 배출 기준은 지방자치단체 정책에 따라 달라질 수 있습니다. 실제 배출 전에는 해당 지자체 안내를 함께 확인해 주세요.</string>
+    <string name="settings_terms_privacy">앱은 문의 기능에서 이메일 주소가 확정되기 전까지 별도 문의 전송 정보를 수집하지 않습니다.</string>
+    <string name="settings_sources_data_description">앱의 안내 정보는 공공데이터포털 Open API와 공식 분리배출 안내 자료를 바탕으로 제공합니다.</string>
+    <string name="settings_source_disposal_home_title">생활폐기물 분리배출 누리집</string>
+    <string name="settings_source_disposal_home_description">품목별 배출 방법, 대표 분류별 안내</string>
+    <string name="settings_source_recycling_api_title">공공데이터포털 Open API</string>
+    <string name="settings_source_recycling_api_description">기후에너지환경부 분리배출 정보조회 서비스</string>
+    <string name="settings_source_household_api_title">공공데이터포털 Open API</string>
+    <string name="settings_source_household_api_description">행정안전부 생활쓰레기배출정보 조회서비스</string>
+    <string name="settings_source_admin_region_title">행정안전부 행정구역 데이터</string>
+    <string name="settings_source_admin_region_description">지역 검색과 지역별 안내 매칭</string>
+    <string name="settings_sources_usage_condition_description">출처 표시와 배포 가능 범위는 제공기관 답변에 맞춰 앱과 저장소 문서에 반영합니다.</string>
+    <string name="settings_open_source_title">오픈소스 라이선스</string>
+    <string name="settings_tabler_icons_title">Tabler Icons</string>
+    <string name="settings_tabler_usage_title">MIT License</string>
+    <string name="settings_tabler_usage_description">앱의 일부 아이콘은 Tabler Icons를 바탕으로 사용했습니다.</string>
+    <string name="settings_tabler_license_text" tools:ignore="TypographyOther"><![CDATA[MIT License
+
+Copyright (c) 2020-2026 Paweł Kuna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.]]></string>
+    <string name="settings_cache_confirm_description">현재 위치로 주변 수거 장소를 찾았을 때 임시 저장된 위치 캐시를 삭제합니다. 즐겨찾기와 품목 검색 기록은 삭제되지 않습니다.</string>
+    <string name="settings_cache_delete_action">삭제</string>
 </resources>


### PR DESCRIPTION
## 요약
- 홈 화면 상단에 설정 진입 아이콘을 추가했습니다.
- 설정 목록과 상세 화면을 추가했습니다.
- 공지사항, 문의하기, 앱 정보, 위치 권한, 이용약관, 출처 및 이용조건, 캐시 삭제 내용을 구성했습니다.
- 출처 및 이용조건 화면에 공공데이터포털 Open API 사용 정보와 Tabler Icons MIT License 전문을 함께 표시했습니다.

## 검증
- `./gradlew.bat :app:compileDebugKotlin :presentation:compileDebugKotlin` 통과
- `./gradlew.bat :presentation:lintDebug` 실패: 기존 `presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt:277`의 `UnusedBoxWithConstraintsScope` lint error

## 관련 이슈
Related #208

## 스크린샷

| 홈 화면 | 설정 화면 | 공지사항 |
| --- | --- | --- |
| <img width="220" alt="홈 화면" src="https://github.com/user-attachments/assets/8ad8d920-e9ff-472f-a46f-503bcb78e780"> | <img width="220" alt="설정 화면" src="https://github.com/user-attachments/assets/994cceed-6fb2-4e91-aca9-6952a79e2318"> | <img width="220" alt="공지사항" src="https://github.com/user-attachments/assets/c6df1d6e-fc6c-45cd-8b69-4e4f5e3e4d90"> |

| 문의하기 | 앱 정보 | 위치 권한 |
| --- | --- | --- |
| <img width="220" alt="문의하기" src="https://github.com/user-attachments/assets/c2af3df4-9dba-45ae-bcde-ba033bdaeb1a"> | <img width="220" alt="앱 정보" src="https://github.com/user-attachments/assets/7e14d468-054b-45c8-9e0f-f8717be73d9b"> | <img width="220" alt="위치 권한" src="https://github.com/user-attachments/assets/eb9e2cac-a8a4-49d8-aacf-1a9c1a2575bc"> |

| 이용 약관 | 출처 및 이용 조건 | 캐시 삭제 |
| --- | --- | --- |
| <img width="220" alt="이용 약관" src="https://github.com/user-attachments/assets/817b2fac-e412-4648-8cb4-5857634ad122"> | <img width="220" alt="출처 및 이용 조건" src="https://github.com/user-attachments/assets/cf6c0f7a-68ac-4d87-821a-bdca03ba6b48"> | <img width="220" alt="캐시 삭제" src="https://github.com/user-attachments/assets/fe884912-c8ce-4db3-94ed-a7a5481ed987"> |
