### PR TITLE
[Refactor] 하단 탭 라벨 문자열 리소스 분리

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/BottomTabNavigation.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/BottomTabNavigation.kt
@@ -1,5 +1,7 @@
 package com.team.yeogibeoryeo.navigation
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
@@ -10,6 +12,7 @@ import com.team.yeogibeoryeo.common.R as CommonR
 import com.team.yeogibeoryeo.common.navigation.BottomNavigationItem
 import com.team.yeogibeoryeo.common.navigation.navigateBottomTab
 
+@Composable
 internal fun NavHostController.createBottomNavigationItems(
     currentBackStackEntry: NavBackStackEntry?,
     currentDestination: NavDestination?,
@@ -17,7 +20,7 @@ internal fun NavHostController.createBottomNavigationItems(
 ): List<BottomNavigationItem> =
     listOf(
         BottomNavigationItem(
-            label = "품목",
+            label = stringResource(AppR.string.bottom_tab_item_search),
             iconResId = CommonR.drawable.ic_symbol_recycle,
             selected = currentBackStackEntry.isItemSearchSelected(),
             onClick = {
@@ -25,7 +28,7 @@ internal fun NavHostController.createBottomNavigationItems(
             },
         ),
         BottomNavigationItem(
-            label = "지도",
+            label = stringResource(AppR.string.bottom_tab_map),
             iconResId = AppR.drawable.ic_navigation_map,
             selected = currentDestination?.hasRoute<MapRoute>() == true,
             onClick = {
@@ -36,7 +39,7 @@ internal fun NavHostController.createBottomNavigationItems(
             },
         ),
         BottomNavigationItem(
-            label = "안내",
+            label = stringResource(AppR.string.bottom_tab_regional_guide),
             iconResId = AppR.drawable.ic_navigation_guide,
             selected = currentBackStackEntry.isRegionalGuideSelected(),
             onClick = {
@@ -44,7 +47,7 @@ internal fun NavHostController.createBottomNavigationItems(
             },
         ),
         BottomNavigationItem(
-            label = "저장",
+            label = stringResource(AppR.string.bottom_tab_favorites),
             iconResId = CommonR.drawable.ic_favorite,
             selected = currentBackStackEntry.isFavoritesSelected(),
             onClick = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">여기버려</string>
+    <string name="bottom_tab_item_search">품목</string>
+    <string name="bottom_tab_map">지도</string>
+    <string name="bottom_tab_regional_guide">안내</string>
+    <string name="bottom_tab_favorites">저장</string>
 </resources>


### PR DESCRIPTION
## 요약
- 하단 탭 라벨 문자열을 app 모듈 string resource로 분리했습니다.
- `BottomTabNavigation`에서 리소스 기반 라벨을 사용하도록 변경했습니다.

## 검증
- `./gradlew.bat :app:compileDebugKotlin` 통과

## 관련 이슈
Related #210
