### PR TITLE
fix: 현재 위치 캐시 권한 철회 및 TTL 정책 보강

### DIFF
--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/GetFreshRecentCurrentLocationSpotsUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/GetFreshRecentCurrentLocationSpotsUseCase.kt
@@ -12,8 +12,11 @@ class GetFreshRecentCurrentLocationSpotsUseCase @Inject constructor(
     suspend operator fun invoke(): RecentCurrentLocationSpotCacheEntry? {
         val entry = repository.getRecentCurrentLocationSpots() ?: return null
 
-        return entry.takeIf {
-            it.isFresh(nowMillis = timeProvider.currentTimeMillis())
+        if (entry.isFresh(nowMillis = timeProvider.currentTimeMillis())) {
+            return entry
         }
+
+        repository.clearRecentCurrentLocationSpots()
+        return null
     }
 }

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/RecentCurrentLocationSpotCacheUseCasesTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/RecentCurrentLocationSpotCacheUseCasesTest.kt
@@ -49,6 +49,8 @@ class RecentCurrentLocationSpotCacheUseCasesTest {
             val result = useCase()
 
             assertNull(result)
+            assertNull(repository.entry)
+            assertEquals(1, repository.clearCallCount)
         }
 
     @Test
@@ -68,6 +70,8 @@ class RecentCurrentLocationSpotCacheUseCasesTest {
             val result = useCase()
 
             assertNull(result)
+            assertNull(repository.entry)
+            assertEquals(1, repository.clearCallCount)
         }
 
     @Test
@@ -102,6 +106,9 @@ class RecentCurrentLocationSpotCacheUseCasesTest {
     private class FakeRecentCurrentLocationSpotCacheRepository(
         var entry: RecentCurrentLocationSpotCacheEntry? = null,
     ) : RecentCurrentLocationSpotCacheRepository {
+        var clearCallCount = 0
+            private set
+
         override suspend fun getRecentCurrentLocationSpots(): RecentCurrentLocationSpotCacheEntry? {
             return entry
         }
@@ -111,6 +118,7 @@ class RecentCurrentLocationSpotCacheUseCasesTest {
         }
 
         override suspend fun clearRecentCurrentLocationSpots() {
+            clearCallCount += 1
             entry = null
         }
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -80,6 +80,9 @@ fun CollectionSpotMapScreen(
     LaunchedEffect(hasFineLocationPermission) {
         if (!hasFineLocationPermission) {
             hasGrantedLocationPermissionInSession = false
+            if (previousFineLocationPermission) {
+                viewModel.onLocationPermissionRevoked()
+            }
         } else if (!previousFineLocationPermission) {
             hasGrantedLocationPermissionInSession = true
             locationTrackingMode = LocationTrackingMode.NoFollow

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -9,6 +9,7 @@ import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.usecase.CalculateDistanceMeterUseCase
+import com.team.yeogibeoryeo.domain.spot.usecase.ClearRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.GetFreshRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SaveRecentCurrentLocationSpotsUseCase
@@ -37,6 +38,7 @@ class CollectionSpotMapViewModel @Inject constructor(
     private val locationPermissionChecker: LocationPermissionChecker,
     private val getFreshRecentCurrentLocationSpotsUseCase: GetFreshRecentCurrentLocationSpotsUseCase,
     private val saveRecentCurrentLocationSpotsUseCase: SaveRecentCurrentLocationSpotsUseCase,
+    private val clearRecentCurrentLocationSpotsUseCase: ClearRecentCurrentLocationSpotsUseCase,
     private val observeFavoritesUseCase: ObserveFavoritesUseCase,
     private val toggleCollectionSpotFavoriteUseCase: ToggleCollectionSpotFavoriteUseCase,
     private val calculateDistanceMeterUseCase: CalculateDistanceMeterUseCase,
@@ -171,6 +173,11 @@ class CollectionSpotMapViewModel @Inject constructor(
         currentLocationRefreshJob?.cancel()
         spotSearchJob?.cancel()
         spotSearchJob = viewModelScope.launch {
+            if (!locationPermissionChecker.hasFineLocationPermission()) {
+                onLocationPermissionDenied()
+                return@launch
+            }
+
             val cachedEntry = getFreshRecentCurrentLocationSpotsUseCase()
 
             if (cachedEntry != null) {
@@ -320,6 +327,25 @@ class CollectionSpotMapViewModel @Inject constructor(
     }
 
     fun onLocationPermissionDenied() {
+        clearRecentCurrentLocationCache()
+        showLocationPermissionDeniedNotice()
+    }
+
+    fun onLocationPermissionRevoked() {
+        clearRecentCurrentLocationCache()
+
+        if (uiState.value.searchMode == MapSearchMode.CURRENT_LOCATION) {
+            showLocationPermissionDeniedNotice()
+        }
+    }
+
+    private fun clearRecentCurrentLocationCache() {
+        viewModelScope.launch {
+            clearRecentCurrentLocationSpotsUseCase()
+        }
+    }
+
+    private fun showLocationPermissionDeniedNotice() {
         originalSpots = emptyList()
 
         _uiState.update {
@@ -565,9 +591,7 @@ class CollectionSpotMapViewModel @Inject constructor(
             }
 
             CurrentLocationResult.PermissionDenied -> {
-                if (!preservePreviousResultOnFailure) {
-                    onLocationPermissionDenied()
-                }
+                onLocationPermissionDenied()
             }
         }
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -174,7 +174,7 @@ class CollectionSpotMapViewModel @Inject constructor(
         spotSearchJob?.cancel()
         spotSearchJob = viewModelScope.launch {
             if (!locationPermissionChecker.hasFineLocationPermission()) {
-                onLocationPermissionDenied()
+                handleLocationPermissionDenied()
                 return@launch
             }
 
@@ -327,22 +327,28 @@ class CollectionSpotMapViewModel @Inject constructor(
     }
 
     fun onLocationPermissionDenied() {
+        viewModelScope.launch {
+            handleLocationPermissionDenied()
+        }
+    }
+
+    fun onLocationPermissionRevoked() {
+        viewModelScope.launch {
+            clearRecentCurrentLocationCache()
+
+            if (uiState.value.searchMode == MapSearchMode.CURRENT_LOCATION) {
+                showLocationPermissionDeniedNotice()
+            }
+        }
+    }
+
+    private suspend fun handleLocationPermissionDenied() {
         clearRecentCurrentLocationCache()
         showLocationPermissionDeniedNotice()
     }
 
-    fun onLocationPermissionRevoked() {
-        clearRecentCurrentLocationCache()
-
-        if (uiState.value.searchMode == MapSearchMode.CURRENT_LOCATION) {
-            showLocationPermissionDeniedNotice()
-        }
-    }
-
-    private fun clearRecentCurrentLocationCache() {
-        viewModelScope.launch {
-            clearRecentCurrentLocationSpotsUseCase()
-        }
+    private suspend fun clearRecentCurrentLocationCache() {
+        clearRecentCurrentLocationSpotsUseCase()
     }
 
     private fun showLocationPermissionDeniedNotice() {
@@ -591,7 +597,7 @@ class CollectionSpotMapViewModel @Inject constructor(
             }
 
             CurrentLocationResult.PermissionDenied -> {
-                onLocationPermissionDenied()
+                handleLocationPermissionDenied()
             }
         }
     }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapCacheViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapCacheViewModelTest.kt
@@ -219,6 +219,11 @@ class CollectionSpotMapCacheViewModelTest : CollectionSpotMapViewModelTestFixtur
             advanceUntilIdle()
 
             assertEquals(1, repository.locationSearchCallCount)
+            assertEquals(1, cache.clearCallCount)
+            assertEquals(
+                listOf(expectedSpot).withDistanceFrom(Coordinate(latitude = 37.5666102, longitude = 126.9783881)),
+                cache.entry?.spots,
+            )
             assertEquals(
                 listOf(expectedSpot).withDistanceFrom(Coordinate(latitude = 37.5666102, longitude = 126.9783881)),
                 viewModel.uiState.value.spots,

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapCurrentLocationViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapCurrentLocationViewModelTest.kt
@@ -43,6 +43,115 @@ class CollectionSpotMapCurrentLocationViewModelTest : CollectionSpotMapViewModel
         }
 
     @Test
+    fun `위치 권한이 없으면 수동 현재 위치 검색 시 캐시를 표시하지 않고 삭제한다`() =
+        runTest {
+            val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
+            val cache = FakeRecentCurrentLocationSpotCacheRepository(
+                entry = freshCacheEntry(listOf(cachedSpot)),
+            )
+            val repository = FakeCollectionSpotRepository()
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(
+                    Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+                ),
+                hasFineLocationPermission = false,
+                recentCurrentLocationSpotCacheRepository = cache,
+            )
+
+            viewModel.searchByCurrentLocation()
+            advanceUntilIdle()
+
+            assertEquals(0, cache.getCallCount)
+            assertEquals(1, cache.clearCallCount)
+            assertNull(cache.entry)
+            assertEquals(0, repository.locationSearchCallCount)
+            assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
+            assertEquals("위치 권한이 필요합니다.", viewModel.uiState.value.locationNotice?.title)
+        }
+
+    @Test
+    fun `캐시 표시 후 권한 거부 결과를 받으면 캐시와 현재 위치 결과를 정리한다`() =
+        runTest {
+            val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
+            val cache = FakeRecentCurrentLocationSpotCacheRepository(
+                entry = freshCacheEntry(listOf(cachedSpot)),
+            )
+            val repository = FakeCollectionSpotRepository()
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.PermissionDenied,
+                hasFineLocationPermission = true,
+                recentCurrentLocationSpotCacheRepository = cache,
+            )
+
+            viewModel.searchByCurrentLocation()
+            advanceUntilIdle()
+
+            assertEquals(1, cache.getCallCount)
+            assertEquals(1, cache.clearCallCount)
+            assertNull(cache.entry)
+            assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
+            assertEquals("위치 권한이 필요합니다.", viewModel.uiState.value.locationNotice?.title)
+        }
+
+    @Test
+    fun `권한 철회 시 현재 위치 캐시와 현재 위치 결과를 정리한다`() =
+        runTest {
+            val currentCoordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881)
+            val locationSpot = sampleSpot("location", CollectionSpotType.STANDARD_BAG_STORE)
+            val cache = FakeRecentCurrentLocationSpotCacheRepository()
+            val repository = FakeCollectionSpotRepository(locationSpots = listOf(locationSpot))
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.Found(currentCoordinate),
+                recentCurrentLocationSpotCacheRepository = cache,
+            )
+            viewModel.searchByCurrentLocation()
+            advanceUntilIdle()
+
+            viewModel.onLocationPermissionRevoked()
+            advanceUntilIdle()
+
+            assertEquals(1, cache.clearCallCount)
+            assertNull(cache.entry)
+            assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
+            assertEquals("위치 권한이 필요합니다.", viewModel.uiState.value.locationNotice?.title)
+        }
+
+    @Test
+    fun `권한 철회 시 키워드 검색 결과는 유지하고 현재 위치 캐시만 삭제한다`() =
+        runTest {
+            val keywordSpot = sampleSpot("keyword", CollectionSpotType.OTHER)
+            val cachedSpot = sampleSpot("cache", CollectionSpotType.STANDARD_BAG_STORE)
+            val cache = FakeRecentCurrentLocationSpotCacheRepository(
+                entry = freshCacheEntry(listOf(cachedSpot)),
+            )
+            val repository = FakeCollectionSpotRepository(keywordSpots = listOf(keywordSpot))
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+                recentCurrentLocationSpotCacheRepository = cache,
+            )
+            viewModel.onSearchKeywordChanged("문래동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            viewModel.onLocationPermissionRevoked()
+            advanceUntilIdle()
+
+            assertEquals(1, cache.clearCallCount)
+            assertNull(cache.entry)
+            assertEquals(listOf(keywordSpot), viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
+            assertNull(viewModel.uiState.value.locationNotice)
+            assertNull(viewModel.uiState.value.locationNoticeMessage)
+        }
+
+    @Test
     fun `최근 위치 캐시가 없으면 현재 위치 조회 실패 안내를 표시한다`() =
         runTest {
             val repository = FakeCollectionSpotRepository()

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTestFixture.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTestFixture.kt
@@ -16,6 +16,7 @@ import com.team.yeogibeoryeo.domain.spot.model.RecentCurrentLocationSpotCacheEnt
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import com.team.yeogibeoryeo.domain.spot.repository.RecentCurrentLocationSpotCacheRepository
 import com.team.yeogibeoryeo.domain.spot.usecase.CalculateDistanceMeterUseCase
+import com.team.yeogibeoryeo.domain.spot.usecase.ClearRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.GetFreshRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SaveRecentCurrentLocationSpotsUseCase
@@ -83,6 +84,9 @@ internal fun createViewModel(
         saveRecentCurrentLocationSpotsUseCase = SaveRecentCurrentLocationSpotsUseCase(
             repository = recentCurrentLocationSpotCacheRepository,
             timeProvider = timeProvider,
+        ),
+        clearRecentCurrentLocationSpotsUseCase = ClearRecentCurrentLocationSpotsUseCase(
+            repository = recentCurrentLocationSpotCacheRepository,
         ),
         observeFavoritesUseCase = ObserveFavoritesUseCase(favoriteRepository),
         toggleCollectionSpotFavoriteUseCase = ToggleCollectionSpotFavoriteUseCase(


### PR DESCRIPTION
## 작업 내용

Related #212

최근 현재 위치 검색 결과 캐시가 위치 권한 상태와 TTL 정책에 맞게 동작하도록 보정했습니다.

기존에는 권한 철회 후에도 이전 현재 위치 기반 캐시가 남아 있으면 Map 재진입 또는 현재 위치 버튼 클릭 시 과거 내 주변 결과처럼 보일 수 있었습니다.  
이번 PR에서는 권한 없음 / 권한 철회 / TTL 만료 상태에서 stale cache가 노출되지 않도록 정리했습니다.

| 구분 | 내용 |
| --- | --- |
| 권한 없음 | 최근 현재 위치 캐시를 자동 표시하지 않음 |
| 권한 철회 | 최근 현재 위치 캐시 삭제 |
| 현재 위치 버튼 | 캐시보다 권한 상태를 먼저 확인 |
| TTL 만료 | 만료된 캐시는 조회 시 무효화 |
| silent refresh | 권한 허용 상태에서는 기존 캐시 즉시 표시 + refresh 유지 |
| 기존 검색 | 키워드 검색 / 현 지도 검색 / 즐겨찾기 동작 유지 |

## 주요 변경 사항

| 파일/영역 | 변경 내용 |
| --- | --- |
| `GetFreshRecentCurrentLocationSpotsUseCase` | TTL 만료 또는 비정상 시각 캐시 조회 시 삭제 처리 |
| `CollectionSpotMapViewModel` | 권한 없음 / 권한 철회 / `PermissionDenied` 시 최근 현재 위치 캐시 삭제 |
| `CollectionSpotMapScreen` | 위치 권한이 허용 → 거부/철회로 바뀐 경우 ViewModel에 알림 |
| ViewModel 테스트 | 권한 없음, 권한 철회, 캐시 삭제, TTL 만료 정책 테스트 보강 |
| Domain usecase 테스트 | 만료 캐시 / 비정상 시각 캐시 무효화 테스트 보강 |

## 정책 정리

| 상황 | 동작 |
| --- | --- |
| 위치 권한 허용 + 10분 이내 캐시 있음 | 캐시 즉시 표시 후 silent refresh |
| 위치 권한 없음 + Map 진입 | 캐시 자동 표시 안 함 |
| 위치 권한 철회 | 최근 현재 위치 캐시 삭제 |
| 권한 철회 후 Map 복귀 | 과거 현재 위치 캐시 미표시 |
| 권한 철회 상태에서 현재 위치 버튼 클릭 | 과거 캐시 대신 권한 요청 / 안내 표시 |
| TTL 10분 초과 | 캐시 표시 안 함, 조회 시 삭제 |

## 유지한 범위

- `/getSpot` API 로직 변경 없음
- `CurrentLocationProvider` 구조 변경 없음
- NaverMap overlay / trackingMode 변경 없음
- BottomSheet UX 대규모 변경 없음
- 키워드 검색 / 현 지도 검색 / 즐겨찾기 동작 유지
- 정확한 사용자 현재 위치 좌표 저장 없음

## 검증

| 항목 | 결과 |
| --- | --- |
| 위치 권한 허용 → 현재 위치 검색 성공 → Map 재진입 시 10분 이내 캐시 표시 | 확인 |
| 위치 권한 허용 → 현재 위치 검색 성공 → 권한 철회 → Map 재진입 시 캐시 미표시 | 확인 |
| 권한 철회 상태에서 현재 위치 버튼 클릭 → 과거 캐시 대신 권한 안내 표시 | 확인 |
| 기존 키워드 검색 / 현 지도 검색 / 즐겨찾기 동작 | 확인 |

## 테스트

```bash
./gradlew.bat :domain:test
./gradlew.bat :presentation:testDebugUnitTest
./gradlew.bat :presentation:compileDebugKotlin
./gradlew.bat :app:assembleDebug
```

## 스크린샷

| 위치 권한 허용 상태 | 앱 설정에서 위치 권한 해제 |
| --- | --- |
| <img width="260" alt="위치 권한 허용 상태" src="https://github.com/user-attachments/assets/238d0161-f0b7-4604-94ab-a7c374f3c9dc" /> | <img width="260" alt="앱 설정 위치 권한 해제" src="https://github.com/user-attachments/assets/eb843a1d-1c9c-4b68-a92a-25637d962d1d" /> |

| 권한 해제 후 캐시 미표시 | 현재 위치 버튼 클릭 시 권한 요청 |
| --- | --- |
| <img width="260" alt="권한 해제 후 지도 복귀 시 캐시 미표시" src="https://github.com/user-attachments/assets/5a1fc230-03e0-448a-b207-4fd4ac039315" /> | <img width="260" alt="현재 위치 버튼 클릭 시 권한 팝업 표시" src="https://github.com/user-attachments/assets/5e3506af-0a08-4653-b76c-fd29f1e2dca1" /> |

## 참고

TTL 10분 초과 / 다음날 재진입 케이스는 정책상 domain usecase 테스트로 보강했고, 실제 단말 장기 검증은 필요 시 추가로 확인할 예정입니다.