### PR TITLE
feat: 지도 검색 입력 안내를 동읍면 기준으로 개선

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -501,7 +501,7 @@ private fun CollectionSpotMapContentPreview() {
 
 private fun MapSearchMode.toLoadingDescription(): String {
     return when (this) {
-        MapSearchMode.KEYWORD -> "입력한 동네 주변을 찾고 있어요"
+        MapSearchMode.KEYWORD -> "입력한 동/읍/면 주변을 찾고 있어요"
         MapSearchMode.CURRENT_LOCATION -> "현재 위치 주변을 찾고 있어요"
         MapSearchMode.MAP_CENTER -> "현 지도 주변을 찾고 있어요"
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -4,7 +4,8 @@ import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBars
@@ -15,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -24,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -35,6 +38,7 @@ import com.naver.maps.map.compose.LocationTrackingMode
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.map.components.CollectionSpotNaverMap
 import com.team.yeogibeoryeo.presentation.map.components.MapSearchLoadingOverlay
 import com.team.yeogibeoryeo.presentation.map.components.MapCenterSearchButton
@@ -52,11 +56,11 @@ import com.team.yeogibeoryeo.presentation.map.model.FavoriteSpotMapMoveRequest
 
 @Composable
 fun CollectionSpotMapScreen(
+    modifier: Modifier = Modifier,
     initialSpotType: CollectionSpotType? = null,
     favoriteSpotMoveRequest: FavoriteSpotMapMoveRequest? = null,
     onBottomBarVisibilityChanged: (Boolean) -> Unit = {},
     onRegionalGuideClick: (String) -> Unit = {},
-    modifier: Modifier = Modifier,
     viewModel: CollectionSpotMapViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -84,7 +88,6 @@ fun CollectionSpotMapScreen(
                 viewModel.onLocationPermissionRevoked()
             }
         } else if (!previousFineLocationPermission) {
-            hasGrantedLocationPermissionInSession = true
             locationTrackingMode = LocationTrackingMode.NoFollow
             viewModel.searchByCurrentLocation()
         }
@@ -98,7 +101,6 @@ fun CollectionSpotMapScreen(
                 currentHasFineLocationPermission &&
                 currentLocationNotice.shouldRetryCurrentLocationSearchOnResume()
             ) {
-                hasGrantedLocationPermissionInSession = true
                 previousFineLocationPermission = true
                 locationTrackingMode = LocationTrackingMode.NoFollow
                 viewModel.searchByCurrentLocation()
@@ -184,7 +186,7 @@ private fun CollectionSpotMapContent(
     val shouldShowBottomSheet = uiState.shouldShowBottomSheet && !isSpotSearchLoading
     var mapUiMode by remember { mutableStateOf(MapUiMode.Browsing) }
     var sheetLevel by remember { mutableStateOf(MapSheetLevel.Hidden) }
-    var sheetRevealRequest by remember { mutableStateOf(0) }
+    var sheetRevealRequest by remember { mutableIntStateOf(0) }
     var mapCenterCoordinate by remember { mutableStateOf<Coordinate?>(null) }
     var shouldShowMapCenterSearchButton by remember { mutableStateOf(false) }
     val selectedSpot = uiState.selectedSpot
@@ -275,7 +277,7 @@ private fun CollectionSpotMapContent(
         onBottomBarVisibilityChanged(!shouldHideBottomBar)
     }
 
-    BoxWithConstraints(
+    Box(
         modifier = modifier.fillMaxSize(),
     ) {
         val density = LocalDensity.current
@@ -381,7 +383,7 @@ private fun CollectionSpotMapContent(
 
         if (isSpotSearchLoading) {
             MapSearchLoadingOverlay(
-                description = uiState.searchMode.toLoadingDescription(),
+                description = stringResource(uiState.searchMode.toLoadingDescriptionResId()),
             )
         }
 
@@ -499,11 +501,12 @@ private fun CollectionSpotMapContentPreview() {
 
 }
 
-private fun MapSearchMode.toLoadingDescription(): String {
+@StringRes
+private fun MapSearchMode.toLoadingDescriptionResId(): Int {
     return when (this) {
-        MapSearchMode.KEYWORD -> "입력한 동/읍/면 주변을 찾고 있어요"
-        MapSearchMode.CURRENT_LOCATION -> "현재 위치 주변을 찾고 있어요"
-        MapSearchMode.MAP_CENTER -> "현 지도 주변을 찾고 있어요"
+        MapSearchMode.KEYWORD -> R.string.map_search_loading_keyword
+        MapSearchMode.CURRENT_LOCATION -> R.string.map_search_loading_current_location
+        MapSearchMode.MAP_CENTER -> R.string.map_search_loading_map_center
     }
 }
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/MapLocationNotices.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/MapLocationNotices.kt
@@ -1,24 +1,24 @@
 package com.team.yeogibeoryeo.presentation.map
 
 object MapLocationNotices {
-    const val SpotSearchFailureMessage = "네트워크 연결을 확인한 뒤 다시 시도해 주세요."
+    const val SpotSearchFailureMessage = "잠시 후 다시 시도하거나 네트워크 연결을 확인해 주세요."
     const val CurrentLocationSpotSearchFailureMessage =
-        "네트워크 연결을 확인한 뒤 다시 시도하거나 직접 동네명/주소를 검색해 주세요."
+        "네트워크 연결을 확인한 뒤 다시 시도하거나 직접 동/읍/면을 검색해 주세요."
 
     val PermissionDenied = MapLocationNotice(
         title = "위치 권한이 필요합니다.",
-        message = "현재 위치 검색은 정확한 위치 권한을 허용하면 사용할 수 있어요. 직접 동네나 주소를 검색할 수도 있습니다.",
+        message = "현재 위치 검색은 정확한 위치 권한을 허용하면 사용할 수 있어요. 직접 동/읍/면을 검색할 수도 있습니다.",
         action = MapLocationNoticeAction.OpenAppSettings,
     )
 
     val LocationServiceDisabled = MapLocationNotice(
         title = "위치 서비스가 꺼져 있습니다.",
-        message = "기기의 위치 서비스가 꺼져 있어 현재 위치를 확인할 수 없어요. 위치 서비스를 켠 뒤 다시 시도하거나 직접 동네명/주소를 검색해 주세요.",
+        message = "기기의 위치 서비스가 꺼져 있어 현재 위치를 확인할 수 없어요. 위치 서비스를 켠 뒤 다시 시도하거나 직접 동/읍/면을 검색해 주세요.",
         action = MapLocationNoticeAction.OpenLocationSettings,
     )
 
     val CurrentLocationUnavailable = MapLocationNotice(
         title = "현재 위치를 확인하지 못했습니다.",
-        message = "현재 위치를 확인하지 못했습니다. 잠시 후 다시 시도하거나 직접 동네명/주소를 검색해 주세요.",
+        message = "현재 위치를 확인하지 못했습니다. 잠시 후 다시 시도하거나 직접 동/읍/면을 검색해 주세요.",
     )
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CurrentLocationSearchLoadingOverlay.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/CurrentLocationSearchLoadingOverlay.kt
@@ -14,8 +14,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.presentation.R
 
 @Composable
 fun MapSearchLoadingOverlay(
@@ -40,7 +42,7 @@ fun MapSearchLoadingOverlay(
                 verticalArrangement = Arrangement.spacedBy(14.dp),
             ) {
                 Text(
-                    text = "검색중",
+                    text = stringResource(R.string.map_search_loading_title),
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
@@ -64,7 +66,7 @@ fun MapSearchLoadingOverlay(
 private fun CurrentLocationSearchLoadingOverlayPreview() {
     MaterialTheme {
         MapSearchLoadingOverlay(
-            description = "현재 위치 주변을 찾고 있어요",
+            description = stringResource(R.string.map_search_loading_current_location),
         )
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/EmptySpotResult.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/EmptySpotResult.kt
@@ -11,17 +11,22 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.presentation.R
 
 @Composable
 fun EmptySpotResult(
     modifier: Modifier = Modifier,
-    title: String = "검색 결과가 없습니다.",
-    description: String = "동/읍/면 이름으로 다시 검색해 주세요.\n예: 문래동, 역삼동",
+    title: String? = null,
+    description: String? = null,
     actionLabel: String? = null,
     onActionClick: (() -> Unit)? = null,
 ) {
+    val displayTitle = title ?: stringResource(R.string.map_empty_spot_result_title)
+    val displayDescription = description ?: stringResource(R.string.map_empty_spot_result_description)
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -30,13 +35,13 @@ fun EmptySpotResult(
         verticalArrangement = Arrangement.Center,
     ) {
         Text(
-            text = title,
+            text = displayTitle,
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onSurface,
         )
 
         Text(
-            text = description,
+            text = displayDescription,
             modifier = Modifier.padding(top = 8.dp),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/EmptySpotResult.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/EmptySpotResult.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.dp
 fun EmptySpotResult(
     modifier: Modifier = Modifier,
     title: String = "검색 결과가 없습니다.",
-    description: String = "다른 동네명이나 주소로 다시 검색해 주세요.",
+    description: String = "동/읍/면 이름으로 다시 검색해 주세요.\n예: 문래동, 역삼동",
     actionLabel: String? = null,
     onActionClick: (() -> Unit)? = null,
 ) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
@@ -43,7 +43,7 @@ fun MapSearchBar(
         onSearch = {
             submitSearch()
         },
-        placeholder = "동네 또는 주소를 검색해주세요.",
+        placeholder = "동/읍/면을 검색해주세요.",
         trailingContent = { isFocused ->
             val searchIconColor = when {
                 keyword.isNotBlank() || isFocused -> MaterialTheme.colorScheme.primary

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/MapSearchBar.kt
@@ -43,7 +43,7 @@ fun MapSearchBar(
         onSearch = {
             submitSearch()
         },
-        placeholder = "동/읍/면을 검색해주세요.",
+        placeholder = stringResource(R.string.map_search_placeholder),
         trailingContent = { isFocused ->
             val searchIconColor = when {
                 keyword.isNotBlank() || isFocused -> MaterialTheme.colorScheme.primary

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
@@ -89,7 +89,7 @@ fun SpotBottomSheetContent(
 
             errorMessage != null -> {
                 EmptySpotResult(
-                    title = "수거 장소를 불러오지 못했습니다.",
+                    title = "검색에 실패했습니다.",
                     description = errorMessage,
                 )
             }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
@@ -1,6 +1,7 @@
 package com.team.yeogibeoryeo.presentation.map.components
 
 import androidx.compose.foundation.clickable
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,11 +19,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.map.MapLocationNotice
 import com.team.yeogibeoryeo.presentation.map.MapLocationNoticeAction
 
@@ -73,7 +76,7 @@ fun SpotBottomSheetContent(
                 EmptySpotResult(
                     title = locationNotice.title,
                     description = locationNotice.message,
-                    actionLabel = locationNotice.action?.toActionLabel(),
+                    actionLabel = locationNotice.action?.let { stringResource(it.toActionLabelResId()) },
                     onActionClick = locationNotice.action?.let { action ->
                         { onLocationNoticeActionClick(action) }
                     },
@@ -82,14 +85,14 @@ fun SpotBottomSheetContent(
 
             locationNoticeMessage != null -> {
                 EmptySpotResult(
-                    title = "현재 위치 검색 안내",
+                    title = stringResource(R.string.map_current_location_notice_title),
                     description = locationNoticeMessage,
                 )
             }
 
             errorMessage != null -> {
                 EmptySpotResult(
-                    title = "검색에 실패했습니다.",
+                    title = stringResource(R.string.map_search_failed_title),
                     description = errorMessage,
                 )
             }
@@ -125,9 +128,9 @@ fun SpotBottomSheetHeader(
     ) {
         Text(
             text = if (hasSearched) {
-                "검색 결과 ${resultCount}개"
+                stringResource(R.string.map_spot_result_count, resultCount)
             } else {
-                "수거 장소 검색"
+                stringResource(R.string.map_spot_search_title)
             },
             modifier = Modifier.padding(horizontal = 20.dp, vertical = 14.dp),
             style = MaterialTheme.typography.titleMedium,
@@ -157,11 +160,11 @@ private fun SpotBottomSheetLoading(
 @Composable
 fun SpotDetailBottomSheetContent(
     spot: CollectionSpot,
+    modifier: Modifier = Modifier,
     isNearbyLoading: Boolean = false,
     onFavoriteClick: (CollectionSpot) -> Unit,
     onRegionalGuideClick: (String) -> Unit = {},
     onCloseClick: () -> Unit,
-    modifier: Modifier = Modifier,
     bottomContentPadding: Dp = 0.dp,
 ) {
     Column(
@@ -185,7 +188,7 @@ fun SpotDetailBottomSheetContent(
                     .fillMaxWidth()
                     .padding(top = 12.dp),
             ) {
-                Text(text = "이 지역 배출 정보 보기")
+                Text(text = stringResource(R.string.map_regional_guide_action))
             }
         }
 
@@ -203,7 +206,7 @@ fun SpotDetailBottomSheetContent(
                     strokeWidth = 2.dp,
                 )
                 Text(
-                    text = "주변 목록 준비 중",
+                    text = stringResource(R.string.map_nearby_list_loading),
                     modifier = Modifier.padding(end = 12.dp),
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -211,7 +214,7 @@ fun SpotDetailBottomSheetContent(
             }
 
             Text(
-                text = "목록으로",
+                text = stringResource(R.string.map_spot_detail_back_to_list),
                 modifier = Modifier
                     .clickable(onClick = onCloseClick),
                 style = MaterialTheme.typography.labelLarge,
@@ -352,9 +355,10 @@ private fun sampleSpotBottomSheetSpots(): List<CollectionSpot> {
     )
 }
 
-private fun MapLocationNoticeAction.toActionLabel(): String {
+@StringRes
+private fun MapLocationNoticeAction.toActionLabelResId(): Int {
     return when (this) {
-        MapLocationNoticeAction.OpenAppSettings -> "앱 설정 열기"
-        MapLocationNoticeAction.OpenLocationSettings -> "위치 설정 열기"
+        MapLocationNoticeAction.OpenAppSettings -> R.string.map_location_notice_open_app_settings
+        MapLocationNoticeAction.OpenLocationSettings -> R.string.map_location_notice_open_location_settings
     }
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -206,4 +206,20 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.]]></string>
     <string name="settings_cache_confirm_description">현재 위치로 주변 수거 장소를 찾았을 때 임시 저장된 위치 캐시를 삭제합니다. 즐겨찾기와 품목 검색 기록은 삭제되지 않습니다.</string>
     <string name="settings_cache_delete_action">삭제</string>
+    <string name="map_search_placeholder">동/읍/면을 검색해주세요.</string>
+    <string name="map_search_loading_title">검색중</string>
+    <string name="map_search_loading_keyword">입력한 동/읍/면 주변을 찾고 있어요</string>
+    <string name="map_search_loading_current_location">현재 위치 주변을 찾고 있어요</string>
+    <string name="map_search_loading_map_center">현 지도 주변을 찾고 있어요</string>
+    <string name="map_spot_search_title">수거 장소 검색</string>
+    <string name="map_spot_result_count">검색 결과 %1$d개</string>
+    <string name="map_empty_spot_result_title">검색 결과가 없습니다.</string>
+    <string name="map_empty_spot_result_description">동/읍/면 이름으로 다시 검색해 주세요.\n예: 문래동, 역삼동</string>
+    <string name="map_current_location_notice_title">현재 위치 검색 안내</string>
+    <string name="map_search_failed_title">검색에 실패했습니다.</string>
+    <string name="map_location_notice_open_app_settings">앱 설정 열기</string>
+    <string name="map_location_notice_open_location_settings">위치 설정 열기</string>
+    <string name="map_regional_guide_action">이 지역 배출 정보 보기</string>
+    <string name="map_nearby_list_loading">주변 목록 준비 중</string>
+    <string name="map_spot_detail_back_to_list">목록으로</string>
 </resources>

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapCurrentLocationViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapCurrentLocationViewModelTest.kt
@@ -31,10 +31,10 @@ class CollectionSpotMapCurrentLocationViewModelTest : CollectionSpotMapViewModel
             assertFalse(viewModel.uiState.value.isLoading)
             assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
             assertEquals(
-                "현재 위치 검색은 정확한 위치 권한을 허용하면 사용할 수 있어요. 직접 동/읍/면을 검색할 수도 있습니다.",
+                MapLocationNotices.PermissionDenied.message,
                 viewModel.uiState.value.locationNoticeMessage,
             )
-            assertEquals("위치 권한이 필요합니다.", viewModel.uiState.value.locationNotice?.title)
+            assertEquals(MapLocationNotices.PermissionDenied.title, viewModel.uiState.value.locationNotice?.title)
             assertEquals(
                 viewModel.uiState.value.locationNotice?.message,
                 viewModel.uiState.value.locationNoticeMessage,
@@ -68,7 +68,7 @@ class CollectionSpotMapCurrentLocationViewModelTest : CollectionSpotMapViewModel
             assertEquals(0, repository.locationSearchCallCount)
             assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
             assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
-            assertEquals("위치 권한이 필요합니다.", viewModel.uiState.value.locationNotice?.title)
+            assertEquals(MapLocationNotices.PermissionDenied.title, viewModel.uiState.value.locationNotice?.title)
         }
 
     @Test
@@ -94,7 +94,7 @@ class CollectionSpotMapCurrentLocationViewModelTest : CollectionSpotMapViewModel
             assertNull(cache.entry)
             assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
             assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
-            assertEquals("위치 권한이 필요합니다.", viewModel.uiState.value.locationNotice?.title)
+            assertEquals(MapLocationNotices.PermissionDenied.title, viewModel.uiState.value.locationNotice?.title)
         }
 
     @Test
@@ -119,7 +119,7 @@ class CollectionSpotMapCurrentLocationViewModelTest : CollectionSpotMapViewModel
             assertNull(cache.entry)
             assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
             assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
-            assertEquals("위치 권한이 필요합니다.", viewModel.uiState.value.locationNotice?.title)
+            assertEquals(MapLocationNotices.PermissionDenied.title, viewModel.uiState.value.locationNotice?.title)
         }
 
     @Test
@@ -167,10 +167,13 @@ class CollectionSpotMapCurrentLocationViewModelTest : CollectionSpotMapViewModel
             assertFalse(viewModel.uiState.value.isLoading)
             assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
             assertEquals(
-                "현재 위치를 확인하지 못했습니다. 잠시 후 다시 시도하거나 직접 동/읍/면을 검색해 주세요.",
+                MapLocationNotices.CurrentLocationUnavailable.message,
                 viewModel.uiState.value.locationNoticeMessage,
             )
-            assertEquals("현재 위치를 확인하지 못했습니다.", viewModel.uiState.value.locationNotice?.title)
+            assertEquals(
+                MapLocationNotices.CurrentLocationUnavailable.title,
+                viewModel.uiState.value.locationNotice?.title,
+            )
             assertEquals(
                 viewModel.uiState.value.locationNotice?.message,
                 viewModel.uiState.value.locationNoticeMessage,
@@ -194,10 +197,13 @@ class CollectionSpotMapCurrentLocationViewModelTest : CollectionSpotMapViewModel
             assertFalse(viewModel.uiState.value.isLoading)
             assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
             assertEquals(
-                "기기의 위치 서비스가 꺼져 있어 현재 위치를 확인할 수 없어요. 위치 서비스를 켠 뒤 다시 시도하거나 직접 동/읍/면을 검색해 주세요.",
+                MapLocationNotices.LocationServiceDisabled.message,
                 viewModel.uiState.value.locationNoticeMessage,
             )
-            assertEquals("위치 서비스가 꺼져 있습니다.", viewModel.uiState.value.locationNotice?.title)
+            assertEquals(
+                MapLocationNotices.LocationServiceDisabled.title,
+                viewModel.uiState.value.locationNotice?.title,
+            )
             assertEquals(
                 viewModel.uiState.value.locationNotice?.message,
                 viewModel.uiState.value.locationNoticeMessage,
@@ -250,7 +256,7 @@ class CollectionSpotMapCurrentLocationViewModelTest : CollectionSpotMapViewModel
             assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
             assertFalse(viewModel.uiState.value.isLoading)
             assertEquals(
-                "네트워크 연결을 확인한 뒤 다시 시도하거나 직접 동/읍/면을 검색해 주세요.",
+                MapLocationNotices.CurrentLocationSpotSearchFailureMessage,
                 viewModel.uiState.value.errorMessage,
             )
             assertNull(viewModel.uiState.value.locationNotice)
@@ -337,7 +343,10 @@ class CollectionSpotMapCurrentLocationViewModelTest : CollectionSpotMapViewModel
             secondResult.complete(CurrentLocationResult.LocationServiceDisabled)
             advanceUntilIdle()
 
-            assertEquals("위치 서비스가 꺼져 있습니다.", viewModel.uiState.value.locationNotice?.title)
+            assertEquals(
+                MapLocationNotices.LocationServiceDisabled.title,
+                viewModel.uiState.value.locationNotice?.title,
+            )
             assertEquals(MapLocationNoticeAction.OpenLocationSettings, viewModel.uiState.value.locationNotice?.action)
             assertEquals(
                 viewModel.uiState.value.locationNotice?.message,
@@ -365,7 +374,10 @@ class CollectionSpotMapCurrentLocationViewModelTest : CollectionSpotMapViewModel
             viewModel.searchByCurrentLocation()
             advanceUntilIdle()
 
-            assertEquals("위치 서비스가 꺼져 있습니다.", viewModel.uiState.value.locationNotice?.title)
+            assertEquals(
+                MapLocationNotices.LocationServiceDisabled.title,
+                viewModel.uiState.value.locationNotice?.title,
+            )
 
             currentLocationResult = CurrentLocationResult.Found(currentCoordinate)
             viewModel.searchByCurrentLocation()

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapCurrentLocationViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapCurrentLocationViewModelTest.kt
@@ -31,7 +31,7 @@ class CollectionSpotMapCurrentLocationViewModelTest : CollectionSpotMapViewModel
             assertFalse(viewModel.uiState.value.isLoading)
             assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
             assertEquals(
-                "현재 위치 검색은 정확한 위치 권한을 허용하면 사용할 수 있어요. 직접 동네나 주소를 검색할 수도 있습니다.",
+                "현재 위치 검색은 정확한 위치 권한을 허용하면 사용할 수 있어요. 직접 동/읍/면을 검색할 수도 있습니다.",
                 viewModel.uiState.value.locationNoticeMessage,
             )
             assertEquals("위치 권한이 필요합니다.", viewModel.uiState.value.locationNotice?.title)
@@ -167,7 +167,7 @@ class CollectionSpotMapCurrentLocationViewModelTest : CollectionSpotMapViewModel
             assertFalse(viewModel.uiState.value.isLoading)
             assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
             assertEquals(
-                "현재 위치를 확인하지 못했습니다. 잠시 후 다시 시도하거나 직접 동네명/주소를 검색해 주세요.",
+                "현재 위치를 확인하지 못했습니다. 잠시 후 다시 시도하거나 직접 동/읍/면을 검색해 주세요.",
                 viewModel.uiState.value.locationNoticeMessage,
             )
             assertEquals("현재 위치를 확인하지 못했습니다.", viewModel.uiState.value.locationNotice?.title)
@@ -194,7 +194,7 @@ class CollectionSpotMapCurrentLocationViewModelTest : CollectionSpotMapViewModel
             assertFalse(viewModel.uiState.value.isLoading)
             assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
             assertEquals(
-                "기기의 위치 서비스가 꺼져 있어 현재 위치를 확인할 수 없어요. 위치 서비스를 켠 뒤 다시 시도하거나 직접 동네명/주소를 검색해 주세요.",
+                "기기의 위치 서비스가 꺼져 있어 현재 위치를 확인할 수 없어요. 위치 서비스를 켠 뒤 다시 시도하거나 직접 동/읍/면을 검색해 주세요.",
                 viewModel.uiState.value.locationNoticeMessage,
             )
             assertEquals("위치 서비스가 꺼져 있습니다.", viewModel.uiState.value.locationNotice?.title)
@@ -250,7 +250,7 @@ class CollectionSpotMapCurrentLocationViewModelTest : CollectionSpotMapViewModel
             assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
             assertFalse(viewModel.uiState.value.isLoading)
             assertEquals(
-                "네트워크 연결을 확인한 뒤 다시 시도하거나 직접 동네명/주소를 검색해 주세요.",
+                "네트워크 연결을 확인한 뒤 다시 시도하거나 직접 동/읍/면을 검색해 주세요.",
                 viewModel.uiState.value.errorMessage,
             )
             assertNull(viewModel.uiState.value.locationNotice)

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapSearchViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapSearchViewModelTest.kt
@@ -117,7 +117,10 @@ class CollectionSpotMapSearchViewModelTest : CollectionSpotMapViewModelTestFixtu
             assertEquals(listOf("용답동"), repository.keywords)
             assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
             assertFalse(viewModel.uiState.value.isLoading)
-            assertEquals("네트워크 연결을 확인한 뒤 다시 시도해 주세요.", viewModel.uiState.value.errorMessage)
+            assertEquals(
+                "잠시 후 다시 시도하거나 네트워크 연결을 확인해 주세요.",
+                viewModel.uiState.value.errorMessage,
+            )
             assertNull(viewModel.uiState.value.locationNotice)
             assertNull(viewModel.uiState.value.locationNoticeMessage)
         }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapSearchViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapSearchViewModelTest.kt
@@ -118,7 +118,7 @@ class CollectionSpotMapSearchViewModelTest : CollectionSpotMapViewModelTestFixtu
             assertEquals(emptyList<CollectionSpot>(), viewModel.uiState.value.spots)
             assertFalse(viewModel.uiState.value.isLoading)
             assertEquals(
-                "잠시 후 다시 시도하거나 네트워크 연결을 확인해 주세요.",
+                MapLocationNotices.SpotSearchFailureMessage,
                 viewModel.uiState.value.errorMessage,
             )
             assertNull(viewModel.uiState.value.locationNotice)


### PR DESCRIPTION
## 작업 내용

Related #213

지도 키워드 검색 안내를 `/getSpot` API의 `addr` 입력 특성에 맞춰 동/읍/면 단위로 정리했습니다.

현재 지도 검색은 입력값을 별도 파싱 없이 `/getSpot`의 `addr` 파라미터로 그대로 전달하므로, 일반 주소 검색처럼 안내하기보다 동/읍/면 입력을 유도하는 쪽으로 UX 문구를 조정했습니다.

## 주요 변경 사항

| 구분 | 내용 |
| --- | --- |
| 검색창 placeholder | `동/읍/면을 검색해주세요.`로 변경 |
| 키워드 검색 로딩 문구 | `입력한 동/읍/면 주변을 찾고 있어요`로 변경 |
| 검색 결과 없음 안내 | 동/읍/면 단위 재검색 안내와 예시 추가 |
| 검색 실패 문구 | 검색 결과 없음과 네트워크/API 실패 안내를 구분 |
| 현재 위치 실패 안내 | 직접 검색 안내를 동/읍/면 기준으로 통일 |
| 테스트 | 변경된 안내 문구에 맞춰 ViewModel 테스트 기대값 갱신 |

## 정책 정리

| 항목 | 정책 |
| --- | --- |
| API 호출 방식 | 기존처럼 입력값을 `/getSpot addr`에 그대로 전달 |
| 구/동 조합 입력 보정 | 이번 PR 범위에서 제외 |
| 도로명 주소 파싱 | 이번 PR 범위에서 제외 |
| 동일 동명 결과 | 여러 지역 결과가 함께 표시될 수 있으며 기존 지도 축소/마커 표시 정책 유지 |
| 도로명 주소 표시 | 동/읍/면 검색 결과라도 카드에는 도로명 주소가 표시될 수 있음 |
| 결과 후처리 | 카드 주소에 입력 동명이 직접 포함되지 않는다는 이유로 결과를 제거하지 않음 |

## 참고

`금호동` 검색 결과 중 `성동구 독서당로 303-5`처럼 카드에는 도로명 주소가 표시될 수 있습니다.

해당 주소는 지번 기준 `금호동3가 324`로 확인되어, API가 `금호동` 결과로 내려준 정상 케이스로 봤습니다.

구/동 조합 입력 보정, 도로명 주소 파싱, 검색 후보 리스트, reverse geocoding 기반 검증은 후속 이슈로 분리합니다.

## 검증

| 항목 | 결과 |
| --- | --- |
| 검색창 placeholder가 동/읍/면 기준으로 표시되는지 확인 | 확인 |
| `금호동` 검색 시 여러 지역 결과가 지도에 표시되는지 확인 | 확인 |
| 동일 동명 결과 표시를 위해 지도 카메라가 축소되는지 확인 | 확인 |
| 도로명 주소로 표시되는 정상 결과가 유지되는지 확인 | 확인 |
| 검색 결과 없음 안내 문구 확인 | 확인 |
| 기존 현재 위치 검색 동작 | 확인 |
| 기존 현 지도 검색 동작 | 확인 |
| 기존 BottomSheet / 마커 / 필터 동작 | 확인 |

## 테스트

```bash
./gradlew.bat :presentation:testDebugUnitTest --tests com.team.yeogibeoryeo.presentation.map.CollectionSpotMapSearchViewModelTest --tests com.team.yeogibeoryeo.presentation.map.CollectionSpotMapCurrentLocationViewModelTest
```

## 스크린샷

| 검색바 안내 | 동일 동명 결과 지도 표시 | 도로명 주소 카드 표시 |
| --- | --- | --- |
| <img width="240" alt="동/읍/면 검색 placeholder" src="https://github.com/user-attachments/assets/c500fb42-bebc-4587-a204-a0b470af9a8a" /> | <img width="240" alt="금호동 검색 시 여러 지역 결과 표시" src="https://github.com/user-attachments/assets/ab5d0178-517c-42af-8cdf-05369f74565f" /> | <img width="240" alt="도로명 주소로 표시되는 금호동 검색 결과 카드" src="https://github.com/user-attachments/assets/8113a9db-8396-4d2d-bedd-23315d5abc93" /> |