### PR TITLE
[Refactor] 품목 검색/상세 화면 IDE 경고 정리

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest>
 
 </manifest>

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/BottomBarVisibilityOnScrollEffect.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/BottomBarVisibilityOnScrollEffect.kt
@@ -21,7 +21,7 @@ internal fun BottomBarVisibilityOnScrollEffect(
 
         snapshotFlow { scrollState.value to scrollState.maxValue }
             .collect { (currentOffset, maxOffset) ->
-                val isAtBottom = maxOffset > 0 && currentOffset >= maxOffset
+                val isAtBottom = maxOffset > 0 && currentOffset in maxOffset..Int.MAX_VALUE
                 when {
                     currentOffset == 0 -> onBottomBarVisibilityChangedState(true)
                     currentOffset > previousOffset -> onBottomBarVisibilityChangedState(false)
@@ -49,8 +49,8 @@ internal fun BottomBarVisibilityOnScrollEffect(
             val layoutInfo = listState.layoutInfo
             val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
             val lastIndex = layoutInfo.totalItemsCount - 1
-            val isAtBottom = lastIndex >= 0 && lastVisibleIndex >= lastIndex
-            val position = listState.firstVisibleItemIndex.toLong() * ScrollPositionItemMultiplier +
+            val isAtBottom = lastIndex >= 0 && lastVisibleIndex in lastIndex..Int.MAX_VALUE
+            val position = listState.firstVisibleItemIndex.toLong() * SCROLL_POSITION_ITEM_MULTIPLIER +
                 listState.firstVisibleItemScrollOffset
             Triple(position, listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0, isAtBottom)
         }.collect { (currentPosition, isAtTop, isAtBottom) ->
@@ -66,4 +66,4 @@ internal fun BottomBarVisibilityOnScrollEffect(
     }
 }
 
-private const val ScrollPositionItemMultiplier = 1_000_000L
+private const val SCROLL_POSITION_ITEM_MULTIPLIER = 1_000_000L

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/HomeRegionalGuideSummaryViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/HomeRegionalGuideSummaryViewModel.kt
@@ -50,8 +50,8 @@ class HomeRegionalGuideSummaryViewModel
         ): HomeRegionalGuideSummaryUiState {
             return if (
                 previous is HomeRegionalGuideSummaryUiState.Summary &&
-                next is HomeRegionalGuideSummaryUiState.Loading &&
-                previous.targetId == next.targetId
+                    next is HomeRegionalGuideSummaryUiState.Loading &&
+                    previous.targetId == next.targetId
             ) {
                 previous
             } else {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
@@ -20,12 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import com.team.yeogibeoryeo.domain.item.model.DisposalCategory
-import com.team.yeogibeoryeo.domain.item.model.DisposalInstruction
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
-import com.team.yeogibeoryeo.domain.item.model.DisposalSubCategory
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
-import com.team.yeogibeoryeo.common.R as CommonR
 import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
 import com.team.yeogibeoryeo.presentation.search.components.DisposalGuideMetadataChips
@@ -37,18 +33,19 @@ import com.team.yeogibeoryeo.presentation.search.components.iconResId
 import com.team.yeogibeoryeo.presentation.search.components.iconTint
 import com.team.yeogibeoryeo.presentation.search.model.ItemGuideDetailAction
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
+import com.team.yeogibeoryeo.common.R as CommonR
 
 @Composable
 fun ItemGuideDetailScreen(
     guide: DisposalItemGuide,
-    actions: List<ItemGuideDetailAction> = emptyList(),
     isFavorite: Boolean,
     onBackClick: () -> Unit,
     onFavoriteClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    actions: List<ItemGuideDetailAction> = emptyList(),
     onCollectionSpotTypeClick: (CollectionSpotType) -> Unit = {},
     onOfficialGuideClick: (String) -> Unit = {},
     onBottomBarVisibilityChanged: (Boolean) -> Unit = {},
-    modifier: Modifier = Modifier,
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
     val size = ItemSearchLayoutDefaults.size

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailTextStyles.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailTextStyles.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.text.TextStyle
 
 @Composable
 internal fun itemGuideDetailTextStyles(): ItemGuideDetailTextStyles {
-    val useLargeFontLayout = LocalDensity.current.fontScale >= ItemGuideDetailTypographyBreakpoints.LargeFontScale
+    val useLargeFontLayout = LocalDensity.current.fontScale >= ItemGuideDetailTypographyBreakpoints.LARGE_FONT_SCALE
 
     return if (useLargeFontLayout) {
         ItemGuideDetailTextStyles(
@@ -40,5 +40,5 @@ internal data class ItemGuideDetailTextStyles(
 )
 
 private object ItemGuideDetailTypographyBreakpoints {
-    const val LargeFontScale = 1.3f
+    const val LARGE_FONT_SCALE = 1.3f
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailViewModel.kt
@@ -64,7 +64,7 @@ constructor(
                     }
                 } catch (exception: CancellationException) {
                     throw exception
-                } catch (exception: Throwable) {
+                } catch (_: Throwable) {
                     _uiState.value =
                         ItemGuideDetailUiState.Error(
                             R.string.item_guide_detail_load_failed_message,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
@@ -51,9 +51,6 @@ fun ItemSearchInitialContent(
     onSearchClick: () -> Unit,
     onUsefulGuideClick: (ItemUsefulGuideContent) -> Unit,
     regionalGuideSummaryState: HomeRegionalGuideSummaryUiState,
-    modifier: Modifier = Modifier,
-    onRegionalGuideSummaryClick: (String) -> Unit = {},
-    onRegionalGuideSummaryRetryClick: () -> Unit = {},
     onQuickCategoryClick: (RepresentativeGuideCategory) -> Unit,
     onQuickCategorySettingsClick: (Int) -> Unit,
     quickCategories: List<RepresentativeGuideCategory>,
@@ -68,6 +65,9 @@ fun ItemSearchInitialContent(
     onQuickCategoryViewportChanged: () -> Unit,
     onSettingsClick: (() -> Unit)?,
     listState: LazyListState,
+    modifier: Modifier = Modifier,
+    onRegionalGuideSummaryClick: (String) -> Unit = {},
+    onRegionalGuideSummaryRetryClick: () -> Unit = {},
 ) {
     var viewportBottomInRootPx by rememberSaveable { mutableIntStateOf(0) }
     var maxSelectedQuickCategoryCount by rememberSaveable { mutableIntStateOf(quickCategories.size) }
@@ -166,7 +166,7 @@ fun ItemSearchInitialContent(
                             text = quickCategoriesTitle,
                             style = MaterialTheme.typography.titleLarge.copy(
                                 fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onSurface
+                                color = MaterialTheme.colorScheme.onSurface,
                             ),
                         )
                         AssistChip(
@@ -240,8 +240,8 @@ fun ItemSearchHeader(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        if (onSettingsClick != null) {
-            IconButton(onClick = onSettingsClick) {
+        onSettingsClick?.let {
+            IconButton(onClick = it) {
                 Icon(
                     painter = painterResource(id = CommonR.drawable.ic_action_settings),
                     contentDescription = stringResource(R.string.settings_action),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchLayoutDefaults.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchLayoutDefaults.kt
@@ -44,11 +44,11 @@ internal object ItemSearchSizeDefaults {
 }
 
 internal object ItemSearchFractionDefaults {
-    const val usefulGuideBannerWidth = 0.94f
+    const val USEFUL_GUIDE_BANNER_WIDTH = 0.94f
 }
 
 internal object ItemSearchAlphaDefaults {
-    const val usefulGuidePageIndicatorInactive = 0.32f
+    const val USEFUL_GUIDE_PAGE_INDICATOR_INACTIVE = 0.32f
 }
 
 internal object ItemSearchStrokeDefaults {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -210,13 +210,13 @@ fun ItemSearchScreen(
                     else -> {
                         val searchResultCountText = stringResource(
                             R.string.search_results_count,
-                            uiState.guides.size
+                            uiState.guides.size,
                         )
                         KoreanLineBreakText(
                             text = searchResultCountText,
                             style = MaterialTheme.typography.titleLarge.copy(
                                 fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onSurface
+                                color = MaterialTheme.colorScheme.onSurface,
                             ),
                         )
                         LazyColumn(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
-import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.domain.item.usecase.GetDisposalCategoryGuidesUseCase
 import com.team.yeogibeoryeo.domain.item.usecase.LimitHomeQuickCategoriesUseCase
 import com.team.yeogibeoryeo.domain.item.usecase.ObserveHomeQuickCategoriesUseCase
@@ -158,8 +157,8 @@ constructor(
                             guides.firstOrNull { it.name == category.representativeGuideName }
                                 ?: guides.firstOrNull()
 
-                        if (representativeGuide != null) {
-                            _events.emit(ItemSearchEvent.NavigateToGuide(representativeGuide))
+                        representativeGuide?.let {
+                            _events.emit(ItemSearchEvent.NavigateToGuide(it))
                         }
                     }
                     .onFailure {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/QuickCategorySettingsRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/QuickCategorySettingsRoute.kt
@@ -222,8 +222,9 @@ private fun QuickCategoryDisplayRow(
                 value = isSelected,
                 enabled = enabled,
                 role = Role.Checkbox,
-                onValueChange = { onClick() },
-            ),
+            ) {
+                onClick()
+            },
         shape = MaterialTheme.shapes.large,
         color =
             if (isSelected) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemUsefulGuideBannerRow.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemUsefulGuideBannerRow.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 import com.team.yeogibeoryeo.presentation.search.model.ItemUsefulGuideContent
 import com.team.yeogibeoryeo.presentation.search.model.ItemUsefulGuideType
@@ -83,7 +82,7 @@ fun ItemUsefulGuideBannerRow(
                     guide = guide,
                     onClick = { onGuideClick(guide) },
                     modifier = Modifier
-                        .fillParentMaxWidth(fraction.usefulGuideBannerWidth)
+                        .fillParentMaxWidth(fraction.USEFUL_GUIDE_BANNER_WIDTH)
                         .height(size.usefulGuideBannerCardHeight),
                 )
             }
@@ -104,7 +103,6 @@ private fun ItemUsefulGuideBannerCard(
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
     val size = ItemSearchLayoutDefaults.size
-    val alpha = ItemSearchLayoutDefaults.alpha
 
     Card(
         modifier = modifier
@@ -193,7 +191,7 @@ private fun ItemUsefulGuidePageIndicator(
             val targetColor = if (isSelected) {
                 MaterialTheme.colorScheme.primary
             } else {
-                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = alpha.usefulGuidePageIndicatorInactive)
+                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = alpha.USEFUL_GUIDE_PAGE_INDICATOR_INACTIVE)
             }
             val color by animateColorAsState(targetValue = targetColor)
             val width by animateDpAsState(
@@ -201,7 +199,7 @@ private fun ItemUsefulGuidePageIndicator(
                     size.usefulGuidePageIndicatorActiveWidth
                 } else {
                     size.usefulGuidePageIndicatorInactiveSize
-                }
+                },
             )
             Box(
                 modifier = Modifier

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
@@ -142,18 +141,17 @@ fun QuickCategoryGrid(
                     collapseLayout.showsMore -> add(
                         QuickCategoryGridItem.Toggle(
                             labelResId = R.string.quick_category_more_action,
-                            onClick = {
-                                shouldBringExpandedGridIntoView = true
-                                onMoreClick(collapseLayout.collapsedItemCount)
-                            },
-                        )
+                        ) {
+                            shouldBringExpandedGridIntoView = true
+                            onMoreClick(collapseLayout.collapsedItemCount)
+                        },
                     )
 
                     collapseLayout.showsCollapse -> add(
                         QuickCategoryGridItem.Toggle(
                             labelResId = R.string.quick_category_collapse_action,
                             onClick = onCollapseClick,
-                        )
+                        ),
                     )
                 }
             }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModelTest.kt
@@ -560,11 +560,11 @@ class ItemSearchViewModelTest {
         ) {
             toggledHomeQuickCategories += category
             if (category in categories.value) {
-                categories.value = categories.value - category
+                categories.value -= category
             } else if (categories.value.size >= maxSelectedCount.coerceAtLeast(0)) {
                 return
             } else {
-                categories.value = categories.value + category
+                categories.value += category
             }
         }
 


### PR DESCRIPTION
## 작업 내용

- 품목 검색/상세 화면의 unused import와 불필요한 파라미터를 제거했습니다.
- Compose 함수의 `modifier` 파라미터 위치를 정리했습니다.
- const property 네이밍을 `UPPER_SNAKE_CASE`로 정리했습니다.
- 기존 비교 의미를 유지하면서 range check 표현을 정리했습니다.
- presentation manifest의 unused namespace를 제거했습니다.

## 확인 사항

- 기능 동작 변경 없이 IDE inspection warning 정리만 포함했습니다.
- `map`, `regionalguide`, `region`, `data`, `domain`, `app/navigation`, `gradle/libs.versions.toml`은 이번 PR 범위에서 제외했습니다.

## 테스트

- `./gradlew.bat :presentation:compileDebugKotlin :presentation:compileDebugUnitTestKotlin`
- `git diff --check`

## 관련 이슈

Related #229
