### PR TITLE
[Refactor] 품목 DataStore 테스트 파일 IO dispatcher 정리

### DIFF
--- a/data/src/test/java/com/team/yeogibeoryeo/data/item/repository/DataStoreHomeQuickCategoryRepositoryTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/item/repository/DataStoreHomeQuickCategoryRepositoryTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -72,8 +73,11 @@ class DataStoreHomeQuickCategoryRepositoryTest {
     private suspend fun withRepository(
         block: suspend (DataStoreHomeQuickCategoryRepository) -> Unit,
     ) {
-        val file = File.createTempFile("home-quick-category", ".preferences_pb")
-        file.delete()
+        val file = withContext(Dispatchers.IO) {
+            File.createTempFile("home-quick-category", ".preferences_pb").apply {
+                delete()
+            }
+        }
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         val dataStore =
             PreferenceDataStoreFactory.create(
@@ -86,7 +90,9 @@ class DataStoreHomeQuickCategoryRepositoryTest {
             block(repository)
         } finally {
             scope.cancel()
-            file.delete()
+            withContext(Dispatchers.IO) {
+                file.delete()
+            }
         }
     }
 }


### PR DESCRIPTION
## 작업 내용

- `DataStoreHomeQuickCategoryRepositoryTest`의 테스트 helper에서 파일 생성과 삭제를 `Dispatchers.IO`에서 실행하도록 정리했습니다.
- suspend context에서 blocking 파일 IO를 직접 호출해 IDE inspection warning이 뜨던 부분을 제거했습니다.

## 테스트

- `./gradlew.bat :data:testDebugUnitTest --tests com.team.yeogibeoryeo.data.item.repository.DataStoreHomeQuickCategoryRepositoryTest`
- `git diff --check`

## 관련 이슈

Related #231
