### PR TITLE
[Feature] 지도 검색어 주소 보정 및 동명 오탐 방어

### DIFF
--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/NormalizeCollectionSpotSearchKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/NormalizeCollectionSpotSearchKeywordUseCase.kt
@@ -1,0 +1,47 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import javax.inject.Inject
+
+class NormalizeCollectionSpotSearchKeywordUseCase @Inject constructor() {
+
+    operator fun invoke(keyword: String): String {
+        val trimmedKeyword = keyword.trim()
+        if (trimmedKeyword.isBlank()) return trimmedKeyword
+
+        val tokens = trimmedKeyword
+            .split(WHITESPACE_REGEX)
+            .map { token -> token.cleanToken() }
+            .filter { token -> token.isNotBlank() }
+
+        if (tokens.any { token -> token.hasAddressNumber() || token.isRoadNameLike() }) {
+            return trimmedKeyword
+        }
+
+        return tokens
+            .lastOrNull { token -> token.isEupMyeonDongCandidate() }
+            ?: trimmedKeyword
+    }
+
+    private fun String.cleanToken(): String =
+        trim().trim('(', ')', '[', ']', ',', '.', ' ')
+
+    private fun String.hasAddressNumber(): Boolean =
+        ADDRESS_NUMBER_REGEX.matches(this)
+
+    private fun String.isRoadNameLike(): Boolean {
+        val nameWithoutNumbers = replace(DIGIT_REGEX, "")
+        return nameWithoutNumbers.endsWith("로") || nameWithoutNumbers.endsWith("길")
+    }
+
+    private fun String.isEupMyeonDongCandidate(): Boolean =
+        EUP_MYEON_DONG_REGEX.matches(this) ||
+            LEGAL_DONG_GA_REGEX.matches(this)
+
+    private companion object {
+        private val WHITESPACE_REGEX = "\\s+".toRegex()
+        private val DIGIT_REGEX = "\\d+".toRegex()
+        private val ADDRESS_NUMBER_REGEX = """\d+(-\d+)?""".toRegex()
+        private val EUP_MYEON_DONG_REGEX = """[가-힣]+\d*(동|읍|면)""".toRegex()
+        private val LEGAL_DONG_GA_REGEX = """[가-힣]+\d+가""".toRegex()
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/NormalizeCollectionSpotSearchKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/NormalizeCollectionSpotSearchKeywordUseCase.kt
@@ -41,7 +41,7 @@ class NormalizeCollectionSpotSearchKeywordUseCase @Inject constructor() {
         private val WHITESPACE_REGEX = "\\s+".toRegex()
         private val DIGIT_REGEX = "\\d+".toRegex()
         private val ADDRESS_NUMBER_REGEX = """\d+(-\d+)?""".toRegex()
-        private val EUP_MYEON_DONG_REGEX = """[가-힣]+\d*(동|읍|면)""".toRegex()
+        private val EUP_MYEON_DONG_REGEX = """[가-힣]+\d*[동읍면]""".toRegex()
         private val LEGAL_DONG_GA_REGEX = """[가-힣]+\d+가""".toRegex()
     }
 }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
@@ -6,15 +6,73 @@ import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import javax.inject.Inject
 
 class SearchCollectionSpotsByKeywordUseCase @Inject constructor(
-    private val repository: CollectionSpotRepository
+    private val repository: CollectionSpotRepository,
+    private val normalizeKeywordUseCase: NormalizeCollectionSpotSearchKeywordUseCase,
 ) {
     suspend operator fun invoke(
         keyword: String,
         types: Set<CollectionSpotType> = emptySet()
     ): List<CollectionSpot> {
+        val normalizedKeyword = normalizeKeywordUseCase(keyword)
+
         return repository.searchByKeyword(
-            keyword = keyword,
+            keyword = normalizedKeyword,
             types = types
-        )
+        ).filterByExplicitRegionKeyword(normalizedKeyword)
+    }
+
+    private fun List<CollectionSpot>.filterByExplicitRegionKeyword(
+        keyword: String,
+    ): List<CollectionSpot> {
+        if (!keyword.isEupMyeonDongCandidate()) return this
+
+        return filter { spot ->
+            val explicitRegions = spot.address.extractExplicitRegions()
+            explicitRegions.isEmpty() ||
+                explicitRegions.any { region -> region.matchesKeyword(keyword) }
+        }
+    }
+
+    private fun String.extractExplicitRegions(): List<String> {
+        val parenthesizedRegions = PARENTHESIZED_TEXT_REGEX
+            .findAll(this)
+            .flatMap { matchResult ->
+                matchResult.groupValues
+                    .getOrNull(1)
+                    .orEmpty()
+                    .split(REGION_TOKEN_DELIMITER_REGEX)
+                    .asSequence()
+            }
+
+        val tokenRegions = split(REGION_TOKEN_DELIMITER_REGEX)
+            .asSequence()
+
+        return (parenthesizedRegions + tokenRegions)
+            .map { token -> token.cleanToken() }
+            .filter { token -> token.isEupMyeonDongCandidate() }
+            .distinct()
+            .toList()
+    }
+
+    private fun String.matchesKeyword(keyword: String): Boolean {
+        return this == keyword ||
+            (startsWith(keyword) && isLegalDongGaCandidate())
+    }
+
+    private fun String.cleanToken(): String =
+        trim().trim('(', ')', '[', ']', ',', '.', ' ')
+
+    private fun String.isEupMyeonDongCandidate(): Boolean =
+        EUP_MYEON_DONG_REGEX.matches(this) ||
+            isLegalDongGaCandidate()
+
+    private fun String.isLegalDongGaCandidate(): Boolean =
+        LEGAL_DONG_GA_REGEX.matches(this)
+
+    private companion object {
+        private val PARENTHESIZED_TEXT_REGEX = "\\(([^)]+)\\)".toRegex()
+        private val REGION_TOKEN_DELIMITER_REGEX = "[,\\s]+".toRegex()
+        private val EUP_MYEON_DONG_REGEX = """[가-힣]+\d*(동|읍|면)""".toRegex()
+        private val LEGAL_DONG_GA_REGEX = """[가-힣]+\d+가""".toRegex()
     }
 }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
@@ -72,7 +72,7 @@ class SearchCollectionSpotsByKeywordUseCase @Inject constructor(
     private companion object {
         private val PARENTHESIZED_TEXT_REGEX = "\\(([^)]+)\\)".toRegex()
         private val REGION_TOKEN_DELIMITER_REGEX = "[,\\s]+".toRegex()
-        private val EUP_MYEON_DONG_REGEX = """[가-힣]+\d*(동|읍|면)""".toRegex()
+        private val EUP_MYEON_DONG_REGEX = """[가-힣]+\d*[동읍면]""".toRegex()
         private val LEGAL_DONG_GA_REGEX = """[가-힣]+\d+가""".toRegex()
     }
 }

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/NormalizeCollectionSpotSearchKeywordUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/NormalizeCollectionSpotSearchKeywordUseCaseTest.kt
@@ -1,0 +1,85 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NormalizeCollectionSpotSearchKeywordUseCaseTest {
+
+    private val useCase = NormalizeCollectionSpotSearchKeywordUseCase()
+
+    @Test
+    fun `동 단독 검색어는 그대로 유지한다`() {
+        assertEquals("금호동", useCase("금호동"))
+    }
+
+    @Test
+    fun `구 동 조합에서 동을 추출한다`() {
+        assertEquals("금호동", useCase("성동구 금호동"))
+    }
+
+    @Test
+    fun `시 구 동 조합에서 동을 추출한다`() {
+        assertEquals("금호동", useCase("서울 성동구 금호동"))
+    }
+
+    @Test
+    fun `정식 시도 구 동 조합에서 동을 추출한다`() {
+        assertEquals("금호동", useCase("서울특별시 성동구 금호동"))
+    }
+
+    @Test
+    fun `중구 명동 조합에서 명동을 추출한다`() {
+        assertEquals("명동", useCase("중구 명동"))
+    }
+
+    @Test
+    fun `서울 중구 명동 조합에서 명동을 추출한다`() {
+        assertEquals("명동", useCase("서울 중구 명동"))
+    }
+
+    @Test
+    fun `서울특별시 중구 명동 조합에서 명동을 추출한다`() {
+        assertEquals("명동", useCase("서울특별시 중구 명동"))
+    }
+
+    @Test
+    fun `숫자가 포함된 법정동 가 단독 검색어는 그대로 유지한다`() {
+        assertEquals("금호동3가", useCase("금호동3가"))
+    }
+
+    @Test
+    fun `구 법정동 가 조합에서 법정동을 추출한다`() {
+        assertEquals("금호동3가", useCase("성동구 금호동3가"))
+    }
+
+    @Test
+    fun `도로명 주소는 동으로 잘못 보정하지 않는다`() {
+        assertEquals("성동구 독서당로 303-5", useCase("성동구 독서당로 303-5"))
+    }
+
+    @Test
+    fun `시 구 도로명 주소는 동으로 잘못 보정하지 않는다`() {
+        assertEquals("서울 성동구 독서당로 303-5", useCase("서울 성동구 독서당로 303-5"))
+    }
+
+    @Test
+    fun `정식 시도 구 도로명 주소는 동으로 잘못 보정하지 않는다`() {
+        assertEquals("서울특별시 성동구 독서당로 303-5", useCase("서울특별시 성동구 독서당로 303-5"))
+    }
+
+    @Test
+    fun `도로명과 번지만 있는 입력은 그대로 유지한다`() {
+        assertEquals("강남대로 123", useCase("강남대로 123"))
+    }
+
+    @Test
+    fun `지번 상세 주소는 동으로 잘못 보정하지 않는다`() {
+        assertEquals("역삼동 123-4", useCase("역삼동 123-4"))
+    }
+
+    @Test
+    fun `빈 문자열과 공백 문자열을 안전하게 처리한다`() {
+        assertEquals("", useCase(""))
+        assertEquals("", useCase("   "))
+    }
+}

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCaseTest.kt
@@ -1,0 +1,148 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SearchCollectionSpotsByKeywordUseCaseTest {
+
+    private val repository = FakeCollectionSpotRepository()
+    private val useCase = SearchCollectionSpotsByKeywordUseCase(
+        repository = repository,
+        normalizeKeywordUseCase = NormalizeCollectionSpotSearchKeywordUseCase(),
+    )
+
+    @Test
+    fun `명동 검색에서 괄호 속 봉명동 결과는 제외한다`() =
+        runSuspendTest {
+            val myeongDongSpot = collectionSpot(
+                id = "myeongdong",
+                address = "서울특별시 중구 명동길 26 (명동)",
+            )
+            val bongMyeongDongSpot = collectionSpot(
+                id = "bongmyeongdong",
+                address = "충청북도 청주시 흥덕구 송절로124번길 65 (봉명동)",
+            )
+            repository.keywordSpots = listOf(myeongDongSpot, bongMyeongDongSpot)
+
+            val result = useCase(keyword = "명동")
+
+            assertEquals(listOf("명동"), repository.keywords)
+            assertEquals(listOf(myeongDongSpot), result)
+        }
+
+    @Test
+    fun `명동 검색에서 번지에 붙은 괄호 속 봉명동 결과는 제외한다`() =
+        runSuspendTest {
+            val spot = collectionSpot(
+                id = "bongmyeongdong-attached-parentheses",
+                address = "충청북도 청주시 흥덕구 직지대로 609(봉명동)",
+            )
+            repository.keywordSpots = listOf(spot)
+
+            val result = useCase(keyword = "명동")
+
+            assertEquals(emptyList<CollectionSpot>(), result)
+        }
+
+    @Test
+    fun `명동 검색에서 주소 본문 속 봉명동 결과는 제외한다`() =
+        runSuspendTest {
+            val spot = collectionSpot(
+                id = "bongmyeongdong-body",
+                address = "충청북도 청주시 흥덕구 봉명동 1순환로584번길 59",
+            )
+            repository.keywordSpots = listOf(spot)
+
+            val result = useCase(keyword = "명동")
+
+            assertEquals(emptyList<CollectionSpot>(), result)
+        }
+
+    @Test
+    fun `명동 검색에서 명동1가 같은 법정동 결과는 유지한다`() =
+        runSuspendTest {
+            val spot = collectionSpot(
+                id = "myeongdong-1ga",
+                address = "서울특별시 중구 명동길 14 (명동1가)",
+            )
+            repository.keywordSpots = listOf(spot)
+
+            val result = useCase(keyword = "명동")
+
+            assertEquals(listOf(spot), result)
+        }
+
+    @Test
+    fun `동 정보가 없는 도로명 주소 결과는 유지한다`() =
+        runSuspendTest {
+            val spot = collectionSpot(
+                id = "road-address",
+                address = "서울특별시 성동구 독서당로 303-5",
+            )
+            repository.keywordSpots = listOf(spot)
+
+            val result = useCase(keyword = "성동구 금호동")
+
+            assertEquals(listOf("금호동"), repository.keywords)
+            assertEquals(listOf(spot), result)
+        }
+
+    @Test
+    fun `복합 설명에서 명확한 동명이 검색어와 다르면 제외한다`() =
+        runSuspendTest {
+            val spot = collectionSpot(
+                id = "complex-parentheses",
+                address = "충청북도 청주시 흥덕구 월명로 76 (봉명동, 청주 SK VIEW 자이)",
+            )
+            repository.keywordSpots = listOf(spot)
+
+            val result = useCase(keyword = "명동")
+
+            assertEquals(emptyList<CollectionSpot>(), result)
+        }
+
+    private fun runSuspendTest(block: suspend () -> Unit) {
+        kotlinx.coroutines.runBlocking {
+            block()
+        }
+    }
+
+    private fun collectionSpot(
+        id: String,
+        address: String,
+    ): CollectionSpot {
+        return CollectionSpot(
+            id = id,
+            name = "수거 장소 $id",
+            type = CollectionSpotType.STANDARD_BAG_STORE,
+            address = address,
+            detailLocation = null,
+            coordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+        )
+    }
+
+    private class FakeCollectionSpotRepository : CollectionSpotRepository {
+        var keywordSpots: List<CollectionSpot> = emptyList()
+        val keywords = mutableListOf<String>()
+
+        override suspend fun searchByKeyword(
+            keyword: String,
+            types: Set<CollectionSpotType>,
+        ): List<CollectionSpot> {
+            keywords += keyword
+            return keywordSpots
+        }
+
+        override suspend fun searchByLocation(
+            coordinate: Coordinate,
+            radiusMeter: Int,
+            types: Set<CollectionSpotType>,
+        ): List<CollectionSpot> = emptyList()
+
+        override suspend fun geocodeSpot(spot: CollectionSpot): CollectionSpot = spot
+    }
+}

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapSearchViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapSearchViewModelTest.kt
@@ -16,6 +16,121 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class CollectionSpotMapSearchViewModelTest : CollectionSpotMapViewModelTestFixture() {
     @Test
+    fun `성동구 금호동 입력 시 금호동으로 보정해 키워드 검색을 요청한다`() =
+        runTest {
+            val expectedSpots = listOf(sampleSpot("geumho", CollectionSpotType.BATTERY_BIN))
+            val repository = FakeCollectionSpotRepository(
+                keywordSpots = expectedSpots,
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.onSearchKeywordChanged("성동구 금호동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            assertEquals(listOf("금호동"), repository.keywords)
+            assertEquals("성동구 금호동", viewModel.uiState.value.searchKeyword)
+            assertEquals(expectedSpots, viewModel.uiState.value.spots)
+            assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
+        }
+
+    @Test
+    fun `서울 성동구 금호동 입력 시 금호동으로 보정해 키워드 검색을 요청한다`() =
+        runTest {
+            val repository = FakeCollectionSpotRepository()
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.onSearchKeywordChanged("서울 성동구 금호동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            assertEquals(listOf("금호동"), repository.keywords)
+            assertEquals("서울 성동구 금호동", viewModel.uiState.value.searchKeyword)
+        }
+
+    @Test
+    fun `기존 동 단독 검색어는 그대로 키워드 검색을 요청한다`() =
+        runTest {
+            val repository = FakeCollectionSpotRepository()
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.onSearchKeywordChanged("금호동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            assertEquals(listOf("금호동"), repository.keywords)
+        }
+
+    @Test
+    fun `도로명 주소 입력은 동 검색어로 보정하지 않고 원문으로 검색한다`() =
+        runTest {
+            val repository = FakeCollectionSpotRepository()
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.onSearchKeywordChanged("서울 성동구 독서당로 303-5")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            assertEquals(listOf("서울 성동구 독서당로 303-5"), repository.keywords)
+        }
+
+    @Test
+    fun `검색 결과 주소가 입력 동명을 포함하지 않아도 결과를 유지한다`() =
+        runTest {
+            val roadAddressSpot = sampleSpot("road-address", CollectionSpotType.STANDARD_BAG_STORE)
+                .copy(address = "서울특별시 성동구 독서당로 303-5")
+            val repository = FakeCollectionSpotRepository(
+                keywordSpots = listOf(roadAddressSpot),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.onSearchKeywordChanged("성동구 금호동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            assertEquals(listOf("금호동"), repository.keywords)
+            assertEquals(listOf(roadAddressSpot), viewModel.uiState.value.spots)
+    }
+
+    @Test
+    fun `명동 검색 결과에서 봉명동 주소는 제외한다`() =
+        runTest {
+            val myeongDongSpot = sampleSpot("myeongdong", CollectionSpotType.STANDARD_BAG_STORE)
+                .copy(address = "서울특별시 중구 명동길 26 (명동)")
+            val bongMyeongDongSpot = sampleSpot("bongmyeongdong", CollectionSpotType.STANDARD_BAG_STORE)
+                .copy(address = "충청북도 청주시 흥덕구 봉명동 1순환로584번길 59")
+            val repository = FakeCollectionSpotRepository(
+                keywordSpots = listOf(myeongDongSpot, bongMyeongDongSpot),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.onSearchKeywordChanged("명동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            assertEquals(listOf("명동"), repository.keywords)
+            assertEquals(listOf(myeongDongSpot), viewModel.uiState.value.spots)
+        }
+
+    @Test
     fun `지도 중심 검색은 전달된 카메라 중심 좌표로 수거 장소를 검색한다`() =
         runTest {
             val mapCenterCoordinate = Coordinate(latitude = 37.5701, longitude = 127.0012)

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTestFixture.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTestFixture.kt
@@ -19,6 +19,7 @@ import com.team.yeogibeoryeo.domain.spot.usecase.CalculateDistanceMeterUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.ClearRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.GetFreshRecentCurrentLocationSpotsUseCase
+import com.team.yeogibeoryeo.domain.spot.usecase.NormalizeCollectionSpotSearchKeywordUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SaveRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByKeywordUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByLocationUseCase
@@ -72,7 +73,10 @@ internal fun createViewModel(
         FakeCollectionSpotFavoriteSnapshotRepository(),
 ): CollectionSpotMapViewModel {
     return CollectionSpotMapViewModel(
-        searchCollectionSpotsByKeywordUseCase = SearchCollectionSpotsByKeywordUseCase(repository),
+        searchCollectionSpotsByKeywordUseCase = SearchCollectionSpotsByKeywordUseCase(
+            repository = repository,
+            normalizeKeywordUseCase = NormalizeCollectionSpotSearchKeywordUseCase(),
+        ),
         searchCollectionSpotsByLocationUseCase = SearchCollectionSpotsByLocationUseCase(repository),
         filterCollectionSpotsUseCase = FilterCollectionSpotsUseCase(),
         currentLocationProvider = currentLocationProvider,


### PR DESCRIPTION
## 작업 내용

지도 키워드 검색에서 사용자가 입력한 주소/지역 검색어를 `/getSpot` API가 기대하는 동/읍/면 단위 검색어로 안전하게 보정했습니다.

이번 PR에서는 #227 범위에 맞춰 **입력 보정과 명확한 검색 오탐 방어**까지만 처리했습니다.

### 구현한 내용

- `성동구 금호동`, `서울 성동구 금호동`, `서울특별시 성동구 금호동` 입력 시 `금호동`으로 보정
- `중구 명동`, `서울 중구 명동`, `서울특별시 중구 명동` 입력 시 `명동`으로 보정
- `금호동`, `명동`, `금호동3가` 같은 기존 동/읍/면/가 단독 검색 유지
- 도로명 주소 / 지번 상세 주소는 무리하게 동 검색어로 잘못 보정하지 않도록 처리
- `명동` 검색 시 `봉명동`처럼 명확히 다른 동 토큰이 포함된 결과를 제외
- `609(봉명동)`, `65 (봉명동)`, `봉명동 1순환로...` 형태의 오탐 방어
- 도로명 주소만 표시되는 정상 결과는 무조건 제외하지 않도록 기존 정책 유지

## 이번 PR에서 하지 않은 것

아래 항목은 검색 정확도 고도화 범위가 더 커지므로 후속 이슈로 분리합니다.

- 동일 동명 검색 후보 선택 UI
- 자동완성
- 전체 결과 대상 reverse geocoding
- 동일 동명 결과를 지역별로 묶어 보여주는 UX
- 도로명 주소를 동/읍/면으로 변환하는 고도화

## 후속 이슈에서 작업할 내용

후속 이슈에서는 `명동`, `금호동`, `봉명동`처럼 동일하거나 유사한 동명이 여러 지역에 존재하는 경우, 사용자가 원하는 지역을 직접 선택할 수 있는 후보 선택 UX를 추가할 예정입니다.

예상 작업:

- `명동` 검색 시 `서울특별시 중구 명동`, `충청북도 제천시 명동`, `경상남도 창원시 진해구 명동` 등 후보 표시
- 후보 선택 후 선택한 지역 기준으로 지도 검색 진행
- `서울 중구 명동`처럼 지역 범위가 포함된 입력은 후보를 좁혀 바로 검색
- 후보 선택 이후에도 도로명 주소로 표시되는 정상 결과는 과도하게 제외하지 않도록 처리
- reverse geocoding은 전체 결과 기본 후처리가 아니라 필요 시 별도 검토

## 테스트

- `./gradlew.bat :domain:test`
- `./gradlew.bat :domain:test --tests com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByKeywordUseCaseTest --tests com.team.yeogibeoryeo.domain.spot.usecase.NormalizeCollectionSpotSearchKeywordUseCaseTest`
- `./gradlew.bat :presentation:testDebugUnitTest --tests com.team.yeogibeoryeo.presentation.map.CollectionSpotMapSearchViewModelTest`
- `./gradlew.bat :presentation:testDebugUnitTest`
- `./gradlew.bat :presentation:compileDebugKotlin`
- `./gradlew.bat :app:assembleDebug`
- `git diff --check`

## 참고

Related #227

Follow-up: #238