### PR TITLE
[Refactor] 상세 화면 상단 정렬 기준 통일

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -104,29 +104,17 @@ fun YeogiBeoryeoNavHost(
             }
         },
     ) { innerPadding ->
-        val navHostPadding = when {
-            isMapScreen -> {
-                PaddingValues(
-                    start = innerPadding.calculateStartPadding(layoutDirection),
-                    top = 0.dp,
-                    end = innerPadding.calculateEndPadding(layoutDirection),
-                    bottom = if (isBottomBarVisible) {
-                        innerPadding.calculateBottomPadding()
-                    } else {
-                        0.dp
-                    },
-                )
-            }
-            hidesBottomBarOnScroll && !isBottomBarVisible -> {
-                PaddingValues(
-                    start = innerPadding.calculateStartPadding(layoutDirection),
-                    top = innerPadding.calculateTopPadding(),
-                    end = innerPadding.calculateEndPadding(layoutDirection),
-                    bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding(),
-                )
-            }
-            else -> innerPadding
-        }
+        val navHostPadding = PaddingValues(
+            start = innerPadding.calculateStartPadding(layoutDirection),
+            top = 0.dp,
+            end = innerPadding.calculateEndPadding(layoutDirection),
+            bottom = when {
+                isMapScreen && !isBottomBarVisible -> 0.dp
+                hidesBottomBarOnScroll && !isBottomBarVisible ->
+                    WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+                else -> innerPadding.calculateBottomPadding()
+            },
+        )
 
         NavHost(
             navController = navController,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/components/AppTopBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/components/AppTopBar.kt
@@ -1,5 +1,84 @@
 package com.team.yeogibeoryeo.presentation.common.components
 
-/**
- * 여러 화면에서 공통으로 사용할 상단 앱 바 컴포넌트 자리
- */
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.presentation.R
+
+@Composable
+fun AppTopBar(
+    modifier: Modifier = Modifier,
+    navigationIcon: @Composable () -> Unit = {},
+    title: @Composable () -> Unit = {},
+    actions: @Composable RowScope.() -> Unit = {},
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+            .height(AppTopBarHeight)
+            .padding(horizontal = AppTopBarHorizontalPadding),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier.size(AppTopBarButtonSize),
+            contentAlignment = Alignment.Center,
+        ) {
+            navigationIcon()
+        }
+
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = AppTopBarTitleStartPadding),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            title()
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            content = actions,
+        )
+    }
+}
+
+@Composable
+fun AppBackButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    IconButton(
+        onClick = onClick,
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = stringResource(R.string.back_action),
+            tint = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+private val AppTopBarHeight = 64.dp
+private val AppTopBarHorizontalPadding = 12.dp
+private val AppTopBarButtonSize = 48.dp
+private val AppTopBarTitleStartPadding = 8.dp

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/favorites/FavoritesRoute.kt
@@ -1,10 +1,11 @@
 package com.team.yeogibeoryeo.presentation.favorites
 
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.compose.ui.Modifier
 import com.team.yeogibeoryeo.presentation.favorites.model.FavoriteCollectionSpotMapMoveRequest
 
 @Composable
@@ -25,6 +26,6 @@ fun FavoritesRoute(
         onRegionalGuideClick = onRegionalGuideClick,
         onCollectionSpotFavoriteRemoveClick = viewModel::removeCollectionSpotFavorite,
         onRegionalGuideFavoriteRemoveClick = viewModel::removeRegionalGuideFavorite,
-        modifier = modifier,
+        modifier = modifier.statusBarsPadding(),
     )
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -88,7 +89,7 @@ fun RegionalGuideRoute(
         onCandidateClick = viewModel::onRegionCandidateSelected,
         onGuideCandidateClick = viewModel::onRegionalGuideCandidateSelected,
         onFavoriteClick = viewModel::onFavoriteClick,
-        modifier = modifier,
+        modifier = modifier.statusBarsPadding(),
     )
 }
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemGuideDetailScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -14,15 +15,19 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.common.components.AppBackButton
+import com.team.yeogibeoryeo.presentation.common.components.AppTopBar
 import com.team.yeogibeoryeo.presentation.common.effects.BottomBarVisibilityOnScrollEffect
 import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
 import com.team.yeogibeoryeo.presentation.search.components.DisposalGuideMetadataChips
@@ -58,7 +63,147 @@ fun ItemGuideDetailScreen(
         onBottomBarVisibilityChanged = onBottomBarVisibilityChanged,
     )
 
-    val backActionDescription = stringResource(R.string.back_action)
+    val matchedRepresentativeCategory = RepresentativeGuideCategory.fromGuideName(guide.name)
+    val isRepresentativeGuide = matchedRepresentativeCategory != null
+    val representativeCategory =
+        matchedRepresentativeCategory
+            ?: RepresentativeGuideCategory.fromDisposalCategory(guide.category)
+
+    Scaffold(
+        modifier = modifier,
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
+        topBar = {
+            ItemGuideDetailTopBar(
+                isFavorite = isFavorite,
+                onBackClick = onBackClick,
+                onFavoriteClick = onFavoriteClick,
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(innerPadding)
+                .verticalScroll(scrollState)
+                .padding(
+                    start = spacing.md,
+                    top = 0.dp,
+                    end = spacing.md,
+                    bottom = spacing.xl,
+                ),
+            verticalArrangement = Arrangement.spacedBy(spacing.md),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing.md),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(size.detailIconContainer)
+                        .background(
+                            color = representativeCategory.containerColor(),
+                            shape = MaterialTheme.shapes.extraLarge
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        painter = painterResource(id = representativeCategory.iconResId),
+                        // 옆의 품목명과 metadata chip이 의미를 제공하므로 아이콘은 중복 읽기를 피합니다.
+                        contentDescription = null,
+                        modifier = Modifier.size(size.iconProminent),
+                        tint = representativeCategory.iconTint()
+                    )
+                }
+
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(spacing.sm),
+                ) {
+                    KoreanLineBreakText(
+                        text = guide.name,
+                        style = textStyles.title.copy(
+                            fontWeight = FontWeight.ExtraBold,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    )
+
+                    DisposalGuideMetadataChips(
+                        guide = guide,
+                        showCategoryChip = !isRepresentativeGuide,
+                    )
+                }
+            }
+
+            if (actions.isNotEmpty()) {
+                ItemGuideActionButtons(
+                    actions = actions,
+                    onCollectionSpotTypeClick = onCollectionSpotTypeClick,
+                    onOfficialGuideClick = onOfficialGuideClick,
+                )
+            }
+
+            if (guide.detailSections.isNotEmpty()) {
+                guide.detailSections.forEach { section ->
+                    SectionCard(
+                        title = section.title,
+                        lines = section.lines,
+                        rows = section.rows,
+                    )
+                }
+            } else {
+                if (guide.steps.isNotEmpty()) {
+                    SectionCard(
+                        title = stringResource(R.string.disposal_steps_title),
+                        lines = guide.steps,
+                        numbered = true,
+                    )
+                }
+
+                if (guide.cautions.isNotEmpty()) {
+                    SectionCard(
+                        title = stringResource(R.string.cautions_title),
+                        lines = guide.cautions,
+                    )
+                }
+
+                if (guide.subGuides.isNotEmpty()) {
+                    SubGuideSection(
+                        title = stringResource(R.string.sub_guides_title),
+                        subGuides = guide.subGuides,
+                    )
+                }
+
+                if (guide.features.isNotEmpty()) {
+                    SectionCard(
+                        title = stringResource(R.string.features_title),
+                        lines = guide.features,
+                    )
+                }
+
+                guide.tip?.let {
+                    SectionCard(
+                        title = stringResource(R.string.tip_title),
+                        lines = listOf(it),
+                    )
+                }
+            }
+
+            SectionCard(
+                title = stringResource(R.string.local_disposal_notice_title),
+                lines = listOf(stringResource(R.string.local_disposal_notice)),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ItemGuideDetailTopBar(
+    isFavorite: Boolean,
+    onBackClick: () -> Unit,
+    onFavoriteClick: () -> Unit,
+) {
     val favoriteActionDescription =
         stringResource(
             if (isFavorite) {
@@ -67,38 +212,12 @@ fun ItemGuideDetailScreen(
                 R.string.favorite_add_action
             },
         )
-    val matchedRepresentativeCategory = RepresentativeGuideCategory.fromGuideName(guide.name)
-    val isRepresentativeGuide = matchedRepresentativeCategory != null
-    val representativeCategory =
-        matchedRepresentativeCategory
-            ?: RepresentativeGuideCategory.fromDisposalCategory(guide.category)
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .verticalScroll(scrollState)
-            .padding(
-                start = spacing.xl,
-                top = spacing.md,
-                end = spacing.xl,
-                bottom = spacing.xl,
-            ),
-        verticalArrangement = Arrangement.spacedBy(spacing.md),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            IconButton(onClick = onBackClick) {
-                Icon(
-                    painter = painterResource(id = CommonR.drawable.ic_action_back),
-                    contentDescription = backActionDescription,
-                    tint = MaterialTheme.colorScheme.onSurface,
-                )
-            }
-
+    AppTopBar(
+        navigationIcon = {
+            AppBackButton(onClick = onBackClick)
+        },
+        actions = {
             IconButton(onClick = onFavoriteClick) {
                 Icon(
                     painter = painterResource(
@@ -116,109 +235,8 @@ fun ItemGuideDetailScreen(
                     },
                 )
             }
-        }
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(spacing.md),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(size.detailIconContainer)
-                    .background(
-                        color = representativeCategory.containerColor(),
-                        shape = MaterialTheme.shapes.extraLarge
-                    ),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    painter = painterResource(id = representativeCategory.iconResId),
-                    // 옆의 품목명과 metadata chip이 의미를 제공하므로 아이콘은 중복 읽기를 피합니다.
-                    contentDescription = null,
-                    modifier = Modifier.size(size.iconProminent),
-                    tint = representativeCategory.iconTint()
-                )
-            }
-
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(spacing.sm),
-            ) {
-                KoreanLineBreakText(
-                    text = guide.name,
-                    style = textStyles.title.copy(
-                        fontWeight = FontWeight.ExtraBold,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                )
-
-                DisposalGuideMetadataChips(
-                    guide = guide,
-                    showCategoryChip = !isRepresentativeGuide,
-                )
-            }
-        }
-
-        if (actions.isNotEmpty()) {
-            ItemGuideActionButtons(
-                actions = actions,
-                onCollectionSpotTypeClick = onCollectionSpotTypeClick,
-                onOfficialGuideClick = onOfficialGuideClick,
-            )
-        }
-
-        if (guide.detailSections.isNotEmpty()) {
-            guide.detailSections.forEach { section ->
-                SectionCard(
-                    title = section.title,
-                    lines = section.lines,
-                    rows = section.rows,
-                )
-            }
-        } else {
-            if (guide.steps.isNotEmpty()) {
-                SectionCard(
-                    title = stringResource(R.string.disposal_steps_title),
-                    lines = guide.steps,
-                    numbered = true,
-                )
-            }
-
-            if (guide.cautions.isNotEmpty()) {
-                SectionCard(
-                    title = stringResource(R.string.cautions_title),
-                    lines = guide.cautions,
-                )
-            }
-
-            if (guide.subGuides.isNotEmpty()) {
-                SubGuideSection(
-                    title = stringResource(R.string.sub_guides_title),
-                    subGuides = guide.subGuides,
-                )
-            }
-
-            if (guide.features.isNotEmpty()) {
-                SectionCard(
-                    title = stringResource(R.string.features_title),
-                    lines = guide.features,
-                )
-            }
-
-            guide.tip?.let {
-                SectionCard(
-                    title = stringResource(R.string.tip_title),
-                    lines = listOf(it),
-                )
-            }
-        }
-
-        SectionCard(
-            title = stringResource(R.string.local_disposal_notice_title),
-            lines = listOf(stringResource(R.string.local_disposal_notice)),
-        )
-    }
+        },
+    )
 }
 
 @Composable

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
@@ -39,12 +40,13 @@ import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCatego
 
 @Composable
 fun ItemSearchRoute(
-    initialQuery: String? = null,
     onGuideSelected: (DisposalItemGuide) -> Unit,
     onUsefulGuideClick: (ItemUsefulGuideContent) -> Unit,
     onRegionalGuideSummaryClick: (String) -> Unit,
     onQuickCategorySettingsClick: (Int) -> Unit,
     onSettingsClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    initialQuery: String? = null,
     viewModel: ItemSearchViewModel = hiltViewModel(),
     regionalGuideSummaryViewModel: HomeRegionalGuideSummaryViewModel = hiltViewModel(),
 ) {
@@ -104,6 +106,7 @@ fun ItemSearchRoute(
         onSettingsClick = onSettingsClick,
         searchResultListState = searchResultListState,
         categoryListState = categoryListState,
+        modifier = modifier.statusBarsPadding(),
     )
 }
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemUsefulGuideRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemUsefulGuideRoute.kt
@@ -11,18 +11,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ErrorOutline
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -33,6 +28,8 @@ import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.common.R as CommonR
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.common.components.AppBackButton
+import com.team.yeogibeoryeo.presentation.common.components.AppTopBar
 import com.team.yeogibeoryeo.presentation.common.components.MessageSnackbar
 import com.team.yeogibeoryeo.presentation.common.effects.BottomBarVisibilityOnScrollEffect
 import com.team.yeogibeoryeo.presentation.search.components.ItemGuideActionButton
@@ -41,7 +38,6 @@ import com.team.yeogibeoryeo.presentation.search.model.ItemUsefulGuideType
 import com.team.yeogibeoryeo.presentation.search.model.toUsefulGuideContent
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ItemUsefulGuideRoute(
     guideType: ItemUsefulGuideType,
@@ -118,7 +114,10 @@ fun ItemUsefulGuideRoute(
             }
         },
         topBar = {
-            TopAppBar(
+            AppTopBar(
+                navigationIcon = {
+                    AppBackButton(onClick = onBackClick)
+                },
                 title = {
                     Text(
                         text = stringResource(content.titleResId),
@@ -126,17 +125,6 @@ fun ItemUsefulGuideRoute(
                         fontWeight = FontWeight.Bold,
                     )
                 },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.back_action),
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background,
-                ),
             )
         },
     ) { innerPadding ->

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/QuickCategorySettingsRoute.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/QuickCategorySettingsRoute.kt
@@ -18,16 +18,12 @@ import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -43,8 +39,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.team.yeogibeoryeo.common.R as CommonR
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.common.components.AppBackButton
+import com.team.yeogibeoryeo.presentation.common.components.AppTopBar
 import com.team.yeogibeoryeo.presentation.search.components.containerColor
 import com.team.yeogibeoryeo.presentation.search.components.iconResId
 import com.team.yeogibeoryeo.presentation.search.components.iconTint
@@ -77,7 +74,6 @@ fun QuickCategorySettingsRoute(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun QuickCategorySettingsScreen(
     selectedCategories: Set<RepresentativeGuideCategory>,
@@ -99,7 +95,10 @@ private fun QuickCategorySettingsScreen(
         modifier = modifier,
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            TopAppBar(
+            AppTopBar(
+                navigationIcon = {
+                    AppBackButton(onClick = onBackClick)
+                },
                 title = {
                     Text(
                         text = stringResource(R.string.quick_category_settings_title),
@@ -107,17 +106,6 @@ private fun QuickCategorySettingsScreen(
                         fontWeight = FontWeight.Bold,
                     )
                 },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            painter = painterResource(id = CommonR.drawable.ic_action_back),
-                            contentDescription = stringResource(R.string.back_action),
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background,
-                ),
             )
         },
     ) { innerPadding ->

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/SettingsDetailScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/SettingsDetailScreen.kt
@@ -46,8 +46,10 @@ internal fun SettingsDetailScreen(
                 .background(MaterialTheme.colorScheme.background),
             state = listState,
             contentPadding = PaddingValues(
-                horizontal = SettingsLayoutDefaults.detailHorizontalPadding,
-                vertical = SettingsLayoutDefaults.detailVerticalPadding,
+                start = SettingsLayoutDefaults.detailHorizontalPadding,
+                top = SettingsLayoutDefaults.detailTopPadding,
+                end = SettingsLayoutDefaults.detailHorizontalPadding,
+                bottom = SettingsLayoutDefaults.detailVerticalPadding,
             ),
             verticalArrangement = Arrangement.spacedBy(SettingsLayoutDefaults.detailItemSpacing),
         ) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/SettingsLayoutDefaults.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/SettingsLayoutDefaults.kt
@@ -5,9 +5,11 @@ import androidx.compose.ui.unit.dp
 
 internal object SettingsLayoutDefaults {
     val listHorizontalPadding: Dp = 24.dp
+    val listTopPadding: Dp = 0.dp
     val listVerticalPadding: Dp = 16.dp
     val listItemVerticalPadding: Dp = 24.dp
     val detailHorizontalPadding: Dp = 24.dp
+    val detailTopPadding: Dp = 0.dp
     val detailVerticalPadding: Dp = 24.dp
     val detailItemSpacing: Dp = 24.dp
     val detailContentSpacing: Dp = 20.dp

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/SettingsScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/SettingsScreen.kt
@@ -31,8 +31,10 @@ internal fun SettingsScreen(
                 .padding(contentPadding)
                 .background(MaterialTheme.colorScheme.background),
             contentPadding = PaddingValues(
-                horizontal = SettingsLayoutDefaults.listHorizontalPadding,
-                vertical = SettingsLayoutDefaults.listVerticalPadding,
+                start = SettingsLayoutDefaults.listHorizontalPadding,
+                top = SettingsLayoutDefaults.listTopPadding,
+                end = SettingsLayoutDefaults.listHorizontalPadding,
+                bottom = SettingsLayoutDefaults.listVerticalPadding,
             ),
         ) {
             items(SettingsMenuItems) { item ->

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/components/SettingsScaffold.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/settings/components/SettingsScaffold.kt
@@ -3,24 +3,16 @@ package com.team.yeogibeoryeo.presentation.settings.components
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.common.components.AppBackButton
+import com.team.yeogibeoryeo.presentation.common.components.AppTopBar
 import com.team.yeogibeoryeo.presentation.common.effects.BottomBarVisibilityOnScrollEffect
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun SettingsScaffold(
     title: String,
@@ -41,7 +33,10 @@ internal fun SettingsScaffold(
         modifier = modifier,
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
-            TopAppBar(
+            AppTopBar(
+                navigationIcon = {
+                    AppBackButton(onClick = onBackClick)
+                },
                 title = {
                     Text(
                         text = title,
@@ -49,20 +44,6 @@ internal fun SettingsScaffold(
                         fontWeight = FontWeight.Bold,
                     )
                 },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.back_action),
-                        )
-                    }
-                },
-                windowInsets = WindowInsets(0, 0, 0, 0),
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background,
-                    titleContentColor = MaterialTheme.colorScheme.onSurface,
-                    navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
-                ),
             )
         },
         content = content,


### PR DESCRIPTION
## 작업 내용

- 공통 `AppTopBar`를 앱 기준선에 맞는 slot 기반 컴포넌트로 정리했습니다.
- 품목 상세, 유용한 가이드, 빠른 품목 설정, 설정/설정 상세 화면의 뒤로가기 영역을 공통 topbar로 맞췄습니다.
- `NavHost`의 top inset 처리를 고정하고, topbar 없는 탭 화면은 각 화면에서 status bar padding을 처리하도록 정리했습니다.
- 설정 목록/상세와 품목 상세의 topbar 아래 여백을 조정했습니다.

## 변경 이유

화면마다 상단 영역 구현 방식이 달라 뒤로가기 아이콘의 위치와 본문 시작 위치가 다르게 보였습니다. 공통 topbar가 상태바, 터치 영역, 아이콘 기준선을 한 곳에서 처리하도록 바꿔 화면 간 이동 시 상단 정렬이 자연스럽게 보이도록 했습니다.

## 확인 사항

- `AppTopBar`는 `navigationIcon`, `title`, `actions` slot을 받는 stateless 컴포넌트입니다.
- 뒤로가기, 즐겨찾기 상태와 클릭 처리는 각 호출부에서 유지합니다.
- bottom navigation hide/show 정책은 바꾸지 않았습니다.


## 스크린샷

| 화면 | Before | After |
| --- | --- | --- |
| 품목 상세 | <img src="https://github.com/user-attachments/assets/4791423c-f39c-4dca-b8e7-009a45f3f578" width="260" /> | <img src="https://github.com/user-attachments/assets/016a600a-9bc5-4a33-a59f-c7bb2f45b8ac" width="260" /> |
| 유용한 가이드 | <img src="https://github.com/user-attachments/assets/b59c40bd-d4af-47cc-8f4d-88ab4398e469" width="260" /> | <img src="https://github.com/user-attachments/assets/8ffff9df-f0bd-4c53-909a-0964170a91e2" width="260" /> |
| 빠른 품목 설정 | <img src="https://github.com/user-attachments/assets/81bf7367-af25-4448-bfbf-2691252dde0b" width="260" /> | <img src="https://github.com/user-attachments/assets/5b47f813-0a22-4656-bf33-0dd5a634ce76" width="260" /> |
| 설정 | <img src="https://github.com/user-attachments/assets/9bf871b6-bd95-4b7d-9787-ff732691fece" width="260" /> | <img src="https://github.com/user-attachments/assets/a731a600-c9ed-43fc-96ff-d5aecae54e02" width="260" /> |
| 설정 상세 - 출처 및 이용조건 | <img src="https://github.com/user-attachments/assets/ee70399b-f330-4372-95da-7dad623ccd21" width="260" /> | <img src="https://github.com/user-attachments/assets/5b577e12-58e2-4c99-9f8d-f9a7edc61ee1" width="260" /> |

## 테스트

- `./gradlew.bat :presentation:compileDebugKotlin :app:compileDebugKotlin`
- `git diff --check`
- 실기기 수동 QA: 품목 상세, 설정, 설정 상세, 출처 및 이용조건 화면의 상단 정렬과 뒤로가기 전환 확인

## 관련 이슈

Related #237
