### PR TITLE
fix: 지역 가이드 selector fallback과 후보 정렬 보완

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapper.kt
@@ -46,7 +46,7 @@ internal object RegionOptionsMapper {
             .map { region -> region.eupmyeondongName }
             .filter { eupmyeondong -> eupmyeondong.isNotBlank() }
             .distinct()
-            .sorted()
+            .sortedWith(REGION_OPTION_NAME_COMPARATOR)
             .toList()
     }
 
@@ -246,6 +246,71 @@ internal object RegionOptionsMapper {
         { region -> region.sigungu.orEmpty() },
         { region -> region.eupmyeondong.orEmpty() }
     )
+
+    private val REGION_OPTION_NAME_COMPARATOR = Comparator<String> { first, second ->
+        compareNaturalRegionName(first, second)
+    }
+
+    private fun compareNaturalRegionName(
+        first: String,
+        second: String
+    ): Int {
+        var firstIndex = 0
+        var secondIndex = 0
+
+        while (firstIndex < first.length && secondIndex < second.length) {
+            val firstChar = first[firstIndex]
+            val secondChar = second[secondIndex]
+
+            if (firstChar.isDigit() && secondChar.isDigit()) {
+                val firstNumberEnd = first.findNumberEndIndex(firstIndex)
+                val secondNumberEnd = second.findNumberEndIndex(secondIndex)
+                val numberComparison = compareNaturalNumberText(
+                    first.substring(firstIndex, firstNumberEnd),
+                    second.substring(secondIndex, secondNumberEnd)
+                )
+
+                if (numberComparison != 0) return numberComparison
+
+                firstIndex = firstNumberEnd
+                secondIndex = secondNumberEnd
+            } else {
+                val charComparison = firstChar.compareTo(secondChar)
+                if (charComparison != 0) return charComparison
+
+                firstIndex += 1
+                secondIndex += 1
+            }
+        }
+
+        return first.length.compareTo(second.length)
+    }
+
+    private fun String.findNumberEndIndex(
+        startIndex: Int
+    ): Int {
+        var endIndex = startIndex
+
+        while (endIndex < length && this[endIndex].isDigit()) {
+            endIndex += 1
+        }
+
+        return endIndex
+    }
+
+    private fun compareNaturalNumberText(
+        first: String,
+        second: String
+    ): Int {
+        val normalizedFirst = first.trimStart('0').ifEmpty { "0" }
+        val normalizedSecond = second.trimStart('0').ifEmpty { "0" }
+
+        return normalizedFirst.length.compareTo(normalizedSecond.length)
+            .takeIf { comparison -> comparison != 0 }
+            ?: normalizedFirst.compareTo(normalizedSecond)
+                .takeIf { comparison -> comparison != 0 }
+            ?: first.length.compareTo(second.length)
+    }
 
     private const val SEJONG_SIDO = "세종특별자치시"
     private const val NO_SIGUNGU_NAME = "없음"

--- a/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapperTest.kt
@@ -279,6 +279,73 @@ class RegionOptionsMapperTest {
     }
 
     @Test
+    fun `eupmyeondong options are sorted by korean name and natural number order`() {
+        val options = RegionOptionsMapper.getEupmyeondongOptions(
+            administrativeRegions = listOf(
+                administrativeRegion(
+                    sidoName = "경상북도",
+                    sigunguName = "성주군",
+                    eupmyeondongName = "월곡10리"
+                ),
+                administrativeRegion(
+                    sidoName = "경상북도",
+                    sigunguName = "성주군",
+                    eupmyeondongName = "고산리"
+                ),
+                administrativeRegion(
+                    sidoName = "경상북도",
+                    sigunguName = "성주군",
+                    eupmyeondongName = "월곡2리"
+                ),
+                administrativeRegion(
+                    sidoName = "경상북도",
+                    sigunguName = "성주군",
+                    eupmyeondongName = "월곡1리"
+                ),
+                administrativeRegion(
+                    sidoName = "경상북도",
+                    sigunguName = "성주군",
+                    eupmyeondongName = "문덕2리"
+                )
+            ),
+            sido = "경상북도",
+            sigungu = "성주군"
+        )
+
+        assertEquals(
+            listOf("고산리", "문덕2리", "월곡1리", "월곡2리", "월곡10리"),
+            options
+        )
+    }
+
+    @Test
+    fun `eupmyeondong options sort numeric dong names by natural number order`() {
+        val options = RegionOptionsMapper.getEupmyeondongOptions(
+            administrativeRegions = listOf(
+                administrativeRegion(
+                    sidoName = "서울특별시",
+                    sigunguName = "중구",
+                    eupmyeondongName = "10동"
+                ),
+                administrativeRegion(
+                    sidoName = "서울특별시",
+                    sigunguName = "중구",
+                    eupmyeondongName = "2동"
+                ),
+                administrativeRegion(
+                    sidoName = "서울특별시",
+                    sigunguName = "중구",
+                    eupmyeondongName = "1동"
+                )
+            ),
+            sido = "서울특별시",
+            sigungu = "중구"
+        )
+
+        assertEquals(listOf("1동", "2동", "10동"), options)
+    }
+
+    @Test
     fun `sigungu keyword search maps official city keyword to info key without city suffix`() {
         val regions = RegionOptionsMapper.findSigunguRegions(
             administrativeRegions = listOf(

--- a/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapperTest.kt
@@ -279,7 +279,7 @@ class RegionOptionsMapperTest {
     }
 
     @Test
-    fun `eupmyeondong options are sorted by korean name and natural number order`() {
+    fun `읍면동 옵션은 가나다순과 숫자 자연 순서로 정렬한다`() {
         val options = RegionOptionsMapper.getEupmyeondongOptions(
             administrativeRegions = listOf(
                 administrativeRegion(
@@ -319,7 +319,7 @@ class RegionOptionsMapperTest {
     }
 
     @Test
-    fun `eupmyeondong options sort numeric dong names by natural number order`() {
+    fun `숫자로 시작하는 동 이름도 자연 순서로 정렬한다`() {
         val options = RegionOptionsMapper.getEupmyeondongOptions(
             administrativeRegions = listOf(
                 administrativeRegion(

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
@@ -104,6 +104,9 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
             return candidates
                 .selectOverallCandidates(sigunguQuery)
                 .toSingleSuccessOrCandidates(requestedRegion)
+                ?: candidates
+                    .selectUnmatchedSelectorFallbackCandidates()
+                    .toCandidateListOrNull(requestedRegion)
         }
 
         return null
@@ -167,12 +170,30 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
         }
     }
 
+    private fun List<RegionalDisposalGuide>.selectUnmatchedSelectorFallbackCandidates(): List<RegionalDisposalGuide> {
+        if (size <= 1) return emptyList()
+
+        return takeIf { candidates ->
+            candidates.all { guide -> !guide.hasExplicitEupmyeondongTarget() }
+        }.orEmpty()
+    }
+
     private fun List<RegionalDisposalGuide>.toCandidateResultOrNotFound(
         displayRegion: Region
     ): RegionalGuideLookupResult {
         if (!displayRegion.eupmyeondong.isNullOrBlank() || size <= 1) {
             return RegionalGuideLookupResult.CandidateNotFound
         }
+
+        return RegionalGuideLookupResult.Candidates(
+            guides = map { guide -> guide.withDisplayRegion(displayRegion) }
+        )
+    }
+
+    private fun List<RegionalDisposalGuide>.toCandidateListOrNull(
+        displayRegion: Region
+    ): RegionalGuideLookupResult.Candidates? {
+        if (isEmpty()) return null
 
         return RegionalGuideLookupResult.Candidates(
             guides = map { guide -> guide.withDisplayRegion(displayRegion) }
@@ -397,6 +418,25 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
             .split(TARGET_REGION_GROUP_DELIMITER)
             .any { token ->
                 ADMIN_DONG_RANGE_REGEX.matches(token) ||
+                    ADMIN_DONG_GROUP_REGEX.matches(token)
+            }
+    }
+
+    private fun RegionalDisposalGuide.hasExplicitEupmyeondongTarget(): Boolean =
+        managementZoneName.hasExplicitEupmyeondongExpression() ||
+            targetRegionName.hasExplicitEupmyeondongExpression()
+
+    private fun String?.hasExplicitEupmyeondongExpression(): Boolean {
+        val value = normalizeRegionName()
+            ?.replace(WHITESPACE_REGEX, "")
+            ?.replace(ADMIN_DONG_NUMBER_MARKER_REGEX, "")
+            ?: return false
+
+        return value
+            .split(TARGET_REGION_GROUP_DELIMITER)
+            .any { token ->
+                token.hasAdministrativeSuffix() ||
+                    ADMIN_DONG_RANGE_REGEX.matches(token) ||
                     ADMIN_DONG_GROUP_REGEX.matches(token)
             }
     }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
@@ -171,11 +171,9 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
     }
 
     private fun List<RegionalDisposalGuide>.selectUnmatchedSelectorFallbackCandidates(): List<RegionalDisposalGuide> {
-        if (size <= 1) return emptyList()
+        val broadCandidates = filter { guide -> !guide.hasExplicitEupmyeondongTarget() }
 
-        return takeIf { candidates ->
-            candidates.all { guide -> !guide.hasExplicitEupmyeondongTarget() }
-        }.orEmpty()
+        return broadCandidates.takeIf { candidates -> candidates.size > 1 }.orEmpty()
     }
 
     private fun List<RegionalDisposalGuide>.toCandidateResultOrNotFound(

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
@@ -460,7 +460,7 @@ class SelectRegionalGuideCandidateIdentityUseCaseTest {
                     targetRegionName = "부곡1,4동"
                 )
             ),
-            query = regionalGuideQuery(
+            query = regionalGuideQurkryery(
                 displayRegion = Region(
                     sido = "부산광역시",
                     sigungu = "금정구",
@@ -923,6 +923,73 @@ class SelectRegionalGuideCandidateIdentityUseCaseTest {
         assertEquals(2, candidates.size)
         assertEquals("관리구역A", candidates[0].managementZoneName)
         assertEquals("온천1동", candidates[1].managementZoneName)
+    }
+
+    @Test
+    fun `직접 매칭이 실패하고 같은 시군구의 유형 후보만 여러 개 있으면 후보 목록을 반환한다`() {
+        val result = useCase(
+            candidates = listOf(
+                regionalDisposalGuide(
+                    sido = "강원특별자치도",
+                    sigungu = "강릉시",
+                    managementZoneName = "문전수거 지역",
+                    targetRegionName = "문전수거 지역",
+                    disposalPlaceType = "문전수거"
+                ),
+                regionalDisposalGuide(
+                    sido = "강원특별자치도",
+                    sigungu = "강릉시",
+                    managementZoneName = "거점수거 지역",
+                    targetRegionName = "거점수거 지역",
+                    disposalPlaceType = "거점수거"
+                )
+            ),
+            query = regionalGuideQuery(
+                displayRegion = Region(
+                    sido = "강원특별자치도",
+                    sigungu = "강릉시",
+                    eupmyeondong = "사천면"
+                ),
+                sigunguQuery = "강릉시"
+            )
+        )
+
+        val candidates = (result as RegionalGuideLookupResult.Candidates).guides
+
+        assertEquals(2, candidates.size)
+        assertEquals("사천면", candidates[0].region.eupmyeondong)
+        assertEquals("문전수거", candidates[0].disposalPlaceType)
+        assertEquals("거점수거", candidates[1].disposalPlaceType)
+    }
+
+    @Test
+    fun `직접 매칭이 실패해도 명시적인 다른 읍면동 후보는 같은 시군구 fallback 후보로 노출하지 않는다`() {
+        val result = useCase(
+            candidates = listOf(
+                regionalDisposalGuide(
+                    sido = "강원특별자치도",
+                    sigungu = "강릉시",
+                    managementZoneName = "교1동",
+                    targetRegionName = "교1동"
+                ),
+                regionalDisposalGuide(
+                    sido = "강원특별자치도",
+                    sigungu = "강릉시",
+                    managementZoneName = "홍제동",
+                    targetRegionName = "홍제동"
+                )
+            ),
+            query = regionalGuideQuery(
+                displayRegion = Region(
+                    sido = "강원특별자치도",
+                    sigungu = "강릉시",
+                    eupmyeondong = "사천면"
+                ),
+                sigunguQuery = "강릉시"
+            )
+        )
+
+        assertEquals(RegionalGuideLookupResult.CandidateNotFound, result)
     }
 }
 

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
@@ -460,7 +460,7 @@ class SelectRegionalGuideCandidateIdentityUseCaseTest {
                     targetRegionName = "부곡1,4동"
                 )
             ),
-            query = regionalGuideQurkryery(
+            query = regionalGuideQuery(
                 displayRegion = Region(
                     sido = "부산광역시",
                     sigungu = "금정구",
@@ -960,6 +960,79 @@ class SelectRegionalGuideCandidateIdentityUseCaseTest {
         assertEquals("사천면", candidates[0].region.eupmyeondong)
         assertEquals("문전수거", candidates[0].disposalPlaceType)
         assertEquals("거점수거", candidates[1].disposalPlaceType)
+    }
+
+    @Test
+    fun `직접 매칭 실패 후 같은 시군구 후보와 다른 읍면동 후보가 섞이면 시군구 후보만 반환한다`() {
+        val result = useCase(
+            candidates = listOf(
+                regionalDisposalGuide(
+                    sido = "강원특별자치도",
+                    sigungu = "강릉시",
+                    managementZoneName = "문전수거 지역",
+                    targetRegionName = "문전수거 지역",
+                    disposalPlaceType = "문전수거"
+                ),
+                regionalDisposalGuide(
+                    sido = "강원특별자치도",
+                    sigungu = "강릉시",
+                    managementZoneName = "거점수거 지역",
+                    targetRegionName = "거점수거 지역",
+                    disposalPlaceType = "거점수거"
+                ),
+                regionalDisposalGuide(
+                    sido = "강원특별자치도",
+                    sigungu = "강릉시",
+                    managementZoneName = "교1동",
+                    targetRegionName = "교1동"
+                )
+            ),
+            query = regionalGuideQuery(
+                displayRegion = Region(
+                    sido = "강원특별자치도",
+                    sigungu = "강릉시",
+                    eupmyeondong = "사천면"
+                ),
+                sigunguQuery = "강릉시"
+            )
+        )
+
+        val candidates = (result as RegionalGuideLookupResult.Candidates).guides
+
+        assertEquals(2, candidates.size)
+        assertEquals(listOf("문전수거", "거점수거"), candidates.map { guide -> guide.disposalPlaceType })
+        assertEquals(listOf("문전수거 지역", "거점수거 지역"), candidates.map { guide -> guide.managementZoneName })
+    }
+
+    @Test
+    fun `직접 매칭 실패 후 같은 시군구 후보가 하나만 남으면 자동 선택하지 않고 실패 흐름을 유지한다`() {
+        val result = useCase(
+            candidates = listOf(
+                regionalDisposalGuide(
+                    sido = "강원특별자치도",
+                    sigungu = "강릉시",
+                    managementZoneName = "문전수거 지역",
+                    targetRegionName = "문전수거 지역",
+                    disposalPlaceType = "문전수거"
+                ),
+                regionalDisposalGuide(
+                    sido = "강원특별자치도",
+                    sigungu = "강릉시",
+                    managementZoneName = "교1동",
+                    targetRegionName = "교1동"
+                )
+            ),
+            query = regionalGuideQuery(
+                displayRegion = Region(
+                    sido = "강원특별자치도",
+                    sigungu = "강릉시",
+                    eupmyeondong = "사천면"
+                ),
+                sigunguQuery = "강릉시"
+            )
+        )
+
+        assertEquals(RegionalGuideLookupResult.CandidateNotFound, result)
     }
 
     @Test

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
@@ -84,8 +84,7 @@ internal fun List<RegionalGuideCandidateUiModel>.withDuplicateDisplayDisambiguat
         .filterValues { candidates -> candidates.size > 1 }
         .mapValues { (_, candidates) ->
             candidates
-                .map { candidate -> candidate.candidateDisambiguationText() }
-                .filterNotNull()
+                .mapNotNull { candidate -> candidate.candidateDisambiguationText() }
                 .distinct()
         }
         .filterValues { disambiguationTexts -> disambiguationTexts.size > 1 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
@@ -22,6 +22,16 @@ data class RegionalGuideCandidateUiModel(
             }
         }.joinToString(CANDIDATE_LABEL_SEPARATOR)
 
+    internal val orderedManagementZoneSortText: String? =
+        primaryDisplayParts()
+            .takeIf { parts -> parts.size >= 2 }
+            ?.let { parts ->
+                parts[0].toOrderedManagementZoneSortText()
+                    ?.let { managementZoneSortText ->
+                        listOf(managementZoneSortText, parts[1]).joinToString(CANDIDATE_LABEL_SEPARATOR)
+                    }
+            }
+
     private fun primaryDisplayParts(): List<String> =
         listOfNotNull(
             guide.managementZoneName.takeIfRegionalGuideDisplayValue(),
@@ -93,12 +103,87 @@ internal fun List<RegionalGuideCandidateUiModel>.withDuplicateDisplayDisambiguat
 
 internal val regionalGuideCandidateDisplayComparator: Comparator<RegionalGuideCandidateUiModel> =
     Comparator { left, right ->
-        compareNaturalText(left.sortText, right.sortText)
+        val leftOrderedManagementZoneSortText = left.orderedManagementZoneSortText
+        val rightOrderedManagementZoneSortText = right.orderedManagementZoneSortText
+        val primaryComparison = if (
+            leftOrderedManagementZoneSortText != null &&
+            rightOrderedManagementZoneSortText != null
+        ) {
+            compareNaturalText(leftOrderedManagementZoneSortText, rightOrderedManagementZoneSortText)
+        } else {
+            compareNaturalText(left.sortText, right.sortText)
+        }
+
+        primaryComparison
             .takeIf { comparison -> comparison != 0 }
             ?: compareNaturalText(left.displayText, right.displayText)
     }
 
 private val naturalSortTokenRegex = Regex("\\d+|\\D+")
+private val leadingNumberRegex = Regex("^제?\\s*(\\d+)")
+private val leadingRomanNumeralRegex = Regex(
+    "^([IVXLCDM]+|[ⅠⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫ]+)(?=\\s*(구역|권역))",
+    RegexOption.IGNORE_CASE
+)
+private val unicodeRomanNumeralValues = mapOf(
+    "Ⅰ" to 1,
+    "Ⅱ" to 2,
+    "Ⅲ" to 3,
+    "Ⅳ" to 4,
+    "Ⅴ" to 5,
+    "Ⅵ" to 6,
+    "Ⅶ" to 7,
+    "Ⅷ" to 8,
+    "Ⅸ" to 9,
+    "Ⅹ" to 10,
+    "Ⅺ" to 11,
+    "Ⅻ" to 12
+)
+
+private fun String.toOrderedManagementZoneSortText(): String? {
+    val trimmed = trim()
+    val leadingOrder =
+        leadingNumberRegex.find(trimmed)?.groupValues?.getOrNull(1)?.toIntOrNull()
+            ?: leadingRomanNumeralRegex.find(trimmed)
+                ?.groupValues
+                ?.getOrNull(1)
+                ?.toRomanNumeralOrNull()
+
+    return leadingOrder?.let { order ->
+        leadingNumberRegex.replaceFirst(trimmed, order.toString())
+            .let { normalized ->
+                leadingRomanNumeralRegex.replaceFirst(normalized, order.toString())
+            }
+    }
+}
+
+private fun String.toRomanNumeralOrNull(): Int? {
+    unicodeRomanNumeralValues[this]?.let { value -> return value }
+
+    val values = mapOf(
+        'I' to 1,
+        'V' to 5,
+        'X' to 10,
+        'L' to 50,
+        'C' to 100,
+        'D' to 500,
+        'M' to 1000
+    )
+    var total = 0
+    var previous = 0
+
+    for (char in uppercase().reversed()) {
+        val value = values[char] ?: return null
+        if (value < previous) {
+            total -= value
+        } else {
+            total += value
+            previous = value
+        }
+    }
+
+    return total.takeIf { value -> value > 0 }
+}
 
 private fun compareNaturalText(left: String, right: String): Int {
     val leftTokens = left.naturalSortTokens()

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModelTest.kt
@@ -175,6 +175,105 @@ class RegionalGuideCandidateUiModelTest {
     }
 
     @Test
+    fun `숫자 권역 후보는 권역 번호 기준으로 자연 순서 정렬한다`() {
+        val candidates = listOf(
+            candidate(managementZoneName = "3권역", targetRegionName = "와부읍, 조안면"),
+            candidate(managementZoneName = "7권역", targetRegionName = "진건읍, 다산1동"),
+            candidate(managementZoneName = "4권역", targetRegionName = "진접읍, 오남읍"),
+            candidate(managementZoneName = "1권역", targetRegionName = "호평동, 평내동, 금곡동")
+        )
+
+        val sorted = candidates.sortedWith(regionalGuideCandidateDisplayComparator)
+
+        assertEquals(
+            listOf(
+                "1권역 / 호평동, 평내동, 금곡동",
+                "3권역 / 와부읍, 조안면",
+                "4권역 / 진접읍, 오남읍",
+                "7권역 / 진건읍, 다산1동"
+            ),
+            sorted.map { candidate -> candidate.displayText }
+        )
+    }
+
+    @Test
+    fun `숫자로 시작하는 관리구역 후보는 뒤 문구와 관계없이 자연 순서 정렬한다`() {
+        val candidates = listOf(
+            candidate(
+                managementZoneName = "7구역(고양위생공사 031-962-0000)",
+                targetRegionName = "능곡동+장항1동+장항2동+마두1동"
+            ),
+            candidate(
+                managementZoneName = "12구역(서강기업 031-972-0000)",
+                targetRegionName = "대화동+탄현1동+탄현2동"
+            ),
+            candidate(
+                managementZoneName = "11구역(수창기업 031-978-0000)",
+                targetRegionName = "덕이동+가좌동+송포동+주엽2동"
+            )
+        )
+
+        val sorted = candidates.sortedWith(regionalGuideCandidateDisplayComparator)
+
+        assertEquals(
+            listOf(
+                "7구역(고양위생공사 031-962-0000) / 능곡동+장항1동+장항2동+마두1동",
+                "11구역(수창기업 031-978-0000) / 덕이동+가좌동+송포동+주엽2동",
+                "12구역(서강기업 031-972-0000) / 대화동+탄현1동+탄현2동"
+            ),
+            sorted.map { candidate -> candidate.displayText }
+        )
+    }
+
+    @Test
+    fun `로마 숫자로 시작하는 관리구역 후보도 관리구역 기준으로 자연 순서 정렬한다`() {
+        val candidates = listOf(
+            candidate(managementZoneName = "II구역", targetRegionName = "갑천면"),
+            candidate(managementZoneName = "I구역", targetRegionName = "강림면"),
+            candidate(managementZoneName = "II구역", targetRegionName = "공근면"),
+            candidate(managementZoneName = "I구역", targetRegionName = "둔내면"),
+            candidate(managementZoneName = "II구역", targetRegionName = "서원면")
+        )
+
+        val sorted = candidates.sortedWith(regionalGuideCandidateDisplayComparator)
+
+        assertEquals(
+            listOf(
+                "I구역 / 강림면",
+                "I구역 / 둔내면",
+                "II구역 / 갑천면",
+                "II구역 / 공근면",
+                "II구역 / 서원면"
+            ),
+            sorted.map { candidate -> candidate.displayText }
+        )
+    }
+
+    @Test
+    fun `유니코드 로마 숫자로 시작하는 관리구역 후보도 관리구역 기준으로 자연 순서 정렬한다`() {
+        val candidates = listOf(
+            candidate(managementZoneName = "Ⅱ구역", targetRegionName = "갑천면"),
+            candidate(managementZoneName = "Ⅰ구역", targetRegionName = "강림면"),
+            candidate(managementZoneName = "Ⅱ구역", targetRegionName = "공근면"),
+            candidate(managementZoneName = "Ⅰ구역", targetRegionName = "둔내면"),
+            candidate(managementZoneName = "Ⅱ구역", targetRegionName = "서원면")
+        )
+
+        val sorted = candidates.sortedWith(regionalGuideCandidateDisplayComparator)
+
+        assertEquals(
+            listOf(
+                "Ⅰ구역 / 강림면",
+                "Ⅰ구역 / 둔내면",
+                "Ⅱ구역 / 갑천면",
+                "Ⅱ구역 / 공근면",
+                "Ⅱ구역 / 서원면"
+            ),
+            sorted.map { candidate -> candidate.displayText }
+        )
+    }
+
+    @Test
     fun `동일한 표시명 후보가 여러 개이고 배출장소가 다르면 배출장소로 구분한다`() {
         val candidates = listOf(
             candidate(


### PR DESCRIPTION
## 작업 내용

#158 2차 작업으로, 지역 가이드 선택형 UI에서 직접 매칭되지 않는 읍면동을 조회했을 때의 selector fallback 정책과 후보/옵션 정렬을 보완했습니다.

선택한 읍면동만으로 문전수거/거점수거 유형을 임의 판정하지 않도록 하고, 같은 시군구 단위 후보는 자동 선택하지 않고 사용자가 판단할 수 있는 후보 목록 또는 기존 안내 흐름으로 연결되도록 정리했습니다.

## 변경 사항

- 직접 매칭 실패 시 같은 시군구 단위 후보를 fallback 후보 목록으로 노출
- 명시적인 다른 읍면동 후보는 fallback 후보에서 제외
- 읍면동이 명시되지 않은 시군구 단위 후보는 fallback 후보로 유지
- 시군구 단위 후보와 명시적인 다른 읍면동 후보가 섞인 경우 시군구 단위 후보만 후보 목록으로 반환
- 시군구 단위 fallback 후보가 1개만 남으면 자동 선택하지 않고 기존 실패/안내 흐름 유지
- 선택한 읍면동만으로 문전수거/거점수거 유형을 임의 판정하지 않도록 처리
- 선택형 UI 읍면동 옵션 정렬 개선
  - 가나다순 정렬
  - 숫자 자연 정렬
  - 예: `1동`, `2동`, `10동`
  - 예: `월곡1리`, `월곡2리`, `월곡10리`
- 후보 목록의 숫자/로마 숫자 관리구역 정렬 보완
  - `1권역`, `3권역`, `10권역`
  - `7구역(...)`, `11구역(...)`, `12구역(...)`
  - `I구역`, `II구역`
  - `Ⅰ구역`, `Ⅱ구역`
- domain test 오타 수정
- 관련 domain/data/presentation 테스트 추가 및 보강

## 유지한 기존 정책

- `/info` API 호출 방식 유지
- `/info` 원본 데이터 유지
- 정확 매칭 우선 정책 유지
- #155 법정동/행정동 매핑 fallback 우선순위 유지
- 복수 후보 첫 번째 임의 선택 방지
- `Region.eupmyeondong` 원본 값 유지
- Favorites key 및 재진입 흐름 유지
- 주소 검색, 키워드 검색, 선택형 UI 조회 흐름 유지
- #158 1차 후보 식별 정책 유지
- #158 1차 후속 `없음` 후보 표시 정책 유지
- #159 검색창 입력값과 실제 조회 상태 분리 정책 유지

## 제외한 범위

- `/info` pagination 전체 조회
- 행정구역 JSON 수정
- 법정동/행정동 매핑 추가 또는 수정
- API row 후보 병합
- Favorites key 정책 변경
- 선택한 읍면동 기준 수거 유형 자동 판정
- #151 focus / 키보드 흐름 변경
- 데이터 출처 및 이용조건 문서화

## 테스트

- [x] `git diff --check`
- [x] `./gradlew :domain:test`
- [x] `./gradlew :data:testDebugUnitTest`
- [x] `./gradlew :presentation:testDebugUnitTest`
- [x] `./gradlew :presentation:compileDebugKotlin`
- [x] `./gradlew :app:assembleDebug`

## 확인한 케이스

- `강원특별자치도 > 강릉시 > 사천면` 선택 시 직접 매칭 후보가 없는 경우
- 같은 시군구 단위 후보가 여러 개 있을 때 후보 목록으로 표시되는지
- 명시적인 다른 읍면동 후보가 fallback 후보에서 제외되는지
- 시군구 단위 후보와 명시적인 다른 읍면동 후보가 섞인 경우 시군구 단위 후보만 남는지
- 시군구 단위 후보가 1개만 남으면 자동 선택하지 않는지
- 선택한 읍면동만으로 문전수거/거점수거 유형을 임의 판정하지 않는지
- 선택형 UI 읍면동 옵션이 가나다순과 숫자 자연 정렬로 표시되는지
- 후보 목록의 숫자/로마 숫자 관리구역 정렬이 자연스럽게 동작하는지

## 스크린샷

화면 레이아웃의 큰 변경은 없습니다.

다만 `강원특별자치도 > 강릉시 > 사천면` 선택 시 직접 매칭 실패 후 첫 번째 후보를 자동 선택하지 않고, 같은 시군구 단위 후보 목록으로 연결되는 것을 단말에서 확인했습니다.

| 사천면 선택 및 시군구 단위 후보 목록 | 후보 선택 결과 |
| --- | --- |
| <img width="720" height="1520" alt="사천면 선택 및 시군구 단위 후보 목록" src="https://github.com/user-attachments/assets/84d2cc0c-7619-441a-9bc1-10df01b14ecb" /> | <img width="720" height="1520" alt="사천면 후보 선택 결과" src="https://github.com/user-attachments/assets/b878c641-674d-4c35-9669-6b74632724f9" /> |

## 관련 이슈

- Related #158
- Related #155
- Related #159