### PR TITLE
feat: 지도 동명 검색 후보 선택 UX 구현

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapper.kt
@@ -75,6 +75,68 @@ internal object RegionOptionsMapper {
             .sortedWith(REGION_NAME_COMPARATOR)
     }
 
+    fun findEupmyeondongRegions(
+        administrativeRegions: List<AdministrativeRegionDto>,
+        legalAdminDongMappings: List<LegalAdminDongMappingDto>,
+        keyword: String
+    ): List<Region> {
+        val targetKeyword = keyword.trim()
+        if (targetKeyword.isBlank()) return emptyList()
+
+        val administrativeMatches = administrativeRegions
+            .filter { region -> region.eupmyeondongName == targetKeyword }
+            .map { region ->
+                RegionNormalizer.normalize(
+                    Region(
+                        sido = region.sidoName,
+                        sigungu = region.sigunguName.ifBlank { null },
+                        eupmyeondong = region.eupmyeondongName
+                    )
+                )
+            }
+
+        val legalMatches = legalAdminDongMappings
+            .filter { mapping -> mapping.legalDongName.trim().matchesLegalDongKeyword(targetKeyword) }
+            .map { mapping ->
+                RegionNormalizer.normalize(
+                    Region(
+                        sido = mapping.sidoName.trim(),
+                        sigungu = mapping.sigunguName.trimToNull(),
+                        eupmyeondong = targetKeyword
+                    )
+                )
+            }
+
+        return (administrativeMatches + legalMatches)
+            .distinctByRegionWithEupmyeondong()
+            .sortedWith(REGION_NAME_COMPARATOR)
+    }
+
+    fun findLegalDongKeywordsByRegion(
+        mappings: List<LegalAdminDongMappingDto>,
+        region: Region,
+        keyword: String
+    ): List<String> {
+        val targetKeyword = keyword.trim()
+        if (targetKeyword.isBlank()) return emptyList()
+
+        val sido = region.sido.trimToNull()
+        val sigungu = region.sigungu.trimToNull()
+
+        return mappings
+            .asSequence()
+            .filter { mapping ->
+                (sido == null || mapping.sidoName.trim() == sido) &&
+                    (sigungu == null || mapping.sigunguName.trim() == sigungu) &&
+                    mapping.legalDongName.trim().matchesLegalDongKeyword(targetKeyword)
+            }
+            .map { mapping -> mapping.legalDongName.trim() }
+            .filter { legalDongName -> legalDongName.isNotBlank() }
+            .distinct()
+            .sorted()
+            .toList()
+    }
+
     fun normalizeRegionForRegionalGuide(
         region: Region,
         regionalGuideRegions: List<RegionalGuideRegionDto>
@@ -236,6 +298,21 @@ internal object RegionOptionsMapper {
         }
     }
 
+    private fun List<Region>.distinctByRegionWithEupmyeondong(): List<Region> {
+        return distinctBy { region ->
+            listOf(
+                region.sido.orEmpty(),
+                region.sigungu.orEmpty(),
+                region.eupmyeondong.orEmpty()
+            )
+        }
+    }
+
+    private fun String.matchesLegalDongKeyword(targetKeyword: String): Boolean {
+        return this == targetKeyword ||
+            (startsWith(targetKeyword) && LEGAL_DONG_GA_REGEX.matches(this))
+    }
+
     private fun String?.trimToNull(): String? =
         this
             ?.trim()
@@ -250,4 +327,5 @@ internal object RegionOptionsMapper {
     private const val SEJONG_SIDO = "세종특별자치시"
     private const val NO_SIGUNGU_NAME = "없음"
     private const val CITY_SUFFIX = "시"
+    private val LEGAL_DONG_GA_REGEX = """[가-힣]+\d+가""".toRegex()
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsRepositoryImpl.kt
@@ -3,7 +3,6 @@ package com.team.yeogibeoryeo.data.region
 import com.team.yeogibeoryeo.data.region.local.RegionOptionsLocalDataSource
 import com.team.yeogibeoryeo.data.region.local.LegalAdminDongMappingLocalDataSource
 import com.team.yeogibeoryeo.data.region.local.RegionalGuideRegionOptionsLocalDataSource
-import com.team.yeogibeoryeo.data.region.local.dto.AdministrativeRegionDto
 import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.region.repository.RegionOptionsRepository
 import javax.inject.Inject
@@ -43,23 +42,22 @@ class RegionOptionsRepositoryImpl @Inject constructor(
     override suspend fun findRegionsByEupmyeondongKeyword(
         keyword: String
     ): List<Region> {
-        val targetKeyword = keyword.trim()
-        if (targetKeyword.isBlank()) return emptyList()
+        return RegionOptionsMapper.findEupmyeondongRegions(
+            administrativeRegions = localDataSource.getRegions(),
+            legalAdminDongMappings = legalAdminDongMappingLocalDataSource.getMappings(),
+            keyword = keyword
+        )
+    }
 
-        val regions = localDataSource.getRegions()
-        val exactMatches = regions
-            .filter { region -> region.eupmyeondongName == targetKeyword }
-
-        val matchedRegions = exactMatches.ifEmpty {
-            regions.filter { region ->
-                region.eupmyeondongName.startsWith(targetKeyword)
-            }
-        }
-
-        return matchedRegions
-            .mapToRegion()
-            .distinct()
-            .sortedWith(REGION_NAME_COMPARATOR)
+    override suspend fun findLegalDongKeywordsByRegion(
+        region: Region,
+        keyword: String
+    ): List<String> {
+        return RegionOptionsMapper.findLegalDongKeywordsByRegion(
+            mappings = legalAdminDongMappingLocalDataSource.getMappings(),
+            region = region,
+            keyword = keyword
+        )
     }
 
     override suspend fun findRegionsBySigunguKeyword(
@@ -90,23 +88,4 @@ class RegionOptionsRepositoryImpl @Inject constructor(
         )
     }
 
-    private fun List<AdministrativeRegionDto>.mapToRegion(): List<Region> {
-        return map { region ->
-            RegionNormalizer.normalize(
-                Region(
-                    sido = region.sidoName,
-                    sigungu = region.sigunguName.ifBlank { null },
-                    eupmyeondong = region.eupmyeondongName
-                )
-            )
-        }
-    }
-
-    private companion object {
-        private val REGION_NAME_COMPARATOR = compareBy<Region>(
-            { region -> region.sido.orEmpty() },
-            { region -> region.sigungu.orEmpty() },
-            { region -> region.eupmyeondong.orEmpty() }
-        )
-    }
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
@@ -62,7 +62,9 @@ class CollectionSpotRepositoryImpl @Inject constructor(
     override suspend fun geocodeSpot(
         spot: CollectionSpot,
     ): CollectionSpot {
-        val coordinate = spotGeocoder.geocode(spot.address)
+        val coordinate = spot.address.toGeocodeKey()?.let { address ->
+            spotGeocoder.geocode(address)
+        }
 
         return spot.copy(
             coordinate = coordinate,
@@ -129,10 +131,15 @@ class CollectionSpotRepositoryImpl @Inject constructor(
     }
 
     private fun String.toGeocodeKey(): String? {
-        return trim().takeIf { it.isNotBlank() }
+        return replace(PARENTHESIZED_TEXT_REGEX, " ")
+            .trim()
+            .replace(WHITESPACE_REGEX, " ")
+            .takeIf { it.isNotBlank() }
     }
 
     private companion object {
         const val MAX_CONCURRENT_GEOCODING_COUNT = 3
+        val PARENTHESIZED_TEXT_REGEX = "\\([^)]*\\)".toRegex()
+        val WHITESPACE_REGEX = "\\s+".toRegex()
     }
 }

--- a/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapperTest.kt
@@ -465,6 +465,85 @@ class RegionOptionsMapperTest {
         assertEquals(emptyList<Region>(), regions)
     }
 
+    @Test
+    fun `eupmyeondong lookup includes legal dong candidates with admin dong suffixes`() {
+        val regions = RegionOptionsMapper.findEupmyeondongRegions(
+            administrativeRegions = listOf(
+                administrativeRegion(
+                    sidoName = "전라남도",
+                    sigunguName = "광양시",
+                    eupmyeondongName = "금호동"
+                )
+            ),
+            legalAdminDongMappings = listOf(
+                legalAdminMapping(
+                    sidoName = "광주광역시",
+                    sigunguName = "서구",
+                    legalDongName = "금호동",
+                    adminDongName = "금호1동"
+                ),
+                legalAdminMapping(
+                    sidoName = "광주광역시",
+                    sigunguName = "서구",
+                    legalDongName = "금호동",
+                    adminDongName = "금호2동"
+                ),
+                legalAdminMapping(
+                    sidoName = "서울특별시",
+                    sigunguName = "성동구",
+                    legalDongName = "금호동1가",
+                    adminDongName = "금호1가동"
+                ),
+                legalAdminMapping(
+                    sidoName = "전라남도",
+                    sigunguName = "보성군",
+                    legalDongName = "금호리",
+                    adminDongName = "노동면"
+                )
+            ),
+            keyword = "금호동"
+        )
+
+        assertEquals(
+            listOf(
+                Region(sido = "광주광역시", sigungu = "서구", eupmyeondong = "금호동"),
+                Region(sido = "서울특별시", sigungu = "성동구", eupmyeondong = "금호동"),
+                Region(sido = "전라남도", sigungu = "광양시", eupmyeondong = "금호동")
+            ),
+            regions
+        )
+    }
+
+    @Test
+    fun `legal dong keyword lookup returns ga aliases but excludes ri aliases`() {
+        val keywords = RegionOptionsMapper.findLegalDongKeywordsByRegion(
+            mappings = listOf(
+                legalAdminMapping(
+                    sidoName = "서울특별시",
+                    sigunguName = "중구",
+                    legalDongName = "명동1가",
+                    adminDongName = "명동"
+                ),
+                legalAdminMapping(
+                    sidoName = "서울특별시",
+                    sigunguName = "중구",
+                    legalDongName = "명동2가",
+                    adminDongName = "명동"
+                ),
+                legalAdminMapping(
+                    sidoName = "경상남도",
+                    sigunguName = "김해시",
+                    legalDongName = "명동리",
+                    adminDongName = "한림면"
+                )
+            ),
+            region = Region(sido = "서울특별시", sigungu = "중구", eupmyeondong = "명동"),
+            keyword = "명동"
+        )
+
+        assertEquals(listOf("명동1가", "명동2가"), keywords)
+    }
+
     private fun administrativeRegion(
         sidoName: String,
         sigunguName: String,

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImplTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImplTest.kt
@@ -149,6 +149,36 @@ class CollectionSpotRepositoryImplTest {
     }
 
     @Test
+    fun `괄호가 포함된 도로명 주소는 괄호를 제거한 주소로 geocoding한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createParenthesizedRoadAddressResponse(),
+        )
+        val spotGeocoder = FakeSpotGeocoder(
+            coordinatesByAddress = mapOf(
+                "서울특별시 성동구 행당로 35" to Coordinate(
+                    latitude = 37.5570,
+                    longitude = 127.0332,
+                ),
+            ),
+        )
+        val repository = createRepository(
+            apiService = apiService,
+            spotGeocoder = spotGeocoder,
+        )
+
+        val result = repository.searchByKeyword(
+            keyword = "금호동",
+        )
+
+        assertEquals(
+            listOf("서울특별시 성동구 행당로 35"),
+            spotGeocoder.requestedAddresses,
+        )
+        assertEquals(37.5570, result.first().coordinate?.latitude)
+        assertEquals(127.0332, result.first().coordinate?.longitude)
+    }
+
+    @Test
     fun `공백 주소는 geocoding하지 않고 좌표 없이 유지한다`() = runBlocking {
         val apiService = FakeSpotApiService(
             response = createBlankAddressResponse(),
@@ -326,6 +356,28 @@ class CollectionSpotRepositoryImplTest {
                                     spotNm = "재활용센터",
                                     addrBase = "서울특별시 구로구 구로동",
                                     addrDtl = "센터 입구",
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        }
+
+        fun createParenthesizedRoadAddressResponse(): SpotResponseDto {
+            return SpotResponseDto(
+                response = SpotResponseBodyDto(
+                    header = SpotHeaderDto(
+                        resultCode = "00",
+                        resultMsg = "NORMAL SERVICE",
+                    ),
+                    body = SpotBodyDto(
+                        items = SpotItemsDto(
+                            item = listOf(
+                                SpotItemDto(
+                                    spotNm = "종량제봉투 판매소",
+                                    addrBase = "서울특별시 성동구 행당로 35 (금호동1가, 금북빌딩)",
+                                    addrDtl = "103호, 105호",
                                 ),
                             ),
                         ),

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/repository/RegionOptionsRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/repository/RegionOptionsRepository.kt
@@ -19,6 +19,11 @@ interface RegionOptionsRepository {
         keyword: String
     ): List<Region>
 
+    suspend fun findLegalDongKeywordsByRegion(
+        region: Region,
+        keyword: String
+    ): List<String> = emptyList()
+
     suspend fun findRegionsBySigunguKeyword(
         keyword: String
     ): List<Region>

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/CollectionSpotAddressSearchPolicy.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/CollectionSpotAddressSearchPolicy.kt
@@ -1,0 +1,147 @@
+package com.team.yeogibeoryeo.domain.spot.model
+
+object CollectionSpotAddressSearchPolicy {
+    fun normalizeKeyword(keyword: String): String {
+        val trimmedKeyword = keyword.trim()
+        if (trimmedKeyword.isBlank()) return trimmedKeyword
+
+        val tokens = tokenize(trimmedKeyword)
+        if (tokens.any { token -> token.hasAddressNumber() || token.isRoadNameLike() }) {
+            return trimmedKeyword
+        }
+
+        return tokens.lastOrNull { token -> token.hasEupMyeonDongShape() } ?: trimmedKeyword
+    }
+
+    fun tokenize(value: String): List<String> =
+        value
+            .trim()
+            .split(REGION_TOKEN_DELIMITER_REGEX)
+            .map { token -> token.cleanToken() }
+            .filter { token -> token.isNotBlank() }
+
+    fun extractExplicitRegions(address: String): List<String> {
+        val parenthesizedRegions = PARENTHESIZED_TEXT_REGEX.findAll(address).flatMap { matchResult ->
+            matchResult.groupValues.getOrNull(1).orEmpty()
+                .split(REGION_TOKEN_DELIMITER_REGEX)
+                .asSequence()
+        }
+        val tokenRegions = address.split(REGION_TOKEN_DELIMITER_REGEX).asSequence()
+
+        return (parenthesizedRegions + tokenRegions)
+            .map { token -> token.cleanToken() }
+            .filter { token -> token.hasEupMyeonDongShape() }
+            .distinct()
+            .toList()
+    }
+
+    fun matchesEupMyeonDongKeyword(regionName: String, keyword: String): Boolean =
+        regionName == keyword || (regionName.startsWith(keyword) && regionName.isLegalDongGaCandidate())
+
+    fun isEupMyeonDongCandidate(token: String): Boolean =
+        token.hasEupMyeonDongShape()
+
+    fun normalizedSidoName(token: String): String? =
+        when {
+            token in SIDO_NAMES -> SIDO_ALIASES[token] ?: token
+            token in SIDO_ALIASES -> SIDO_ALIASES[token]
+            else -> null
+        }
+
+    fun isSigunguLike(token: String): Boolean =
+        token.endsWith(SIGUNGU_CITY_SUFFIX) ||
+            token.endsWith(SIGUNGU_COUNTY_SUFFIX) ||
+            token.endsWith(SIGUNGU_DISTRICT_SUFFIX)
+
+    fun sidoMatches(token: String, sido: String): Boolean =
+        normalizedSidoName(token) == sido || token == sido
+
+    private fun String.cleanToken(): String =
+        trim().trim('(', ')', '[', ']', ',', '.', ' ')
+
+    private fun String.hasAddressNumber(): Boolean =
+        ADDRESS_NUMBER_REGEX.matches(this)
+
+    private fun String.isRoadNameLike(): Boolean {
+        val nameWithoutNumbers = replace(DIGIT_REGEX, "")
+        return nameWithoutNumbers.endsWith(ROAD_NAME_SUFFIX) ||
+            nameWithoutNumbers.endsWith(ROAD_DETAIL_SUFFIX)
+    }
+
+    private fun String.hasEupMyeonDongShape(): Boolean =
+        EUP_MYEON_DONG_REGEX.matches(this) || isLegalDongGaCandidate()
+
+    private fun String.isLegalDongGaCandidate(): Boolean =
+        LEGAL_DONG_GA_REGEX.matches(this)
+
+    private const val ROAD_NAME_SUFFIX = "로"
+    private const val ROAD_DETAIL_SUFFIX = "길"
+    private const val EUP_SUFFIX = "읍"
+    private const val MYEON_SUFFIX = "면"
+    private const val DONG_SUFFIX = "동"
+    private const val LEGAL_DONG_GA_SUFFIX = "가"
+    private const val SIGUNGU_CITY_SUFFIX = "시"
+    private const val SIGUNGU_COUNTY_SUFFIX = "군"
+    private const val SIGUNGU_DISTRICT_SUFFIX = "구"
+
+    private val REGION_TOKEN_DELIMITER_REGEX = "[,\\s]+".toRegex()
+    private val PARENTHESIZED_TEXT_REGEX = "\\(([^)]+)\\)".toRegex()
+    private val DIGIT_REGEX = "\\d+".toRegex()
+    private val ADDRESS_NUMBER_REGEX = """\d+(-\d+)?""".toRegex()
+    private val EUP_MYEON_DONG_REGEX =
+        """[가-힣]+\d*[$EUP_SUFFIX$MYEON_SUFFIX$DONG_SUFFIX]""".toRegex()
+    private val LEGAL_DONG_GA_REGEX = """[가-힣]+\d+$LEGAL_DONG_GA_SUFFIX""".toRegex()
+
+    private val SIDO_NAMES = setOf(
+        "서울특별시",
+        "부산광역시",
+        "대구광역시",
+        "인천광역시",
+        "광주광역시",
+        "대전광역시",
+        "울산광역시",
+        "세종특별자치시",
+        "경기도",
+        "강원특별자치도",
+        "강원도",
+        "충청북도",
+        "충청남도",
+        "전북특별자치도",
+        "전라북도",
+        "전라남도",
+        "경상북도",
+        "경상남도",
+        "제주특별자치도",
+        "제주도",
+    )
+
+    private val SIDO_ALIASES = mapOf(
+        "서울" to "서울특별시",
+        "서울시" to "서울특별시",
+        "부산" to "부산광역시",
+        "부산시" to "부산광역시",
+        "대구" to "대구광역시",
+        "대구시" to "대구광역시",
+        "인천" to "인천광역시",
+        "인천시" to "인천광역시",
+        "광주" to "광주광역시",
+        "대전" to "대전광역시",
+        "대전시" to "대전광역시",
+        "울산" to "울산광역시",
+        "울산시" to "울산광역시",
+        "세종" to "세종특별자치시",
+        "세종시" to "세종특별자치시",
+        "경기" to "경기도",
+        "강원" to "강원특별자치도",
+        "강원도" to "강원특별자치도",
+        "충북" to "충청북도",
+        "충남" to "충청남도",
+        "전북" to "전북특별자치도",
+        "전라북도" to "전북특별자치도",
+        "전남" to "전라남도",
+        "경북" to "경상북도",
+        "경남" to "경상남도",
+        "제주" to "제주특별자치도",
+        "제주도" to "제주특별자치도",
+    )
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/CollectionSpotAddressSearchPolicy.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/CollectionSpotAddressSearchPolicy.kt
@@ -42,9 +42,9 @@ object CollectionSpotAddressSearchPolicy {
         token.hasEupMyeonDongShape()
 
     fun normalizedSidoName(token: String): String? =
-        when {
-            token in SIDO_NAMES -> SIDO_ALIASES[token] ?: token
-            token in SIDO_ALIASES -> SIDO_ALIASES[token]
+        when (token) {
+            in SIDO_NAMES -> SIDO_ALIASES[token] ?: token
+            in SIDO_ALIASES -> SIDO_ALIASES[token]
             else -> null
         }
 

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/MapRegionSearchCandidate.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/MapRegionSearchCandidate.kt
@@ -1,0 +1,29 @@
+package com.team.yeogibeoryeo.domain.spot.model
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+
+data class MapRegionSearchCandidate(
+    val region: Region,
+    val searchKeyword: String,
+    val searchKeywords: List<String> = listOf(searchKeyword),
+) {
+    val displayName: String =
+        listOfNotNull(
+            region.sido,
+            region.sigungu,
+            region.eupmyeondong,
+        ).joinToString(separator = " ")
+}
+
+sealed interface MapRegionSearchCandidateResult {
+    data class ReadyToSearch(
+        val searchKeyword: String,
+        val selectedCandidate: MapRegionSearchCandidate? = null,
+    ) : MapRegionSearchCandidateResult
+
+    data class NeedSelection(
+        val originalKeyword: String,
+        val searchKeyword: String,
+        val candidates: List<MapRegionSearchCandidate>,
+    ) : MapRegionSearchCandidateResult
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/NormalizeCollectionSpotSearchKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/NormalizeCollectionSpotSearchKeywordUseCase.kt
@@ -1,47 +1,11 @@
 package com.team.yeogibeoryeo.domain.spot.usecase
 
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotAddressSearchPolicy
 import javax.inject.Inject
 
 class NormalizeCollectionSpotSearchKeywordUseCase @Inject constructor() {
 
     operator fun invoke(keyword: String): String {
-        val trimmedKeyword = keyword.trim()
-        if (trimmedKeyword.isBlank()) return trimmedKeyword
-
-        val tokens = trimmedKeyword
-            .split(WHITESPACE_REGEX)
-            .map { token -> token.cleanToken() }
-            .filter { token -> token.isNotBlank() }
-
-        if (tokens.any { token -> token.hasAddressNumber() || token.isRoadNameLike() }) {
-            return trimmedKeyword
-        }
-
-        return tokens
-            .lastOrNull { token -> token.isEupMyeonDongCandidate() }
-            ?: trimmedKeyword
-    }
-
-    private fun String.cleanToken(): String =
-        trim().trim('(', ')', '[', ']', ',', '.', ' ')
-
-    private fun String.hasAddressNumber(): Boolean =
-        ADDRESS_NUMBER_REGEX.matches(this)
-
-    private fun String.isRoadNameLike(): Boolean {
-        val nameWithoutNumbers = replace(DIGIT_REGEX, "")
-        return nameWithoutNumbers.endsWith("로") || nameWithoutNumbers.endsWith("길")
-    }
-
-    private fun String.isEupMyeonDongCandidate(): Boolean =
-        EUP_MYEON_DONG_REGEX.matches(this) ||
-            LEGAL_DONG_GA_REGEX.matches(this)
-
-    private companion object {
-        private val WHITESPACE_REGEX = "\\s+".toRegex()
-        private val DIGIT_REGEX = "\\d+".toRegex()
-        private val ADDRESS_NUMBER_REGEX = """\d+(-\d+)?""".toRegex()
-        private val EUP_MYEON_DONG_REGEX = """[가-힣]+\d*[동읍면]""".toRegex()
-        private val LEGAL_DONG_GA_REGEX = """[가-힣]+\d+가""".toRegex()
+        return CollectionSpotAddressSearchPolicy.normalizeKeyword(keyword)
     }
 }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/ResolveMapRegionSearchCandidateUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/ResolveMapRegionSearchCandidateUseCase.kt
@@ -1,0 +1,159 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.region.repository.RegionOptionsRepository
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotAddressSearchPolicy
+import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
+import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidateResult
+import javax.inject.Inject
+
+class ResolveMapRegionSearchCandidateUseCase @Inject constructor(
+    private val regionOptionsRepository: RegionOptionsRepository,
+    private val normalizeKeywordUseCase: NormalizeCollectionSpotSearchKeywordUseCase,
+) {
+    suspend operator fun invoke(keyword: String): MapRegionSearchCandidateResult {
+        val trimmedKeyword = keyword.trim()
+        val searchKeyword = normalizeKeywordUseCase(trimmedKeyword)
+
+        if (
+            trimmedKeyword.isBlank() ||
+            !CollectionSpotAddressSearchPolicy.isEupMyeonDongCandidate(searchKeyword)
+        ) {
+            return MapRegionSearchCandidateResult.ReadyToSearch(searchKeyword)
+        }
+
+        val matchedRegions = regionOptionsRepository.findRegionsByEupmyeondongKeyword(searchKeyword)
+            .filter { region -> region.eupmyeondong.matchesSearchKeyword(searchKeyword) }
+            .filterByScopeTokens(
+                tokens = CollectionSpotAddressSearchPolicy.tokenize(trimmedKeyword),
+                searchKeyword = searchKeyword,
+            )
+        val fallbackRegion = CollectionSpotAddressSearchPolicy.tokenize(trimmedKeyword)
+            .toScopedFallbackRegion(searchKeyword)
+            .takeIf { matchedRegions.isEmpty() }
+        val candidates = (matchedRegions + listOfNotNull(fallbackRegion))
+            .toCandidates(searchKeyword)
+
+        return when (candidates.size) {
+            0 -> MapRegionSearchCandidateResult.ReadyToSearch(searchKeyword)
+            1 -> MapRegionSearchCandidateResult.ReadyToSearch(
+                searchKeyword = searchKeyword,
+                selectedCandidate = candidates.first(),
+            )
+
+            else -> MapRegionSearchCandidateResult.NeedSelection(
+                originalKeyword = trimmedKeyword,
+                searchKeyword = searchKeyword,
+                candidates = candidates,
+            )
+        }
+    }
+
+    private fun List<Region>.filterByScopeTokens(
+        tokens: List<String>,
+        searchKeyword: String,
+    ): List<Region> {
+        val scopeTokens = tokens
+            .filterNot { token ->
+                token == searchKeyword ||
+                    CollectionSpotAddressSearchPolicy.matchesEupMyeonDongKeyword(token, searchKeyword)
+            }
+            .filter { token ->
+                CollectionSpotAddressSearchPolicy.normalizedSidoName(token) != null ||
+                    CollectionSpotAddressSearchPolicy.isSigunguLike(token)
+            }
+
+        if (scopeTokens.isEmpty()) return this
+
+        return filter { region ->
+            scopeTokens.all { token -> region.matchesScopeToken(token) }
+        }
+    }
+
+    private fun Region.matchesScopeToken(token: String): Boolean {
+        val sidoMatches = sido?.let { sido ->
+            CollectionSpotAddressSearchPolicy.sidoMatches(token, sido)
+        } ?: false
+        val sigunguMatches = sigungu
+            ?.split(REGION_SCOPE_SEPARATOR)
+            ?.any { sigunguPart -> sigunguPart == token } == true ||
+            sigungu == token
+
+        return sidoMatches || sigunguMatches
+    }
+
+    private suspend fun List<Region>.toCandidates(searchKeyword: String): List<MapRegionSearchCandidate> {
+        val candidates = mutableListOf<MapRegionSearchCandidate>()
+
+        for (region in this) {
+            candidates += region.toCandidate(searchKeyword)
+        }
+
+        return candidates
+    }
+
+    private suspend fun Region.toCandidate(searchKeyword: String): MapRegionSearchCandidate {
+        val legalDongKeywords = regionOptionsRepository.findLegalDongKeywordsByRegion(
+            region = this,
+            keyword = searchKeyword,
+        )
+        val searchKeywords = (listOf(searchKeyword) + legalDongKeywords)
+            .distinct()
+
+        return MapRegionSearchCandidate(
+            region = this,
+            searchKeyword = searchKeyword,
+            searchKeywords = searchKeywords,
+        )
+    }
+
+    private fun List<String>.toScopedFallbackRegion(searchKeyword: String): Region? {
+        val scopeTokens = filterNot { token ->
+            token == searchKeyword ||
+                CollectionSpotAddressSearchPolicy.matchesEupMyeonDongKeyword(token, searchKeyword)
+        }
+        if (scopeTokens.isEmpty()) return null
+
+        val sido = scopeTokens
+            .firstNotNullOfOrNull { token -> CollectionSpotAddressSearchPolicy.normalizedSidoName(token) }
+        val sigungu = scopeTokens.toSigunguName()
+
+        if (sido == null && sigungu == null) return null
+
+        return Region(
+            sido = sido,
+            sigungu = sigungu,
+            eupmyeondong = searchKeyword,
+        )
+    }
+
+    private fun List<String>.toSigunguName(): String? {
+        val sigunguTokens = filter { token ->
+            CollectionSpotAddressSearchPolicy.normalizedSidoName(token) == null &&
+                CollectionSpotAddressSearchPolicy.isSigunguLike(token)
+        }
+        if (sigunguTokens.isEmpty()) return null
+
+        return sigunguTokens
+            .zipWithNext()
+            .firstOrNull { (current, next) ->
+                current.endsWith(CITY_SUFFIX) && next.endsWith(DISTRICT_SUFFIX)
+            }
+            ?.let { (city, district) -> "$city $district" }
+            ?: sigunguTokens.first()
+    }
+
+    private fun String?.matchesSearchKeyword(searchKeyword: String): Boolean {
+        val regionName = this ?: return false
+        return CollectionSpotAddressSearchPolicy.matchesEupMyeonDongKeyword(
+            regionName = regionName,
+            keyword = searchKeyword,
+        )
+    }
+
+    private companion object {
+        const val REGION_SCOPE_SEPARATOR = " "
+        const val CITY_SUFFIX = "시"
+        const val DISTRICT_SUFFIX = "구"
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
@@ -76,9 +76,8 @@ class SearchCollectionSpotsByKeywordUseCase @Inject constructor(
         val hasSelectedSigungu = selectedSigungu == null ||
             selectedSigungu in tokens ||
             selectedSigunguParts.all { sigunguPart -> sigunguPart in tokens }
-        if (hasAnySigungu && !hasSelectedSigungu) return false
 
-        return true
+        return !hasAnySigungu || hasSelectedSigungu
     }
 
     private companion object {

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
@@ -1,7 +1,9 @@
 package com.team.yeogibeoryeo.domain.spot.usecase
 
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotAddressSearchPolicy
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import javax.inject.Inject
 
@@ -11,68 +13,75 @@ class SearchCollectionSpotsByKeywordUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(
         keyword: String,
-        types: Set<CollectionSpotType> = emptySet()
+        types: Set<CollectionSpotType> = emptySet(),
+        selectedRegionCandidate: MapRegionSearchCandidate? = null,
     ): List<CollectionSpot> {
         val normalizedKeyword = normalizeKeywordUseCase(keyword)
 
         return repository.searchByKeyword(
             keyword = normalizedKeyword,
-            types = types
-        ).filterByExplicitRegionKeyword(normalizedKeyword)
+            types = types,
+        )
+            .filterByExplicitRegionKeyword(normalizedKeyword)
+            .filterBySelectedRegionCandidate(selectedRegionCandidate)
     }
 
     private fun List<CollectionSpot>.filterByExplicitRegionKeyword(
         keyword: String,
     ): List<CollectionSpot> {
-        if (!keyword.isEupMyeonDongCandidate()) return this
+        if (!CollectionSpotAddressSearchPolicy.isEupMyeonDongCandidate(keyword)) return this
 
         return filter { spot ->
-            val explicitRegions = spot.address.extractExplicitRegions()
+            val explicitRegions = CollectionSpotAddressSearchPolicy.extractExplicitRegions(spot.address)
+
             explicitRegions.isEmpty() ||
-                explicitRegions.any { region -> region.matchesKeyword(keyword) }
+                explicitRegions.any { region ->
+                    CollectionSpotAddressSearchPolicy.matchesEupMyeonDongKeyword(
+                        regionName = region,
+                        keyword = keyword,
+                    )
+                }
         }
     }
 
-    private fun String.extractExplicitRegions(): List<String> {
-        val parenthesizedRegions = PARENTHESIZED_TEXT_REGEX
-            .findAll(this)
-            .flatMap { matchResult ->
-                matchResult.groupValues
-                    .getOrNull(1)
-                    .orEmpty()
-                    .split(REGION_TOKEN_DELIMITER_REGEX)
-                    .asSequence()
-            }
+    private fun List<CollectionSpot>.filterBySelectedRegionCandidate(
+        selectedRegionCandidate: MapRegionSearchCandidate?,
+    ): List<CollectionSpot> {
+        val candidate = selectedRegionCandidate ?: return this
 
-        val tokenRegions = split(REGION_TOKEN_DELIMITER_REGEX)
-            .asSequence()
-
-        return (parenthesizedRegions + tokenRegions)
-            .map { token -> token.cleanToken() }
-            .filter { token -> token.isEupMyeonDongCandidate() }
-            .distinct()
-            .toList()
+        return filter { spot ->
+            spot.address.matchesSelectedRegionCandidate(candidate)
+        }
     }
 
-    private fun String.matchesKeyword(keyword: String): Boolean {
-        return this == keyword ||
-            (startsWith(keyword) && isLegalDongGaCandidate())
+    private fun String.matchesSelectedRegionCandidate(
+        candidate: MapRegionSearchCandidate,
+    ): Boolean {
+        val tokens = CollectionSpotAddressSearchPolicy.tokenize(this)
+        val selectedSido = candidate.region.sido
+        val selectedSigungu = candidate.region.sigungu
+
+        val hasAnySido = tokens.any { token ->
+            CollectionSpotAddressSearchPolicy.normalizedSidoName(token) != null
+        }
+        val hasSelectedSido = selectedSido == null ||
+            tokens.any { token -> CollectionSpotAddressSearchPolicy.sidoMatches(token, selectedSido) }
+        if (hasAnySido && !hasSelectedSido) return false
+
+        val selectedSigunguParts = selectedSigungu?.split(REGION_SCOPE_SEPARATOR).orEmpty()
+        val hasAnySigungu = tokens.any { token ->
+            CollectionSpotAddressSearchPolicy.normalizedSidoName(token) == null &&
+                CollectionSpotAddressSearchPolicy.isSigunguLike(token)
+        }
+        val hasSelectedSigungu = selectedSigungu == null ||
+            selectedSigungu in tokens ||
+            selectedSigunguParts.all { sigunguPart -> sigunguPart in tokens }
+        if (hasAnySigungu && !hasSelectedSigungu) return false
+
+        return true
     }
-
-    private fun String.cleanToken(): String =
-        trim().trim('(', ')', '[', ']', ',', '.', ' ')
-
-    private fun String.isEupMyeonDongCandidate(): Boolean =
-        EUP_MYEON_DONG_REGEX.matches(this) ||
-            isLegalDongGaCandidate()
-
-    private fun String.isLegalDongGaCandidate(): Boolean =
-        LEGAL_DONG_GA_REGEX.matches(this)
 
     private companion object {
-        private val PARENTHESIZED_TEXT_REGEX = "\\(([^)]+)\\)".toRegex()
-        private val REGION_TOKEN_DELIMITER_REGEX = "[,\\s]+".toRegex()
-        private val EUP_MYEON_DONG_REGEX = """[가-힣]+\d*[동읍면]""".toRegex()
-        private val LEGAL_DONG_GA_REGEX = """[가-힣]+\d+가""".toRegex()
+        const val REGION_SCOPE_SEPARATOR = " "
     }
 }

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/ResolveMapRegionSearchCandidateUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/ResolveMapRegionSearchCandidateUseCaseTest.kt
@@ -1,0 +1,153 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.region.repository.RegionOptionsRepository
+import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidateResult
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ResolveMapRegionSearchCandidateUseCaseTest {
+
+    private val repository = FakeRegionOptionsRepository(
+        eupmyeondongCandidates = mapOf(
+            "명동" to listOf(
+                Region(sido = "서울특별시", sigungu = "중구", eupmyeondong = "명동"),
+                Region(sido = "충청북도", sigungu = "제천시", eupmyeondong = "명동"),
+                Region(sido = "경상남도", sigungu = "창원시 진해구", eupmyeondong = "명동"),
+            ),
+            "금호동" to listOf(
+                Region(sido = "서울특별시", sigungu = "성동구", eupmyeondong = "금호동"),
+                Region(sido = "광주광역시", sigungu = "서구", eupmyeondong = "금호동"),
+            ),
+            "문래동" to listOf(
+                Region(sido = "서울특별시", sigungu = "영등포구", eupmyeondong = "문래동"),
+            ),
+        ),
+        legalDongKeywords = mapOf(
+            "서울특별시|중구|명동|명동" to listOf("명동1가", "명동2가"),
+        ),
+    )
+    private val useCase = ResolveMapRegionSearchCandidateUseCase(
+        regionOptionsRepository = repository,
+        normalizeKeywordUseCase = NormalizeCollectionSpotSearchKeywordUseCase(),
+    )
+
+    @Test
+    fun `동 단독 검색어에 여러 지역 후보가 있으면 후보 선택 결과를 반환한다`() =
+        runSuspendTest {
+            val result = useCase("명동")
+
+            assertTrue(result is MapRegionSearchCandidateResult.NeedSelection)
+            result as MapRegionSearchCandidateResult.NeedSelection
+            assertEquals("명동", result.searchKeyword)
+            assertEquals(
+                listOf(
+                    "서울특별시 중구 명동",
+                    "충청북도 제천시 명동",
+                    "경상남도 창원시 진해구 명동",
+                ),
+                result.candidates.map { candidate -> candidate.displayName },
+            )
+        }
+
+    @Test
+    fun `시도 시군구 동 입력은 후보를 좁혀 바로 검색 결과를 반환한다`() =
+        runSuspendTest {
+            val result = useCase("서울 중구 명동")
+
+            assertTrue(result is MapRegionSearchCandidateResult.ReadyToSearch)
+            result as MapRegionSearchCandidateResult.ReadyToSearch
+            assertEquals("명동", result.searchKeyword)
+            assertEquals("서울특별시 중구 명동", result.selectedCandidate?.displayName)
+            assertEquals(listOf("명동", "명동1가", "명동2가"), result.selectedCandidate?.searchKeywords)
+        }
+
+    @Test
+    fun `구 동 입력은 후보를 좁혀 바로 검색 결과를 반환한다`() =
+        runSuspendTest {
+            val result = useCase("성동구 금호동")
+
+            assertTrue(result is MapRegionSearchCandidateResult.ReadyToSearch)
+            result as MapRegionSearchCandidateResult.ReadyToSearch
+            assertEquals("금호동", result.searchKeyword)
+            assertEquals("서울특별시 성동구 금호동", result.selectedCandidate?.displayName)
+        }
+
+    @Test
+    fun `후보가 1개이면 선택 UI 없이 바로 검색 결과를 반환한다`() =
+        runSuspendTest {
+            val result = useCase("문래동")
+
+            assertTrue(result is MapRegionSearchCandidateResult.ReadyToSearch)
+            result as MapRegionSearchCandidateResult.ReadyToSearch
+            assertEquals("문래동", result.searchKeyword)
+            assertEquals("서울특별시 영등포구 문래동", result.selectedCandidate?.displayName)
+        }
+
+    @Test
+    fun `후보가 없으면 기존 검색 흐름을 유지한다`() =
+        runSuspendTest {
+            val result = useCase("없는동")
+
+            assertTrue(result is MapRegionSearchCandidateResult.ReadyToSearch)
+            result as MapRegionSearchCandidateResult.ReadyToSearch
+            assertEquals("없는동", result.searchKeyword)
+            assertEquals(null, result.selectedCandidate)
+        }
+
+    @Test
+    fun `지역 범위가 있지만 후보 데이터가 없으면 입력 범위로 후보를 보강한다`() =
+        runSuspendTest {
+            val result = useCase("대구 북구 금호동")
+
+            assertTrue(result is MapRegionSearchCandidateResult.ReadyToSearch)
+            result as MapRegionSearchCandidateResult.ReadyToSearch
+            assertEquals("금호동", result.searchKeyword)
+            assertEquals("대구광역시 북구 금호동", result.selectedCandidate?.displayName)
+        }
+
+    private fun runSuspendTest(block: suspend () -> Unit) {
+        kotlinx.coroutines.runBlocking {
+            block()
+        }
+    }
+
+    private class FakeRegionOptionsRepository(
+        private val eupmyeondongCandidates: Map<String, List<Region>> = emptyMap(),
+        private val legalDongKeywords: Map<String, List<String>> = emptyMap(),
+    ) : RegionOptionsRepository {
+        override suspend fun getSidoOptions(): List<String> = emptyList()
+
+        override suspend fun getSigunguOptions(sido: String): List<String> = emptyList()
+
+        override suspend fun getEupmyeondongOptions(
+            sido: String,
+            sigungu: String,
+        ): List<String> = emptyList()
+
+        override suspend fun findRegionsByEupmyeondongKeyword(keyword: String): List<Region> {
+            return eupmyeondongCandidates[keyword].orEmpty()
+        }
+
+        override suspend fun findLegalDongKeywordsByRegion(
+            region: Region,
+            keyword: String,
+        ): List<String> {
+            return legalDongKeywords[
+                listOf(
+                    region.sido.orEmpty(),
+                    region.sigungu.orEmpty(),
+                    region.eupmyeondong.orEmpty(),
+                    keyword,
+                ).joinToString("|")
+            ].orEmpty()
+        }
+
+        override suspend fun findRegionsBySigunguKeyword(keyword: String): List<Region> = emptyList()
+
+        override suspend fun normalizeRegionForRegionalGuide(region: Region): Region = region
+
+        override suspend fun findAdminDongCandidatesForLegalDong(region: Region): List<Region> = emptyList()
+    }
+}

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCaseTest.kt
@@ -1,8 +1,10 @@
 package com.team.yeogibeoryeo.domain.spot.usecase
 
+import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -103,6 +105,58 @@ class SearchCollectionSpotsByKeywordUseCaseTest {
             val result = useCase(keyword = "명동")
 
             assertEquals(emptyList<CollectionSpot>(), result)
+        }
+
+    @Test
+    fun `선택한 지역 후보와 명확히 다른 시도 결과는 제외한다`() =
+        runSuspendTest {
+            val seoulSpot = collectionSpot(
+                id = "seoul-myeongdong",
+                address = "서울특별시 중구 명동길 3",
+            )
+            val jecheonSpot = collectionSpot(
+                id = "jecheon-myeongdong",
+                address = "충청북도 제천시 명동 1",
+            )
+            repository.keywordSpots = listOf(seoulSpot, jecheonSpot)
+
+            val result = useCase(
+                keyword = "명동",
+                selectedRegionCandidate = MapRegionSearchCandidate(
+                    region = Region(
+                        sido = "서울특별시",
+                        sigungu = "중구",
+                        eupmyeondong = "명동",
+                    ),
+                    searchKeyword = "명동",
+                ),
+            )
+
+            assertEquals(listOf(seoulSpot), result)
+        }
+
+    @Test
+    fun `선택 지역 후보가 있어도 지역 범위가 불명확한 도로명 주소 결과는 유지한다`() =
+        runSuspendTest {
+            val roadAddressSpot = collectionSpot(
+                id = "road-address",
+                address = "명동길 3",
+            )
+            repository.keywordSpots = listOf(roadAddressSpot)
+
+            val result = useCase(
+                keyword = "명동",
+                selectedRegionCandidate = MapRegionSearchCandidate(
+                    region = Region(
+                        sido = "서울특별시",
+                        sigungu = "중구",
+                        eupmyeondong = "명동",
+                    ),
+                    searchKeyword = "명동",
+                ),
+            )
+
+            assertEquals(listOf(roadAddressSpot), result)
         }
 
     private fun runSuspendTest(block: suspend () -> Unit) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -39,6 +39,7 @@ import com.naver.maps.map.compose.LocationTrackingMode
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
 import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.map.components.CollectionSpotNaverMap
 import com.team.yeogibeoryeo.presentation.map.components.MapSearchLoadingOverlay
@@ -141,6 +142,7 @@ fun CollectionSpotMapScreen(
         },
         onKeywordChanged = viewModel::onSearchKeywordChanged,
         onSearchClick = viewModel::searchByKeyword,
+        onRegionCandidateClick = viewModel::onRegionSearchCandidateClick,
         onCurrentLocationClick = {
             requestCurrentLocationSearch()
         },
@@ -166,6 +168,7 @@ private fun CollectionSpotMapContent(
     onLocationTrackingModeChange: (LocationTrackingMode) -> Unit,
     onKeywordChanged: (String) -> Unit,
     onSearchClick: () -> Unit,
+    onRegionCandidateClick: (MapRegionSearchCandidate) -> Unit,
     onCurrentLocationClick: () -> Unit,
     onMapCenterSearchClick: (Coordinate) -> Unit,
     onLocationNoticeActionClick: (MapLocationNoticeAction) -> Unit,
@@ -193,6 +196,7 @@ private fun CollectionSpotMapContent(
     val selectedSpotMoveRequestSequence = uiState.favoriteSpotMoveRequestSequence
     val hasNoticeOrError = uiState.locationNotice != null ||
         uiState.errorMessageResId != null
+    val hasRegionCandidates = uiState.regionSearchCandidates.isNotEmpty()
     val isNoticeOrErrorOnly = hasNoticeOrError &&
         uiState.spots.isEmpty() &&
         selectedSpot == null
@@ -201,7 +205,9 @@ private fun CollectionSpotMapContent(
         locationTrackingMode == LocationTrackingMode.None -> LocationTrackingMode.NoFollow
         else -> locationTrackingMode
     }
-    val hasResultListToReturn = uiState.hasSearched || uiState.spots.isNotEmpty()
+    val hasResultListToReturn = uiState.hasSearched ||
+        uiState.spots.isNotEmpty() ||
+        hasRegionCandidates
 
     BackHandler(enabled = mapUiMode == MapUiMode.SpotDetail && selectedSpot != null) {
         onSpotDetailDismiss()
@@ -226,8 +232,14 @@ private fun CollectionSpotMapContent(
         uiState.searchMode,
         uiState.errorMessageResId,
         uiState.locationNotice,
+        uiState.regionSearchCandidates,
     ) {
         when {
+            hasRegionCandidates -> {
+                mapUiMode = MapUiMode.ResultList
+                sheetLevel = MapSheetLevel.Half
+            }
+
             isSpotSearchLoading -> {
                 mapUiMode = MapUiMode.Browsing
                 sheetLevel = MapSheetLevel.Hidden
@@ -433,9 +445,11 @@ private fun CollectionSpotMapContent(
                             isLoading = uiState.isLoading || uiState.isFavoriteSpotNearbyLoading,
                             hasSearched = uiState.hasSearched,
                             selectedTypes = uiState.selectedTypes,
+                            regionSearchCandidates = uiState.regionSearchCandidates,
                             locationNotice = uiState.locationNotice,
                             errorMessageResId = uiState.errorMessageResId,
                             onTypeClick = onTypeClick,
+                            onRegionCandidateClick = onRegionCandidateClick,
                             onLocationNoticeActionClick = onLocationNoticeActionClick,
                             onSpotFavoriteClick = onSpotFavoriteClick,
                             onSpotClick = { spot ->
@@ -460,6 +474,7 @@ private val CollectionSpotMapUiState.shouldShowBottomSheet: Boolean
     get() = isLoading ||
         locationNotice != null ||
         errorMessageResId != null ||
+        regionSearchCandidates.isNotEmpty() ||
         hasSearched ||
         spots.isNotEmpty() ||
         selectedSpot != null
@@ -500,6 +515,7 @@ private fun CollectionSpotMapContentPreview() {
                 onLocationTrackingModeChange = {},
                 onKeywordChanged = {},
                 onSearchClick = {},
+                onRegionCandidateClick = {},
                 onCurrentLocationClick = {},
                 onMapCenterSearchClick = {},
                 onLocationNoticeActionClick = {},

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapUiState.kt
@@ -3,11 +3,13 @@ package com.team.yeogibeoryeo.presentation.map
 import androidx.annotation.StringRes
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
 
 data class CollectionSpotMapUiState(
     val searchKeyword: String = "",
     val searchMode: MapSearchMode = MapSearchMode.KEYWORD,
     val spots: List<CollectionSpot> = emptyList(),
+    val regionSearchCandidates: List<MapRegionSearchCandidate> = emptyList(),
     val selectedSpot: CollectionSpot? = null,
     val selectedTypes: Set<CollectionSpotType> = emptySet(),
     val isLoading: Boolean = false,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -9,10 +9,13 @@ import com.team.yeogibeoryeo.domain.favorite.usecase.ToggleCollectionSpotFavorit
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
+import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidateResult
 import com.team.yeogibeoryeo.domain.spot.usecase.CalculateDistanceMeterUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.ClearRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.GetFreshRecentCurrentLocationSpotsUseCase
+import com.team.yeogibeoryeo.domain.spot.usecase.ResolveMapRegionSearchCandidateUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SaveRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByKeywordUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByLocationUseCase
@@ -33,6 +36,7 @@ import kotlinx.coroutines.launch
 
 @HiltViewModel
 class CollectionSpotMapViewModel @Inject constructor(
+    private val resolveMapRegionSearchCandidateUseCase: ResolveMapRegionSearchCandidateUseCase,
     private val searchCollectionSpotsByKeywordUseCase: SearchCollectionSpotsByKeywordUseCase,
     private val searchCollectionSpotsByLocationUseCase: SearchCollectionSpotsByLocationUseCase,
     private val filterCollectionSpotsUseCase: FilterCollectionSpotsUseCase,
@@ -87,6 +91,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 } else {
                     it.spots
                 },
+                regionSearchCandidates = emptyList(),
                 selectedSpot = if (shouldCancelSpotSearch) {
                     null
                 } else {
@@ -130,6 +135,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     hasSearched = false,
                     errorMessageResId = R.string.map_search_blank_keyword_message,
                     locationNotice = null,
+                    regionSearchCandidates = emptyList(),
                     isFavoriteSpotNearbyLoading = false,
                     searchMode = MapSearchMode.KEYWORD,
                 )
@@ -139,12 +145,49 @@ class CollectionSpotMapViewModel @Inject constructor(
 
         spotSearchJob?.cancel()
         spotSearchJob = viewModelScope.launch {
+            when (val candidateResult = resolveMapRegionSearchCandidateUseCase(keyword)) {
+                is MapRegionSearchCandidateResult.NeedSelection -> {
+                    showRegionSearchCandidates(candidateResult.candidates)
+                }
+
+                is MapRegionSearchCandidateResult.ReadyToSearch -> {
+                    searchByKeywordInternal(
+                        keyword = candidateResult.searchKeyword,
+                        selectedRegionCandidate = candidateResult.selectedCandidate,
+                    )
+                }
+            }
+        }
+    }
+
+    fun onRegionSearchCandidateClick(candidate: MapRegionSearchCandidate) {
+        currentLocationRefreshJob?.cancel()
+        spotSearchJob?.cancel()
+        spotSearchJob = viewModelScope.launch {
+            searchByKeywordInternal(
+                keyword = candidate.searchKeyword,
+                selectedRegionCandidate = candidate,
+            )
+        }
+    }
+
+    fun clearRegionSearchCandidates() {
+        _uiState.update {
+            it.copy(regionSearchCandidates = emptyList())
+        }
+    }
+
+    private suspend fun searchByKeywordInternal(
+        keyword: String,
+        selectedRegionCandidate: MapRegionSearchCandidate?,
+    ) {
             _uiState.update {
                 it.copy(
                     isLoading = true,
                     hasSearched = true,
                     errorMessageResId = null,
                     locationNotice = null,
+                    regionSearchCandidates = emptyList(),
                     selectedSpot = null,
                     isFavoriteSpotNearbyLoading = false,
                     searchMode = MapSearchMode.KEYWORD,
@@ -152,9 +195,9 @@ class CollectionSpotMapViewModel @Inject constructor(
             }
 
             runCatching {
-                searchCollectionSpotsByKeywordUseCase(
+                searchByCandidateKeywords(
                     keyword = keyword,
-                    types = emptySet(),
+                    selectedRegionCandidate = selectedRegionCandidate,
                 )
             }.onSuccess { spots ->
                 updateSpotResult(spots)
@@ -165,6 +208,43 @@ class CollectionSpotMapViewModel @Inject constructor(
                     messageResId = MapLocationNotices.SpotSearchFailureMessageResId,
                 )
             }
+    }
+
+    private suspend fun searchByCandidateKeywords(
+        keyword: String,
+        selectedRegionCandidate: MapRegionSearchCandidate?,
+    ): List<CollectionSpot> {
+        val searchKeywords = selectedRegionCandidate
+            ?.searchKeywords
+            ?.takeIf { keywords -> keywords.isNotEmpty() }
+            ?: listOf(keyword)
+
+        return searchKeywords
+            .flatMap { searchKeyword ->
+                searchCollectionSpotsByKeywordUseCase(
+                    keyword = searchKeyword,
+                    types = emptySet(),
+                    selectedRegionCandidate = selectedRegionCandidate,
+                )
+            }
+            .distinctBy { spot -> spot.id }
+    }
+
+    private fun showRegionSearchCandidates(candidates: List<MapRegionSearchCandidate>) {
+        originalSpots = emptyList()
+
+        _uiState.update {
+            it.copy(
+                spots = emptyList(),
+                regionSearchCandidates = candidates,
+                selectedSpot = null,
+                isLoading = false,
+                hasSearched = false,
+                errorMessageResId = null,
+                locationNotice = null,
+                isFavoriteSpotNearbyLoading = false,
+                searchMode = MapSearchMode.KEYWORD,
+            )
         }
     }
 
@@ -202,6 +282,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     hasSearched = true,
                     errorMessageResId = null,
                     locationNotice = null,
+                    regionSearchCandidates = emptyList(),
                     selectedSpot = null,
                     isFavoriteSpotNearbyLoading = false,
                     searchMode = MapSearchMode.MAP_CENTER,
@@ -308,6 +389,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isLoading = false,
                 errorMessageResId = null,
                 locationNotice = null,
+                regionSearchCandidates = emptyList(),
                 favoriteSpotMoveRequestId = request.targetId,
                 favoriteSpotMoveRequestSequence = it.favoriteSpotMoveRequestSequence + 1,
                 isFavoriteSpotNearbyLoading = true,
@@ -359,6 +441,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 hasSearched = false,
                 errorMessageResId = null,
                 locationNotice = MapLocationNotices.PermissionDenied,
+                regionSearchCandidates = emptyList(),
                 isFavoriteSpotNearbyLoading = false,
                 searchMode = MapSearchMode.KEYWORD,
             )
@@ -441,6 +524,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 hasSearched = false,
                 errorMessageResId = null,
                 locationNotice = MapLocationNotices.CurrentLocationUnavailable,
+                regionSearchCandidates = emptyList(),
                 isFavoriteSpotNearbyLoading = false,
                 searchMode = MapSearchMode.KEYWORD,
             )
@@ -458,6 +542,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 hasSearched = false,
                 errorMessageResId = null,
                 locationNotice = MapLocationNotices.LocationServiceDisabled,
+                regionSearchCandidates = emptyList(),
                 isFavoriteSpotNearbyLoading = false,
                 searchMode = MapSearchMode.KEYWORD,
             )
@@ -480,6 +565,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 hasSearched = true,
                 errorMessageResId = null,
                 locationNotice = null,
+                regionSearchCandidates = emptyList(),
                 isFavoriteSpotNearbyLoading = false,
             )
         }
@@ -517,6 +603,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                         hasSearched = true,
                         errorMessageResId = null,
                         locationNotice = null,
+                        regionSearchCandidates = emptyList(),
                         searchMode = MapSearchMode.CURRENT_LOCATION,
                     )
                 }
@@ -541,6 +628,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 hasSearched = true,
                 errorMessageResId = messageResId,
                 locationNotice = null,
+                regionSearchCandidates = emptyList(),
                 isFavoriteSpotNearbyLoading = false,
             )
         }
@@ -557,6 +645,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     hasSearched = true,
                     errorMessageResId = null,
                     locationNotice = null,
+                    regionSearchCandidates = emptyList(),
                     selectedSpot = null,
                     isFavoriteSpotNearbyLoading = false,
                     searchMode = MapSearchMode.CURRENT_LOCATION,
@@ -606,6 +695,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 hasSearched = true,
                 errorMessageResId = null,
                 locationNotice = null,
+                regionSearchCandidates = emptyList(),
                 isFavoriteSpotNearbyLoading = false,
                 searchMode = MapSearchMode.CURRENT_LOCATION,
             )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -144,6 +144,7 @@ class CollectionSpotMapViewModel @Inject constructor(
         }
 
         spotSearchJob?.cancel()
+        startKeywordSearchLoading()
         spotSearchJob = viewModelScope.launch {
             when (val candidateResult = resolveMapRegionSearchCandidateUseCase(keyword)) {
                 is MapRegionSearchCandidateResult.NeedSelection -> {
@@ -171,43 +172,41 @@ class CollectionSpotMapViewModel @Inject constructor(
         }
     }
 
-    fun clearRegionSearchCandidates() {
-        _uiState.update {
-            it.copy(regionSearchCandidates = emptyList())
-        }
-    }
-
     private suspend fun searchByKeywordInternal(
         keyword: String,
         selectedRegionCandidate: MapRegionSearchCandidate?,
     ) {
-            _uiState.update {
-                it.copy(
-                    isLoading = true,
-                    hasSearched = true,
-                    errorMessageResId = null,
-                    locationNotice = null,
-                    regionSearchCandidates = emptyList(),
-                    selectedSpot = null,
-                    isFavoriteSpotNearbyLoading = false,
-                    searchMode = MapSearchMode.KEYWORD,
-                )
-            }
+        startKeywordSearchLoading()
 
-            runCatching {
-                searchByCandidateKeywords(
-                    keyword = keyword,
-                    selectedRegionCandidate = selectedRegionCandidate,
-                )
-            }.onSuccess { spots ->
-                updateSpotResult(spots)
-            }.onFailure { throwable ->
-                if (throwable is CancellationException) throw throwable
+        runCatching {
+            searchByCandidateKeywords(
+                keyword = keyword,
+                selectedRegionCandidate = selectedRegionCandidate,
+            )
+        }.onSuccess { spots ->
+            updateSpotResult(spots)
+        }.onFailure { throwable ->
+            if (throwable is CancellationException) throw throwable
 
-                updateSpotFailure(
-                    messageResId = MapLocationNotices.SpotSearchFailureMessageResId,
-                )
-            }
+            updateSpotFailure(
+                messageResId = MapLocationNotices.SpotSearchFailureMessageResId,
+            )
+        }
+    }
+
+    private fun startKeywordSearchLoading() {
+        _uiState.update {
+            it.copy(
+                isLoading = true,
+                hasSearched = true,
+                errorMessageResId = null,
+                locationNotice = null,
+                regionSearchCandidates = emptyList(),
+                selectedSpot = null,
+                isFavoriteSpotNearbyLoading = false,
+                searchMode = MapSearchMode.KEYWORD,
+            )
+        }
     }
 
     private suspend fun searchByCandidateKeywords(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
@@ -1,7 +1,7 @@
 package com.team.yeogibeoryeo.presentation.map.components
 
-import androidx.compose.foundation.clickable
 import androidx.annotation.StringRes
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
@@ -23,8 +25,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
 import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.map.MapLocationNotice
 import com.team.yeogibeoryeo.presentation.map.MapLocationNoticeAction
@@ -36,9 +40,11 @@ fun SpotBottomSheetContent(
     isLoading: Boolean,
     hasSearched: Boolean,
     selectedTypes: Set<CollectionSpotType>,
+    regionSearchCandidates: List<MapRegionSearchCandidate>,
     locationNotice: MapLocationNotice?,
     @StringRes errorMessageResId: Int?,
     onTypeClick: (CollectionSpotType) -> Unit,
+    onRegionCandidateClick: (MapRegionSearchCandidate) -> Unit,
     onLocationNoticeActionClick: (MapLocationNoticeAction) -> Unit,
     onSpotClick: (CollectionSpot) -> Unit,
     onSpotFavoriteClick: (CollectionSpot) -> Unit,
@@ -56,7 +62,12 @@ fun SpotBottomSheetContent(
             hasSearched = hasSearched,
         )
 
-        if (hasSearched && !isLoading && !hasNoticeOrError) {
+        if (
+            hasSearched &&
+            !isLoading &&
+            !hasNoticeOrError &&
+            regionSearchCandidates.isEmpty()
+        ) {
             SpotFilterChipRow(
                 types = MapSpotFilterChipPolicy.visibleTypes,
                 selectedTypes = selectedTypes,
@@ -68,6 +79,16 @@ fun SpotBottomSheetContent(
         when {
             isLoading -> {
                 SpotBottomSheetLoading()
+            }
+
+            regionSearchCandidates.isNotEmpty() -> {
+                MapRegionCandidateSelection(
+                    candidates = regionSearchCandidates,
+                    onCandidateClick = onRegionCandidateClick,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                )
             }
 
             locationNotice != null -> {
@@ -105,6 +126,72 @@ fun SpotBottomSheetContent(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun MapRegionCandidateSelection(
+    candidates: List<MapRegionSearchCandidate>,
+    onCandidateClick: (MapRegionSearchCandidate) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+            .padding(top = 18.dp, bottom = 8.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.map_region_candidate_title),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = stringResource(R.string.map_region_candidate_description),
+            modifier = Modifier.padding(top = 6.dp, bottom = 12.dp),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f, fill = false),
+        ) {
+            items(
+                items = candidates,
+                key = { candidate -> candidate.displayName },
+            ) { candidate ->
+                RegionCandidateRow(
+                    candidate = candidate,
+                    onClick = { onCandidateClick(candidate) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RegionCandidateRow(
+    candidate: MapRegionSearchCandidate,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 14.dp),
+    ) {
+        Text(
+            text = candidate.displayName,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        HorizontalDivider(
+            modifier = Modifier.padding(top = 14.dp),
+            color = MaterialTheme.colorScheme.outlineVariant,
+        )
     }
 }
 
@@ -226,9 +313,11 @@ private fun SpotBottomSheetContentPreview() {
                 isLoading = false,
                 hasSearched = true,
                 selectedTypes = setOf(CollectionSpotType.BATTERY_BIN),
+                regionSearchCandidates = emptyList(),
                 locationNotice = null,
                 errorMessageResId = null,
                 onTypeClick = {},
+                onRegionCandidateClick = {},
                 onLocationNoticeActionClick = {},
                 onSpotClick = {},
                 onSpotFavoriteClick = {},
@@ -248,9 +337,11 @@ private fun SpotBottomSheetContentLoadingPreview() {
                 isLoading = true,
                 hasSearched = true,
                 selectedTypes = emptySet(),
+                regionSearchCandidates = emptyList(),
                 locationNotice = null,
                 errorMessageResId = null,
                 onTypeClick = {},
+                onRegionCandidateClick = {},
                 onLocationNoticeActionClick = {},
                 onSpotClick = {},
                 onSpotFavoriteClick = {},
@@ -270,9 +361,60 @@ private fun SpotBottomSheetContentEmptyPreview() {
                 isLoading = false,
                 hasSearched = true,
                 selectedTypes = emptySet(),
+                regionSearchCandidates = emptyList(),
                 locationNotice = null,
                 errorMessageResId = null,
                 onTypeClick = {},
+                onRegionCandidateClick = {},
+                onLocationNoticeActionClick = {},
+                onSpotClick = {},
+                onSpotFavoriteClick = {},
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SpotBottomSheetContentRegionCandidatePreview() {
+    MaterialTheme {
+        Surface {
+            SpotBottomSheetContent(
+                spots = emptyList(),
+                selectedSpot = null,
+                isLoading = false,
+                hasSearched = false,
+                selectedTypes = emptySet(),
+                regionSearchCandidates = listOf(
+                    MapRegionSearchCandidate(
+                        region = Region(
+                            sido = "서울특별시",
+                            sigungu = "중구",
+                            eupmyeondong = "명동",
+                        ),
+                        searchKeyword = "명동",
+                    ),
+                    MapRegionSearchCandidate(
+                        region = Region(
+                            sido = "충청북도",
+                            sigungu = "제천시",
+                            eupmyeondong = "명동",
+                        ),
+                        searchKeyword = "명동",
+                    ),
+                    MapRegionSearchCandidate(
+                        region = Region(
+                            sido = "경상남도",
+                            sigungu = "창원시 진해구",
+                            eupmyeondong = "명동",
+                        ),
+                        searchKeyword = "명동",
+                    ),
+                ),
+                locationNotice = null,
+                errorMessageResId = null,
+                onTypeClick = {},
+                onRegionCandidateClick = {},
                 onLocationNoticeActionClick = {},
                 onSpotClick = {},
                 onSpotFavoriteClick = {},

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -216,6 +216,8 @@ SOFTWARE.]]></string>
     <string name="map_current_location_spot_search_failure_message">네트워크 연결을 확인한 뒤 다시 시도하거나 직접 동/읍/면을 검색해 주세요.</string>
     <string name="map_spot_search_title">수거 장소 검색</string>
     <string name="map_spot_result_count">검색 결과 %1$d개</string>
+    <string name="map_region_candidate_title">지역을 선택해주세요</string>
+    <string name="map_region_candidate_description">같은 이름의 지역이 여러 곳 있어요.</string>
     <string name="map_empty_spot_result_title">검색 결과가 없습니다.</string>
     <string name="map_empty_spot_result_description">동/읍/면 이름으로 다시 검색해 주세요.\n예: 문래동, 역삼동</string>
     <string name="map_location_permission_denied_title">위치 권한이 필요합니다.</string>

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapSearchViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapSearchViewModelTest.kt
@@ -272,6 +272,48 @@ class CollectionSpotMapSearchViewModelTest : CollectionSpotMapViewModelTestFixtu
         }
 
     @Test
+    fun `지역 후보 조회 중 검색어를 수정하면 이전 후보 조회를 취소한다`() =
+        runTest {
+            val repository = FakeCollectionSpotRepository()
+            val candidateSearchResult = CompletableDeferred<List<Region>>()
+            val regionOptionsRepository = FakeMapRegionOptionsRepository(
+                eupmyeondongCandidateProvider = { keyword ->
+                    if (keyword == "명동") {
+                        candidateSearchResult.await()
+                    } else {
+                        emptyList()
+                    }
+                },
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+                regionOptionsRepository = regionOptionsRepository,
+            )
+
+            viewModel.onSearchKeywordChanged("명동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            assertEquals(true, viewModel.uiState.value.isLoading)
+            assertEquals(MapSearchMode.KEYWORD, viewModel.uiState.value.searchMode)
+
+            viewModel.onSearchKeywordChanged("명동1가")
+            candidateSearchResult.complete(
+                listOf(
+                    Region(sido = "서울특별시", sigungu = "중구", eupmyeondong = "명동"),
+                    Region(sido = "충청북도", sigungu = "제천시", eupmyeondong = "명동"),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals("명동1가", viewModel.uiState.value.searchKeyword)
+            assertEquals(emptyList<MapRegionSearchCandidate>(), viewModel.uiState.value.regionSearchCandidates)
+            assertEquals(false, viewModel.uiState.value.isLoading)
+            assertEquals(false, viewModel.uiState.value.hasSearched)
+        }
+
+    @Test
     fun `지도 중심 검색은 전달된 카메라 중심 좌표로 수거 장소를 검색한다`() =
         runTest {
             val mapCenterCoordinate = Coordinate(latitude = 37.5701, longitude = 127.0012)

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapSearchViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapSearchViewModelTest.kt
@@ -1,8 +1,10 @@
 package com.team.yeogibeoryeo.presentation.map
 
+import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationResult
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -18,7 +20,10 @@ class CollectionSpotMapSearchViewModelTest : CollectionSpotMapViewModelTestFixtu
     @Test
     fun `성동구 금호동 입력 시 금호동으로 보정해 키워드 검색을 요청한다`() =
         runTest {
-            val expectedSpots = listOf(sampleSpot("geumho", CollectionSpotType.BATTERY_BIN))
+            val expectedSpots = listOf(
+                sampleSpot("geumho", CollectionSpotType.BATTERY_BIN)
+                    .copy(address = "서울특별시 성동구 금호동")
+            )
             val repository = FakeCollectionSpotRepository(
                 keywordSpots = expectedSpots,
             )
@@ -128,6 +133,142 @@ class CollectionSpotMapSearchViewModelTest : CollectionSpotMapViewModelTestFixtu
 
             assertEquals(listOf("명동"), repository.keywords)
             assertEquals(listOf(myeongDongSpot), viewModel.uiState.value.spots)
+        }
+
+    @Test
+    fun `동 단독 검색어에 여러 지역 후보가 있으면 검색 대신 후보 목록을 표시한다`() =
+        runTest {
+            val repository = FakeCollectionSpotRepository()
+            val regionOptionsRepository = FakeMapRegionOptionsRepository(
+                eupmyeondongCandidates = mapOf(
+                    "명동" to listOf(
+                        Region(sido = "서울특별시", sigungu = "중구", eupmyeondong = "명동"),
+                        Region(sido = "충청북도", sigungu = "제천시", eupmyeondong = "명동"),
+                    ),
+                ),
+                legalDongKeywords = mapOf(
+                    "서울특별시|중구|명동|명동" to listOf("명동1가", "명동2가"),
+                ),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+                regionOptionsRepository = regionOptionsRepository,
+            )
+
+            viewModel.onSearchKeywordChanged("명동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            assertEquals(emptyList<String>(), repository.keywords)
+            assertEquals(
+                listOf("서울특별시 중구 명동", "충청북도 제천시 명동"),
+                viewModel.uiState.value.regionSearchCandidates.map { candidate -> candidate.displayName },
+            )
+            assertFalse(viewModel.uiState.value.hasSearched)
+        }
+
+    @Test
+    fun `지역 후보를 선택하면 선택한 동 검색어로 검색을 요청한다`() =
+        runTest {
+            val seoulSpot = sampleSpot("seoul-myeongdong", CollectionSpotType.STANDARD_BAG_STORE)
+                .copy(address = "서울특별시 중구 명동길 3")
+            val jecheonSpot = sampleSpot("jecheon-myeongdong", CollectionSpotType.STANDARD_BAG_STORE)
+                .copy(address = "충청북도 제천시 명동 1")
+            val repository = FakeCollectionSpotRepository(
+                keywordSpots = listOf(seoulSpot, jecheonSpot),
+            )
+            val regionOptionsRepository = FakeMapRegionOptionsRepository(
+                eupmyeondongCandidates = mapOf(
+                    "명동" to listOf(
+                        Region(sido = "서울특별시", sigungu = "중구", eupmyeondong = "명동"),
+                        Region(sido = "충청북도", sigungu = "제천시", eupmyeondong = "명동"),
+                    ),
+                ),
+                legalDongKeywords = mapOf(
+                    "서울특별시|중구|명동|명동" to listOf("명동1가", "명동2가"),
+                ),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+                regionOptionsRepository = regionOptionsRepository,
+            )
+
+            viewModel.onSearchKeywordChanged("명동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            val candidate = viewModel.uiState.value.regionSearchCandidates.first()
+            viewModel.onRegionSearchCandidateClick(candidate)
+            advanceUntilIdle()
+
+            assertEquals(listOf("명동", "명동1가", "명동2가"), repository.keywords)
+            assertEquals(emptyList<MapRegionSearchCandidate>(), viewModel.uiState.value.regionSearchCandidates)
+            assertEquals(listOf(seoulSpot), viewModel.uiState.value.spots)
+            assertEquals("명동", viewModel.uiState.value.searchKeyword)
+        }
+
+    @Test
+    fun `지역 범위가 포함된 동 검색어는 후보를 좁혀 바로 검색한다`() =
+        runTest {
+            val expectedSpot = sampleSpot("seoul-myeongdong", CollectionSpotType.STANDARD_BAG_STORE)
+                .copy(address = "서울특별시 중구 명동길 3")
+            val repository = FakeCollectionSpotRepository(
+                keywordSpots = listOf(expectedSpot),
+            )
+            val regionOptionsRepository = FakeMapRegionOptionsRepository(
+                eupmyeondongCandidates = mapOf(
+                    "명동" to listOf(
+                        Region(sido = "서울특별시", sigungu = "중구", eupmyeondong = "명동"),
+                        Region(sido = "충청북도", sigungu = "제천시", eupmyeondong = "명동"),
+                    ),
+                ),
+                legalDongKeywords = mapOf(
+                    "서울특별시|중구|명동|명동" to listOf("명동1가", "명동2가"),
+                ),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+                regionOptionsRepository = regionOptionsRepository,
+            )
+
+            viewModel.onSearchKeywordChanged("서울 중구 명동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            assertEquals(listOf("명동", "명동1가", "명동2가"), repository.keywords)
+            assertEquals(emptyList<MapRegionSearchCandidate>(), viewModel.uiState.value.regionSearchCandidates)
+            assertEquals(expectedSpot, viewModel.uiState.value.spots.single())
+        }
+
+    @Test
+    fun `검색어를 수정하면 표시 중인 지역 후보 목록을 닫는다`() =
+        runTest {
+            val repository = FakeCollectionSpotRepository()
+            val regionOptionsRepository = FakeMapRegionOptionsRepository(
+                eupmyeondongCandidates = mapOf(
+                    "명동" to listOf(
+                        Region(sido = "서울특별시", sigungu = "중구", eupmyeondong = "명동"),
+                        Region(sido = "충청북도", sigungu = "제천시", eupmyeondong = "명동"),
+                    ),
+                ),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+                regionOptionsRepository = regionOptionsRepository,
+            )
+
+            viewModel.onSearchKeywordChanged("명동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            viewModel.onSearchKeywordChanged("명동1가")
+
+            assertEquals(emptyList<MapRegionSearchCandidate>(), viewModel.uiState.value.regionSearchCandidates)
+            assertEquals("명동1가", viewModel.uiState.value.searchKeyword)
         }
 
     @Test

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTestFixture.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTestFixture.kt
@@ -257,6 +257,7 @@ internal class FakeCollectionSpotRepository(
 internal class FakeMapRegionOptionsRepository(
     private val eupmyeondongCandidates: Map<String, List<Region>> = emptyMap(),
     private val legalDongKeywords: Map<String, List<String>> = emptyMap(),
+    private val eupmyeondongCandidateProvider: (suspend (String) -> List<Region>)? = null,
 ) : RegionOptionsRepository {
     val eupmyeondongKeywords = mutableListOf<String>()
 
@@ -271,6 +272,7 @@ internal class FakeMapRegionOptionsRepository(
 
     override suspend fun findRegionsByEupmyeondongKeyword(keyword: String): List<Region> {
         eupmyeondongKeywords += keyword
+        eupmyeondongCandidateProvider?.let { provider -> return provider(keyword) }
         return eupmyeondongCandidates[keyword].orEmpty()
     }
 

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTestFixture.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTestFixture.kt
@@ -9,6 +9,8 @@ import com.team.yeogibeoryeo.domain.favorite.repository.CollectionSpotFavoriteSn
 import com.team.yeogibeoryeo.domain.favorite.repository.FavoriteRepository
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.ToggleCollectionSpotFavoriteUseCase
+import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.region.repository.RegionOptionsRepository
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
@@ -20,6 +22,7 @@ import com.team.yeogibeoryeo.domain.spot.usecase.ClearRecentCurrentLocationSpots
 import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.GetFreshRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.NormalizeCollectionSpotSearchKeywordUseCase
+import com.team.yeogibeoryeo.domain.spot.usecase.ResolveMapRegionSearchCandidateUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SaveRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByKeywordUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.SearchCollectionSpotsByLocationUseCase
@@ -47,6 +50,7 @@ internal fun createViewModel(
         FakeRecentCurrentLocationSpotCacheRepository(),
     timeProvider: TimeProvider = FakeTimeProvider(),
     favoriteRepository: FakeFavoriteRepository = FakeFavoriteRepository(),
+    regionOptionsRepository: FakeMapRegionOptionsRepository = FakeMapRegionOptionsRepository(),
     snapshotRepository: FakeCollectionSpotFavoriteSnapshotRepository =
         FakeCollectionSpotFavoriteSnapshotRepository(),
 ): CollectionSpotMapViewModel {
@@ -57,6 +61,7 @@ internal fun createViewModel(
         recentCurrentLocationSpotCacheRepository = recentCurrentLocationSpotCacheRepository,
         timeProvider = timeProvider,
         favoriteRepository = favoriteRepository,
+        regionOptionsRepository = regionOptionsRepository,
         snapshotRepository = snapshotRepository,
     )
 }
@@ -69,13 +74,20 @@ internal fun createViewModel(
         FakeRecentCurrentLocationSpotCacheRepository(),
     timeProvider: TimeProvider = FakeTimeProvider(),
     favoriteRepository: FakeFavoriteRepository = FakeFavoriteRepository(),
+    regionOptionsRepository: FakeMapRegionOptionsRepository = FakeMapRegionOptionsRepository(),
     snapshotRepository: FakeCollectionSpotFavoriteSnapshotRepository =
         FakeCollectionSpotFavoriteSnapshotRepository(),
 ): CollectionSpotMapViewModel {
+    val normalizeKeywordUseCase = NormalizeCollectionSpotSearchKeywordUseCase()
+
     return CollectionSpotMapViewModel(
+        resolveMapRegionSearchCandidateUseCase = ResolveMapRegionSearchCandidateUseCase(
+            regionOptionsRepository = regionOptionsRepository,
+            normalizeKeywordUseCase = normalizeKeywordUseCase,
+        ),
         searchCollectionSpotsByKeywordUseCase = SearchCollectionSpotsByKeywordUseCase(
             repository = repository,
-            normalizeKeywordUseCase = NormalizeCollectionSpotSearchKeywordUseCase(),
+            normalizeKeywordUseCase = normalizeKeywordUseCase,
         ),
         searchCollectionSpotsByLocationUseCase = SearchCollectionSpotsByLocationUseCase(repository),
         filterCollectionSpotsUseCase = FilterCollectionSpotsUseCase(),
@@ -240,6 +252,47 @@ internal class FakeCollectionSpotRepository(
     }
 
     override suspend fun geocodeSpot(spot: CollectionSpot): CollectionSpot = spot
+}
+
+internal class FakeMapRegionOptionsRepository(
+    private val eupmyeondongCandidates: Map<String, List<Region>> = emptyMap(),
+    private val legalDongKeywords: Map<String, List<String>> = emptyMap(),
+) : RegionOptionsRepository {
+    val eupmyeondongKeywords = mutableListOf<String>()
+
+    override suspend fun getSidoOptions(): List<String> = emptyList()
+
+    override suspend fun getSigunguOptions(sido: String): List<String> = emptyList()
+
+    override suspend fun getEupmyeondongOptions(
+        sido: String,
+        sigungu: String,
+    ): List<String> = emptyList()
+
+    override suspend fun findRegionsByEupmyeondongKeyword(keyword: String): List<Region> {
+        eupmyeondongKeywords += keyword
+        return eupmyeondongCandidates[keyword].orEmpty()
+    }
+
+    override suspend fun findLegalDongKeywordsByRegion(
+        region: Region,
+        keyword: String,
+    ): List<String> {
+        return legalDongKeywords[
+            listOf(
+                region.sido.orEmpty(),
+                region.sigungu.orEmpty(),
+                region.eupmyeondong.orEmpty(),
+                keyword,
+            ).joinToString("|")
+        ].orEmpty()
+    }
+
+    override suspend fun findRegionsBySigunguKeyword(keyword: String): List<Region> = emptyList()
+
+    override suspend fun normalizeRegionForRegionalGuide(region: Region): Region = region
+
+    override suspend fun findAdminDongCandidatesForLegalDong(region: Region): List<Region> = emptyList()
 }
 
 internal fun collectionSpotFavorite(targetId: String): Favorite =


### PR DESCRIPTION
## 작업 내용

지도 검색에서 `명동`, `금호동`처럼 동일한 동/읍/면 이름이 여러 지역에 존재하는 경우, 사용자가 원하는 지역을 직접 선택할 수 있도록 후보 선택 UX를 추가했습니다.

기존에는 `/getSpot addr` 검색이 동/읍/면 단위 검색어 중심으로 동작하다 보니, 사용자가 `금호동`, `명동`처럼 단독 동명을 입력하면 어느 지역을 의도한 것인지 앱이 판단하기 어려웠습니다.  
이번 작업에서는 지역 데이터 기반으로 후보를 먼저 확인하고, 후보가 여러 개인 경우 BottomSheet에서 지역을 선택한 뒤 해당 지역 기준으로 검색하도록 개선했습니다.

## 주요 변경 사항

- 동/읍/면 단독 검색어 입력 시 동일 동명 후보 목록 표시
  - 예: `금호동`, `명동`
- 시군구/시도 범위가 함께 입력된 경우 후보를 좁혀 바로 검색
  - 예: `성동구 금호동`
  - 예: `서울 중구 명동`
- 법정동 `n가` 검색 보완
  - 예: `서울 중구 명동` 검색 시 `명동1가`, `명동2가` 등 서울 중구 명동 일대 결과 조회
- 후보 선택 BottomSheet 노출 높이 조정
  - 후보가 있을 때 사용자가 선택이 필요하다는 것을 더 잘 인지할 수 있도록 개선
- 검색 결과 주소 기반 필터링 보완
  - 선택한 지역과 명확히 다른 동/읍/면 결과는 제외
  - 도로명 주소처럼 동 정보가 명확하지 않은 정상 결과는 유지
- 수거 장소 geocoding 주소 정제
  - `서울특별시 성동구 행당로 35 (금호동1가, 금북빌딩)`처럼 괄호가 포함된 주소는 좌표 보정 시 괄호 내용을 제거한 주소로 geocoding
  - 화면 표시 주소는 기존 원문 유지

## 동작 화면

### 동일 동명 후보 표시

| 금호동 검색 시 후보군 표시 | 명동 검색 시 후보군 표시 |
| --- | --- |
| <img width="320" alt="금호동 검색시 후보군 표시" src="https://github.com/user-attachments/assets/9b2eb48a-1e6e-4502-9571-01c0c0732d91" /> | <img width="320" alt="명동 검색시 후보군 표시" src="https://github.com/user-attachments/assets/5446c33d-26f2-4473-8f62-42ced52e2e53" /> |

`금호동`, `명동`처럼 동일한 이름의 지역이 여러 곳 존재하는 경우 바로 `/getSpot` 검색을 실행하지 않고, 먼저 지역 후보를 표시합니다.  
사용자는 원하는 지역을 선택한 뒤 해당 지역 기준으로 수거 장소를 조회할 수 있습니다.

### 지역 범위 포함 검색

| 성동구 금호동 검색 중 | 성동구 금호동 검색 결과 |
| --- | --- |
| <img width="320" alt="성동구 금호동으로 검색중" src="https://github.com/user-attachments/assets/3fa064c8-ffd5-483a-9e08-e69e2e9eff75" /> | <img width="320" alt="성동구 금호동 검색 결과" src="https://github.com/user-attachments/assets/c76aa436-aa25-4b37-8474-0f16c6a0c934" /> |

`성동구 금호동`처럼 시군구 범위가 함께 입력된 경우에는 후보 선택 UI를 불필요하게 노출하지 않고, 서울특별시 성동구 금호동 후보로 좁혀 검색합니다.

### 서울 중구 명동 검색

<img width="320" alt="서울 중구 명동 검색시 서울 명동일대 검색결과 표시" src="https://github.com/user-attachments/assets/ea45fc51-56cf-4b39-b07a-1e23ccdf088a" />

`서울 중구 명동`은 실제 검색 결과가 `명동1가`, `명동2가` 등 법정동 단위로 내려올 수 있어, 선택된 지역 후보의 관련 동 검색어를 함께 조회하도록 처리했습니다.  
이를 통해 서울 중구 명동 일대의 수거 장소가 자연스럽게 검색됩니다.

## 구현 세부 내용

- `MapRegionSearchCandidate` / `MapRegionSearchCandidateResult` 모델 추가
- `ResolveMapRegionSearchCandidateUseCase` 추가
  - 검색어에서 동/읍/면 후보를 확인
  - 후보 0개 / 1개 / 여러 개 케이스 분기
  - 시도/시군구 입력이 포함된 경우 후보 범위 축소
- `RegionOptionsRepository` 후보 조회 기능 확장
  - 행정동/법정동 매핑 데이터를 활용해 동일 동명 후보 조회
  - 법정동 `n가` 검색어 조회 지원
- `SearchCollectionSpotsByKeywordUseCase` 개선
  - 후보 지역 기준 결과 필터링
  - 명확히 다른 동/읍/면 토큰이 포함된 결과 제외
  - 도로명 주소처럼 동 정보가 불명확한 결과는 유지
- `CollectionSpotMapViewModel` 검색 상태 확장
  - 후보 목록 표시 상태 추가
  - 후보 선택 후 기존 키워드 검색 흐름과 연결
  - 후보 선택 시 관련 검색어들을 조회하고 결과 중복 제거
- 지도 BottomSheet 후보 선택 UI 추가
  - 후보 목록 표시
  - 후보가 있을 때 BottomSheet가 더 잘 보이도록 높이 조정
- 수거 장소 좌표 보정 주소 정제
  - geocoding 시 괄호 안 동명/건물명 제거

## 테스트

- `:domain:test`
- `:data:testDebugUnitTest --tests com.team.yeogibeoryeo.data.region.RegionOptionsMapperTest`
- `:data:testDebugUnitTest --tests com.team.yeogibeoryeo.data.spot.repository.CollectionSpotRepositoryImplTest`
- `:presentation:testDebugUnitTest`
- `:presentation:compileDebugKotlin`
- `:app:assembleDebug`

## 확인한 케이스

- `금호동` 검색 시 여러 지역 후보 표시
- `명동` 검색 시 여러 지역 후보 표시
- `성동구 금호동` 검색 시 서울특별시 성동구 금호동 기준으로 바로 검색
- `서울 중구 명동` 검색 시 서울 중구 명동 일대 결과 표시
- 후보 선택 BottomSheet 노출 위치 확인
- 기존 현재 위치 검색 / 현 지도 검색 / 필터 / 마커 / 즐겨찾기 동작 확인

## 참고

이번 PR은 지도 검색에서 동일 동명/유사 동명으로 인해 사용자가 의도하지 않은 지역 결과가 나오는 문제를 줄이기 위한 작업입니다.

전체 결과에 대한 reverse geocoding 후처리나 서버 API 변경은 포함하지 않았고, 현재 앱이 가진 지역 데이터와 `/getSpot addr` API 특성을 기준으로 후보 선택 UX를 추가하는 방향으로 처리했습니다.

Related #238