### PR TITLE
[Fix] 품목 홈 안내 사항 캐러셀 여백 개선

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
@@ -102,7 +102,6 @@ fun ItemSearchInitialContent(
             state = listState,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = metrics.horizontalPadding)
                 .padding(top = metrics.topPadding)
                 .onGloballyPositioned { coordinates ->
                     val measuredViewportBottomInRootPx =
@@ -116,21 +115,29 @@ fun ItemSearchInitialContent(
             verticalArrangement = Arrangement.spacedBy(metrics.screenVerticalSpace),
         ) {
             item {
-                ItemSearchHeader(onSettingsClick = onSettingsClick)
+                ItemSearchHeader(
+                    modifier = Modifier.padding(horizontal = metrics.horizontalPadding),
+                    onSettingsClick = onSettingsClick,
+                )
             }
 
             item {
-                Column(verticalArrangement = Arrangement.spacedBy(metrics.sectionVerticalSpace)) {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(metrics.sectionVerticalSpace),
+                ) {
                     KoreanLineBreakText(
                         text = stringResource(R.string.item_useful_guide_section_title),
                         style = MaterialTheme.typography.titleLarge.copy(
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.onSurface,
                         ),
+                        modifier = Modifier.padding(horizontal = metrics.horizontalPadding),
                     )
                     ItemUsefulGuideBannerRow(
                         guides = itemUsefulGuideContents,
                         onGuideClick = onUsefulGuideClick,
+                        contentPadding = PaddingValues(horizontal = metrics.horizontalPadding),
                     )
                 }
             }
@@ -140,6 +147,7 @@ fun ItemSearchInitialContent(
                     state = regionalGuideSummaryState,
                     onClick = onRegionalGuideSummaryClick,
                     onRetryClick = onRegionalGuideSummaryRetryClick,
+                    modifier = Modifier.padding(horizontal = metrics.horizontalPadding),
                 )
             }
 
@@ -149,13 +157,18 @@ fun ItemSearchInitialContent(
                     onKeywordChange = onQueryChange,
                     onSearchClick = onSearchClick,
                     placeholder = stringResource(R.string.item_search_query_label),
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = metrics.horizontalPadding),
                     iconSize = metrics.searchIconSize,
                 )
             }
 
             item {
-                Column(verticalArrangement = Arrangement.spacedBy(metrics.sectionVerticalSpace)) {
+                Column(
+                    modifier = Modifier.padding(horizontal = metrics.horizontalPadding),
+                    verticalArrangement = Arrangement.spacedBy(metrics.sectionVerticalSpace),
+                ) {
                     val quickCategoriesTitle = stringResource(R.string.quick_categories)
                     Row(
                         modifier = Modifier.fillMaxWidth(),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemUsefulGuideBannerRow.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemUsefulGuideBannerRow.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 import com.team.yeogibeoryeo.presentation.search.model.ItemUsefulGuideContent
 import com.team.yeogibeoryeo.presentation.search.model.ItemUsefulGuideType
@@ -50,7 +49,7 @@ fun ItemUsefulGuideBannerRow(
     guides: List<ItemUsefulGuideContent>,
     onGuideClick: (ItemUsefulGuideContent) -> Unit,
     modifier: Modifier = Modifier,
-    contentPadding: PaddingValues = PaddingValues(horizontal = 0.dp),
+    contentPadding: PaddingValues = PaddingValues(),
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
     val size = ItemSearchLayoutDefaults.size

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemUsefulGuideBannerRow.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemUsefulGuideBannerRow.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -38,6 +39,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.presentation.search.ItemSearchLayoutDefaults
 import com.team.yeogibeoryeo.presentation.search.model.ItemUsefulGuideContent
 import com.team.yeogibeoryeo.presentation.search.model.ItemUsefulGuideType
@@ -48,6 +50,7 @@ fun ItemUsefulGuideBannerRow(
     guides: List<ItemUsefulGuideContent>,
     onGuideClick: (ItemUsefulGuideContent) -> Unit,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 0.dp),
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
     val size = ItemSearchLayoutDefaults.size
@@ -75,6 +78,7 @@ fun ItemUsefulGuideBannerRow(
         LazyRow(
             state = listState,
             flingBehavior = flingBehavior,
+            contentPadding = contentPadding,
             horizontalArrangement = Arrangement.spacedBy(spacing.sm),
         ) {
             items(guides, key = { it.type }) { guide ->


### PR DESCRIPTION
## 작업 내용
- 품목 홈 화면의 '안내 사항' 캐러셀이 화면 전체 폭을 기준으로 스와이프되도록 조정했습니다.
- 캐러셀의 시작 여백은 기존 화면 좌우 여백과 맞추고, 다른 홈 섹션의 좌우 정렬은 유지했습니다.

## 변경 이유
부모 `LazyColumn`의 좌우 패딩 안에서 캐러셀이 렌더링되면서 다음 카드가 얇게 잘려 보였습니다. 캐러셀만 전체 폭을 사용하고 `LazyRow`의 `contentPadding`으로 시작 위치를 맞추면 카드 peek이 자연스럽게 보입니다.

## 변경 화면

| 구분 | Before | After |
|:---:|:---:|:---:|
| 첫 번째 카드 | <img src="https://github.com/user-attachments/assets/4aa936fc-651f-469b-bef2-d849c33321b3" width="260" /> | <img src="https://github.com/user-attachments/assets/d02c81bc-185d-4ffa-abb9-824da8215615" width="260" /> |
| 두 번째 카드 | <img src="https://github.com/user-attachments/assets/0bdf9645-9497-4a32-81d6-827410862f47" width="260" /> | <img src="https://github.com/user-attachments/assets/ecc9d649-e1b8-43bd-a2f8-6f77a1445f6d" width="260" /> |

## 테스트
- `./gradlew.bat :presentation:compileDebugKotlin`
- `git diff --check`

## 관련 이슈
Related #248