### PR TITLE
[Fix] 품목 검색 초기 검색어 재실행 방지

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -71,9 +71,7 @@ fun ItemSearchRoute(
     }
 
     LaunchedEffect(initialQuery) {
-        if (!initialQuery.isNullOrBlank()) {
-            viewModel.search(initialQuery)
-        }
+        viewModel.searchInitialQueryIfNeeded(initialQuery)
     }
 
     LaunchedEffect(viewModel.events) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModel.kt
@@ -40,6 +40,7 @@ constructor(
     private val _events = MutableSharedFlow<ItemSearchEvent>()
     val events: SharedFlow<ItemSearchEvent> = _events.asSharedFlow()
     private var searchJob: Job? = null
+    private var handledInitialQuery: String? = null
 
     init {
         viewModelScope.launch {
@@ -143,6 +144,14 @@ constructor(
                         }
                     }
             }
+    }
+
+    fun searchInitialQueryIfNeeded(query: String?) {
+        val trimmedQuery = query?.trim().orEmpty()
+        if (trimmedQuery.isBlank() || handledInitialQuery == trimmedQuery) return
+
+        handledInitialQuery = trimmedQuery
+        search(trimmedQuery)
     }
 
     fun openCategoryGuide(category: RepresentativeGuideCategory) {

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModelTest.kt
@@ -70,6 +70,19 @@ class ItemSearchViewModelTest {
         }
 
     @Test
+    fun `초기 검색어는 같은 값으로 다시 소비하지 않는다`() =
+        runTest {
+            val repository = FakeRepository(onSearch = { listOf(sampleGuide(it)) })
+            val viewModel = createViewModel(repository)
+
+            viewModel.searchInitialQueryIfNeeded("유리")
+            viewModel.searchInitialQueryIfNeeded("유리")
+
+            assertEquals(listOf("유리"), repository.queries)
+            assertEquals(listOf("유리"), viewModel.uiState.value.guides.map { it.name })
+        }
+
+    @Test
     fun `검색 성공 시 검색 결과 버전을 증가시킨다`() =
         runTest {
             val repository = FakeRepository(onSearch = { listOf(sampleGuide(it)) })

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModelTest.kt
@@ -83,6 +83,20 @@ class ItemSearchViewModelTest {
         }
 
     @Test
+    fun `초기 검색어는 앞뒤 공백을 제거한 값 기준으로 다시 소비하지 않는다`() =
+        runTest {
+            val repository = FakeRepository(onSearch = { listOf(sampleGuide(it)) })
+            val viewModel = createViewModel(repository)
+
+            viewModel.searchInitialQueryIfNeeded(" 유리 ")
+            viewModel.searchInitialQueryIfNeeded("유리")
+
+            assertEquals(listOf("유리"), repository.queries)
+            assertEquals("유리", viewModel.uiState.value.query)
+            assertEquals(listOf("유리"), viewModel.uiState.value.guides.map { it.name })
+        }
+
+    @Test
     fun `검색 성공 시 검색 결과 버전을 증가시킨다`() =
         runTest {
             val repository = FakeRepository(onSearch = { listOf(sampleGuide(it)) })


### PR DESCRIPTION
## 작업 내용

- 품목 검색 초기 검색어 소비 여부를 `ItemSearchViewModel`에서 관리하도록 수정
- 화면 재생성 시 같은 `initialQuery`로 검색이 다시 실행되지 않도록 보정
- 초기 검색어 중복 소비 방지 테스트 추가

## 변경 이유

`ItemSearchRoute`가 route argument를 `LaunchedEffect(initialQuery)`에서 바로 검색으로 소비하면 화면 재생성이나 route 복원 시 같은 검색이 다시 실행될 수 있습니다.

초기 검색어는 one-shot 성격의 진입 명령이라 ViewModel에서 소비 여부를 관리하는 편이 생명주기와 상태 책임이 더 명확합니다.

## 테스트

- `./gradlew.bat :presentation:testDebugUnitTest --tests "com.team.yeogibeoryeo.presentation.search.ItemSearchViewModelTest"`
- `./gradlew.bat :presentation:compileDebugKotlin`
- `git diff --check`

## 관련 이슈

Related #250
