### PR TITLE
[Fix] 홈 헤더 설정 아이콘 정렬 개선

### DIFF
--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/components/AppTopBar.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/components/AppTopBar.kt
@@ -34,12 +34,12 @@ fun AppTopBar(
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.background)
             .statusBarsPadding()
-            .height(AppTopBarHeight)
-            .padding(horizontal = AppTopBarHorizontalPadding),
+            .height(AppTopBarDefaults.height)
+            .padding(horizontal = AppTopBarDefaults.horizontalPadding),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
-            modifier = Modifier.size(AppTopBarButtonSize),
+            modifier = Modifier.size(AppTopBarDefaults.buttonSize),
             contentAlignment = Alignment.Center,
         ) {
             navigationIcon()
@@ -48,7 +48,7 @@ fun AppTopBar(
         Box(
             modifier = Modifier
                 .weight(1f)
-                .padding(start = AppTopBarTitleStartPadding),
+                .padding(start = AppTopBarDefaults.titleStartPadding),
             contentAlignment = Alignment.CenterStart,
         ) {
             title()
@@ -73,12 +73,16 @@ fun AppBackButton(
         Icon(
             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
             contentDescription = stringResource(R.string.back_action),
+            modifier = Modifier.size(AppTopBarDefaults.iconSize),
             tint = MaterialTheme.colorScheme.onSurface,
         )
     }
 }
 
-private val AppTopBarHeight = 64.dp
-private val AppTopBarHorizontalPadding = 12.dp
-private val AppTopBarButtonSize = 48.dp
-private val AppTopBarTitleStartPadding = 8.dp
+internal object AppTopBarDefaults {
+    val height = 64.dp
+    val horizontalPadding = 12.dp
+    val buttonSize = 48.dp
+    val iconSize = 24.dp
+    val titleStartPadding = 8.dp
+}

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.common.components.AppTopBarDefaults
 import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
@@ -118,7 +119,8 @@ fun ItemSearchInitialContent(
         ) {
             item {
                 ItemSearchHeader(
-                    modifier = Modifier.padding(horizontal = metrics.horizontalPadding),
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalPadding = metrics.horizontalPadding,
                     onSettingsClick = onSettingsClick,
                 )
             }
@@ -230,6 +232,7 @@ fun ItemSearchInitialContent(
 @Composable
 fun ItemSearchHeader(
     modifier: Modifier = Modifier,
+    horizontalPadding: Dp = ItemSearchLayoutDefaults.spacing.xl,
     onSettingsClick: (() -> Unit)? = null,
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
@@ -239,7 +242,12 @@ fun ItemSearchHeader(
         verticalArrangement = Arrangement.spacedBy(spacing.xs),
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    start = horizontalPadding,
+                    end = AppTopBarDefaults.horizontalPadding,
+                ),
             horizontalArrangement = Arrangement.spacedBy(spacing.sm),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -266,6 +274,7 @@ fun ItemSearchHeader(
         }
         KoreanLineBreakText(
             text = stringResource(R.string.item_search_description),
+            modifier = Modifier.padding(horizontal = horizontalPadding),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material.icons.Icons
@@ -33,6 +34,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.common.components.AppTopBarDefaults
 import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
 import com.team.yeogibeoryeo.presentation.search.components.HomeRegionalGuideSummaryBanner
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchBar
@@ -102,7 +104,7 @@ fun ItemSearchInitialContent(
             state = listState,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = metrics.topPadding)
+                .padding(top = metrics.homeHeaderTopPadding)
                 .onGloballyPositioned { coordinates ->
                     val measuredViewportBottomInRootPx =
                         coordinates.positionInRoot().y.toInt() + coordinates.size.height
@@ -232,35 +234,40 @@ fun ItemSearchHeader(
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
 
-    Row(
+    Column(
         modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
-        verticalAlignment = Alignment.Top,
+        verticalArrangement = Arrangement.spacedBy(spacing.xs),
     ) {
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(spacing.xs),
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 text = stringResource(R.string.item_search_title),
+                modifier = Modifier.weight(1f),
                 style = MaterialTheme.typography.headlineLarge,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface,
             )
-            Text(
-                text = stringResource(R.string.item_search_description),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        onSettingsClick?.let {
-            IconButton(onClick = it) {
-                Icon(
-                    painter = painterResource(id = CommonR.drawable.ic_action_settings),
-                    contentDescription = stringResource(R.string.settings_action),
-                    tint = MaterialTheme.colorScheme.onSurface,
-                )
+            onSettingsClick?.let {
+                IconButton(
+                    onClick = it,
+                    modifier = Modifier.size(AppTopBarDefaults.buttonSize),
+                ) {
+                    Icon(
+                        painter = painterResource(id = CommonR.drawable.ic_action_settings),
+                        contentDescription = stringResource(R.string.settings_action),
+                        modifier = Modifier.size(AppTopBarDefaults.iconSize),
+                        tint = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
             }
         }
+        KoreanLineBreakText(
+            text = stringResource(R.string.item_search_description),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreenMetrics.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreenMetrics.kt
@@ -3,6 +3,7 @@ package com.team.yeogibeoryeo.presentation.search
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.presentation.common.components.AppTopBarDefaults
 
 @Composable
 internal fun itemSearchScreenMetrics(
@@ -15,6 +16,7 @@ internal fun itemSearchScreenMetrics(
     return ItemSearchScreenMetrics(
         horizontalPadding = if (isNarrowPhone) spacing.md else spacing.xl,
         topPadding = if (isNarrowPhone) spacing.lg else spacing.xl,
+        homeHeaderTopPadding = (AppTopBarDefaults.height - AppTopBarDefaults.buttonSize) / 2f,
         screenVerticalSpace = if (isNarrowPhone) spacing.lg else spacing.xl,
         sectionVerticalSpace = spacing.md,
         listBottomPadding = spacing.xl,
@@ -25,6 +27,7 @@ internal fun itemSearchScreenMetrics(
 internal data class ItemSearchScreenMetrics(
     val horizontalPadding: Dp,
     val topPadding: Dp,
+    val homeHeaderTopPadding: Dp,
     val screenVerticalSpace: Dp,
     val sectionVerticalSpace: Dp,
     val listBottomPadding: Dp,


### PR DESCRIPTION
## 관련 이슈
Related #252

## 작업 내용
- 홈 헤더에서 제목과 설정 아이콘은 같은 줄에 유지하고, 설명 문구는 전체 폭에서 줄바꿈되도록 구조를 조정했습니다.
- 홈 설정 아이콘의 touch target과 icon size를 AppTopBar의 뒤로가기 버튼 기준과 맞췄습니다.
- 홈 헤더의 오른쪽 여백을 AppTopBar 기준과 맞춰 설정 아이콘이 설정 화면 뒤로가기 버튼과 같은 기준선에 놓이도록 조정했습니다.
- AppTopBar 크기 값을 defaults로 모아 홈 헤더 위치 계산에 재사용했습니다.

## 변경 이유
홈 화면에서 설정 아이콘을 눌러 설정 화면으로 이동할 때, 홈 설정 아이콘과 설정 화면 뒤로가기 버튼의 기준 위치와 크기가 다르게 보여 화면 전환이 어색했습니다.
설명 문구도 제목 Row 안의 남은 폭에 묶여 어색하게 줄바꿈되어, 제목/아이콘 Row와 설명 문구 영역을 분리했습니다.

<table>
<tr>
<th align="center">Before</th>
<th align="center">After<br/>홈 화면</th>
<th align="center">After<br/>설정 화면</th>
</tr>
<tr>
<td align="center">
<img src="https://github.com/user-attachments/assets/bee078af-b275-40e0-8958-8a31911db0e3" width="320" />
</td>
<td align="center">
<img src="https://github.com/user-attachments/assets/e94c4397-03dc-4ba9-85e1-90762a0b02a6" width="320" />
</td>
<td align="center">
<img src="https://github.com/user-attachments/assets/62db0490-ee4b-4bee-9063-af0fa2a88e4b" width="320" />
</td>
</tr>
</table>

## 확인 사항
- 홈 설정 아이콘과 '여기 버려' 제목이 같은 줄에서 정렬됩니다.
- 홈 설명 문구가 전체 폭에서 자연스럽게 줄바꿈됩니다.
- 홈 설정 아이콘은 AppTopBar 뒤로가기 버튼과 같은 touch target, icon size 기준을 사용합니다.
- 홈 설정 아이콘의 오른쪽 여백이 설정 화면 뒤로가기 버튼 기준과 어긋나지 않습니다.

## 테스트
- `./gradlew.bat :presentation:compileDebugKotlin`