### PR TITLE
[Fix] 홈 터치 피드백 shape 정리

### DIFF
--- a/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreenTest.kt
+++ b/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreenTest.kt
@@ -252,7 +252,7 @@ class ItemSearchScreenTest {
         composeTestRule.setContent {
             MaterialTheme {
                 ItemSearchScreen(
-                    uiState = ItemSearchUiState(),
+                    uiState = ItemSearchUiState(isQuickCategoryExpanded = true),
                     onQueryChange = {},
                     onSearchClick = {},
                     onGuideClick = {},
@@ -261,7 +261,7 @@ class ItemSearchScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText(RepresentativeGuideCategory.PLASTIC.displayName)
+        composeTestRule.onNodeWithContentDescription(RepresentativeGuideCategory.PLASTIC.displayName)
             .performScrollTo()
             .performClick()
 
@@ -299,7 +299,7 @@ class ItemSearchScreenTest {
         composeTestRule.onAllNodesWithText(RepresentativeGuideCategory.METAL.displayName)
             .assertCountEquals(0)
 
-        composeTestRule.onNodeWithText("더보기")
+        composeTestRule.onNodeWithContentDescription("더보기")
             .performScrollTo()
             .performClick()
 
@@ -310,7 +310,7 @@ class ItemSearchScreenTest {
             .performScrollTo()
             .assertIsDisplayed()
 
-        composeTestRule.onNodeWithText("접기").performClick()
+        composeTestRule.onNodeWithContentDescription("접기").performClick()
 
         composeTestRule.onAllNodesWithText(RepresentativeGuideCategory.METAL.displayName)
             .assertCountEquals(0)
@@ -339,10 +339,10 @@ class ItemSearchScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("더보기")
+        composeTestRule.onNodeWithContentDescription("더보기")
             .performScrollTo()
             .performClick()
-        composeTestRule.onNodeWithText(RepresentativeGuideCategory.METAL.displayName)
+        composeTestRule.onNodeWithContentDescription(RepresentativeGuideCategory.METAL.displayName)
             .performScrollTo()
             .performClick()
 

--- a/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/SearchComponentsTest.kt
+++ b/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/SearchComponentsTest.kt
@@ -2,6 +2,9 @@ package com.team.yeogibeoryeo.presentation.search
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -200,6 +203,21 @@ class SearchComponentsTest {
         composeTestRule.onNodeWithContentDescription("비닐류").performClick()
 
         assertEquals(RepresentativeGuideCategory.VINYL, clickedCategory)
+    }
+
+    @Test
+    fun 퀵_카테고리_라벨은_클릭_대상이_아니다() {
+        composeTestRule.setContent {
+            MaterialTheme {
+                QuickCategoryGrid(
+                    categories = listOf(RepresentativeGuideCategory.VINYL),
+                    onCategoryClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("비닐류")
+            .assert(SemanticsMatcher.keyNotDefined(SemanticsActions.OnClick))
     }
 
     @Test

--- a/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/SearchComponentsTest.kt
+++ b/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/SearchComponentsTest.kt
@@ -197,7 +197,7 @@ class SearchComponentsTest {
         }
 
         composeTestRule.onNodeWithText("종이").assertIsDisplayed()
-        composeTestRule.onNodeWithText("비닐류").performClick()
+        composeTestRule.onNodeWithContentDescription("비닐류").performClick()
 
         assertEquals(RepresentativeGuideCategory.VINYL, clickedCategory)
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/HomeRegionalGuideSummaryBanner.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/HomeRegionalGuideSummaryBanner.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -39,6 +40,7 @@ fun HomeRegionalGuideSummaryBanner(
         stringResource(id = R.string.home_regional_guide_summary_disposal_days_label)
     val disposalTimeLabel =
         stringResource(id = R.string.home_regional_guide_summary_disposal_time_label)
+    val shape = RoundedCornerShape(8.dp)
     Card(
         modifier =
             modifier
@@ -46,13 +48,13 @@ fun HomeRegionalGuideSummaryBanner(
                 .then(
                     when {
                         content.retryable ->
-                            Modifier.clickable(
+                            Modifier.clip(shape).clickable(
                                 onClickLabel = content.actionLabel,
                                 role = Role.Button,
                                 onClick = onRetryClick,
                             )
                         content.targetId != null ->
-                            Modifier.clickable(
+                            Modifier.clip(shape).clickable(
                                 onClickLabel = content.actionLabel,
                                 role = Role.Button,
                                 onClick = { onClick(content.targetId) },
@@ -64,7 +66,7 @@ fun HomeRegionalGuideSummaryBanner(
             CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.tertiaryContainer,
             ),
-        shape = RoundedCornerShape(8.dp),
+        shape = shape,
     ) {
         Column(
             modifier = Modifier.padding(20.dp),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemUsefulGuideBannerRow.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemUsefulGuideBannerRow.kt
@@ -106,15 +106,17 @@ private fun ItemUsefulGuideBannerCard(
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
     val size = ItemSearchLayoutDefaults.size
+    val shape = MaterialTheme.shapes.medium
 
     Card(
         modifier = modifier
             .fillMaxWidth()
+            .clip(shape)
             .clickable(onClick = onClick),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.secondaryContainer,
         ),
-        shape = MaterialTheme.shapes.medium,
+        shape = shape,
     ) {
         Row(
             modifier = Modifier.padding(spacing.md),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGrid.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
@@ -31,6 +32,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
@@ -38,6 +41,8 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -199,20 +204,12 @@ private fun QuickCategoryToggleItem(
                 minHeight = size.minTouchTarget,
             )
             .width(metrics.cellSize)
-            .clickable(
-                onClickLabel = label,
-                role = Role.Button,
-                onClick = onClick,
-            )
     ) {
-        Box(
-            modifier = Modifier
-                .size(metrics.tileSize)
-                .background(
-                    color = MaterialTheme.colorScheme.surfaceContainer,
-                    shape = MaterialTheme.shapes.large,
-                ),
-            contentAlignment = Alignment.Center,
+        QuickCategoryTile(
+            contentDescription = label,
+            onClickLabel = label,
+            onClick = onClick,
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
         ) {
             Icon(
                 imageVector = Icons.Filled.MoreHoriz,
@@ -309,6 +306,43 @@ private sealed interface QuickCategoryGridItem {
 }
 
 @Composable
+private fun QuickCategoryTile(
+    contentDescription: String,
+    onClickLabel: String,
+    onClick: () -> Unit,
+    containerColor: Color,
+    badge: @Composable BoxScope.() -> Unit = {},
+    content: @Composable BoxScope.() -> Unit,
+) {
+    val metrics = LocalQuickCategoryGridMetrics.current
+    val shape = MaterialTheme.shapes.large
+
+    Box(
+        modifier = Modifier.size(metrics.tileSize),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(metrics.tileSize)
+                .clip(shape)
+                .background(
+                    color = containerColor,
+                    shape = shape
+                )
+                .semantics { this.contentDescription = contentDescription }
+                .clickable(
+                    onClickLabel = onClickLabel,
+                    role = Role.Button,
+                    onClick = onClick,
+                ),
+            contentAlignment = Alignment.Center,
+            content = content,
+        )
+        badge()
+    }
+}
+
+@Composable
 internal fun QuickCategoryItem(
     category: RepresentativeGuideCategory,
     name: String,
@@ -329,20 +363,40 @@ internal fun QuickCategoryItem(
                 minHeight = size.minTouchTarget,
             )
             .width(metrics.cellSize)
-            .clickable(
-                onClickLabel = clickActionLabel,
-                role = Role.Button,
-                onClick = onClick,
-            )
     ) {
-        Box(
-            modifier = Modifier
-                .size(metrics.tileSize)
-                .background(
-                    color = category.containerColor(),
-                    shape = MaterialTheme.shapes.large
-                ),
-            contentAlignment = Alignment.Center
+        QuickCategoryTile(
+            contentDescription = category.displayName,
+            onClickLabel = clickActionLabel,
+            onClick = onClick,
+            containerColor = category.containerColor(),
+            badge = {
+                if (isSelected) {
+                    Surface(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .offset(
+                                x = size.categorySelectionBadgeOffset,
+                                y = -size.categorySelectionBadgeOffset,
+                            )
+                            .size(size.categorySelectionBadge),
+                        shape = MaterialTheme.shapes.extraLarge,
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                        border = BorderStroke(
+                            width = ItemSearchLayoutDefaults.stroke.outline,
+                            color = MaterialTheme.colorScheme.primary,
+                        ),
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(
+                                imageVector = Icons.Filled.Check,
+                                contentDescription = null,
+                                modifier = Modifier.size(size.categorySelectionBadgeIcon),
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    }
+                }
+            },
         ) {
             Icon(
                 painter = painterResource(id = category.iconResId),
@@ -351,32 +405,6 @@ internal fun QuickCategoryItem(
                 modifier = Modifier.size(metrics.iconSize),
                 tint = category.iconTint()
             )
-            if (isSelected) {
-                Surface(
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .offset(
-                            x = size.categorySelectionBadgeOffset,
-                            y = -size.categorySelectionBadgeOffset,
-                        )
-                        .size(size.categorySelectionBadge),
-                    shape = MaterialTheme.shapes.extraLarge,
-                    color = MaterialTheme.colorScheme.primaryContainer,
-                    border = BorderStroke(
-                        width = ItemSearchLayoutDefaults.stroke.outline,
-                        color = MaterialTheme.colorScheme.primary,
-                    ),
-                ) {
-                    Box(contentAlignment = Alignment.Center) {
-                        Icon(
-                            imageVector = Icons.Filled.Check,
-                            contentDescription = null,
-                            modifier = Modifier.size(size.categorySelectionBadgeIcon),
-                            tint = MaterialTheme.colorScheme.primary,
-                        )
-                    }
-                }
-            }
         }
         Text(
             text = name.withKoreanLineBreakOpportunities(),


### PR DESCRIPTION
## 작업 내용

- 홈 빠른 분류 타일의 터치 피드백을 타일 모서리와 같은 rounded shape로 맞췄습니다.
- 빠른 분류 라벨은 클릭 대상에서 제외하고, 타일 영역만 클릭 대상으로 정리했습니다.
- 선택 배지는 타일 clip 밖에 유지해 우측 상단 표시가 잘리지 않게 했습니다.
- 홈 지역 가이드 배너와 안내 사항 배너의 터치 피드백도 카드 shape와 맞췄습니다.

## 변경 이유

홈 화면에서 항목을 누를 때 회색 터치 피드백이 사각형으로 보이거나, 타일 외부 영역까지 표시되어 UI 모서리와 어긋났습니다.

터치 피드백이 실제 컴포넌트 shape와 맞도록 수정했습니다.

빠른 분류는 아이콘 타일이 실제 버튼처럼 보이므로, 라벨 영역은 클릭 대상에서 제외했습니다. 이 정책은 라벨에 클릭 액션이 붙지 않는 테스트로 보호했습니다.

### 빠른 분류 타일

| Before | After |
|:-------:|:------:|
| <img src="https://github.com/user-attachments/assets/3790ff21-8da3-4772-80de-9d6ff2115250" width="280" /> | <img src="https://github.com/user-attachments/assets/d46fbe7a-626e-4434-baf3-7b55bd4c27dd" width="280" /> |

### 지역 가이드 배너

| Before | After |
|:-------:|:------:|
| <img src="https://github.com/user-attachments/assets/a2580882-46d6-4f37-a131-3eac095524b8" width="280" /> | <img src="https://github.com/user-attachments/assets/62bf081f-11b3-4c48-bc39-206e09aedefc" width="280" /> |

### 안내 사항 배너

| Before | After |
|:-------:|:------:|
| <img src="https://github.com/user-attachments/assets/389ab62a-4a0b-4072-af16-157decd18944" width="280" /> | <img src="https://github.com/user-attachments/assets/b6d7add5-2359-49ce-87ea-a7a89d83514c" width="280" /> |

## 확인 사항

- 빠른 분류 항목을 눌러도 라벨 영역에 회색 피드백이 번지지 않습니다.
- 빠른 분류 라벨에는 클릭 액션이 붙지 않습니다.
- 선택된 항목의 우측 상단 체크 배지가 잘리지 않습니다.
- 지역 가이드 배너와 안내 사항 배너의 터치 피드백이 카드 shape와 일치합니다.
- 접근성 role은 타일 클릭 대상에 유지했습니다.

## 테스트

- `./gradlew.bat :presentation:compileDebugKotlin :app:installDebug`
- `./gradlew.bat :presentation:testDebugUnitTest`
- `./gradlew.bat :presentation:compileDebugKotlin :presentation:compileDebugAndroidTestKotlin`

## 관련 이슈

Related #254
