### PR TITLE
fix: 지도 후보 선택 검색 결과 누락 보완

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/remote/datasource/SpotRemoteDataSource.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/remote/datasource/SpotRemoteDataSource.kt
@@ -2,7 +2,10 @@ package com.team.yeogibeoryeo.data.spot.remote.datasource
 
 import com.team.yeogibeoryeo.data.spot.remote.SpotApiService
 import com.team.yeogibeoryeo.data.spot.remote.dto.SpotItemDto
+import com.team.yeogibeoryeo.data.spot.remote.dto.SpotResponseDto
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.JsonPrimitive
 
 class SpotRemoteDataSource @Inject constructor(
     private val apiService: SpotApiService,
@@ -13,14 +16,48 @@ class SpotRemoteDataSource @Inject constructor(
         pageNo: Int = 1,
         numOfRows: Int = 100,
     ): List<SpotItemDto> {
-        val response = apiService.getSpots(
+        val firstPage = fetchKeywordPage(
             serviceKey = serviceKey,
+            keyword = keyword,
             pageNo = pageNo,
             numOfRows = numOfRows,
-            addr = keyword,
         )
+        val effectiveNumOfRows = firstPage.numOfRows ?: numOfRows
+        val currentPageNo = firstPage.pageNo ?: pageNo
+        val totalCount = firstPage.totalCount
+        val totalPages = if (totalCount == null || effectiveNumOfRows <= 0) {
+            currentPageNo
+        } else {
+            ((totalCount + effectiveNumOfRows - 1) / effectiveNumOfRows)
+                .coerceAtLeast(currentPageNo)
+        }
+        val lastPage = totalPages.coerceAtMost(currentPageNo + MAX_ADDR_SEARCH_PAGE_COUNT - 1)
+        val mergedItems = firstPage.items.toMutableList()
 
-        return response.toSpotItemsOrEmpty()
+        for (nextPageNo in (currentPageNo + 1)..lastPage) {
+            val nextPage = try {
+                fetchKeywordPage(
+                    serviceKey = serviceKey,
+                    keyword = keyword,
+                    pageNo = nextPageNo,
+                    numOfRows = numOfRows,
+                )
+            } catch (exception: Throwable) {
+                if (exception is CancellationException) throw exception
+
+                break
+            }
+
+            mergedItems += nextPage.items
+        }
+
+        return mergedItems.distinctBy { item ->
+            listOf(
+                item.spotNm.orEmpty().trim(),
+                item.addrBase.orEmpty().trim(),
+                item.addrDtl.orEmpty().trim(),
+            )
+        }
     }
 
     suspend fun searchByLocation(
@@ -44,7 +81,32 @@ class SpotRemoteDataSource @Inject constructor(
         return response.toSpotItemsOrEmpty()
     }
 
-    private fun com.team.yeogibeoryeo.data.spot.remote.dto.SpotResponseDto.toSpotItemsOrEmpty(): List<SpotItemDto> {
+    private suspend fun fetchKeywordPage(
+        serviceKey: String,
+        keyword: String,
+        pageNo: Int,
+        numOfRows: Int,
+    ): SpotPageResult {
+        val response = apiService.getSpots(
+            serviceKey = serviceKey,
+            pageNo = pageNo,
+            numOfRows = numOfRows,
+            addr = keyword,
+        )
+
+        return response.toSpotPageResult()
+    }
+
+    private fun SpotResponseDto.toSpotPageResult(): SpotPageResult {
+        return SpotPageResult(
+            items = toSpotItemsOrEmpty(),
+            numOfRows = response.body.numOfRows.toIntOrNull(),
+            pageNo = response.body.pageNo.toIntOrNull(),
+            totalCount = response.body.totalCount.toIntOrNull(),
+        )
+    }
+
+    private fun SpotResponseDto.toSpotItemsOrEmpty(): List<SpotItemDto> {
         val resultCode = response.header.resultCode
 
         if (resultCode == RESULT_CODE_NO_DATA) {
@@ -54,7 +116,21 @@ class SpotRemoteDataSource @Inject constructor(
         return response.body.items?.item.orEmpty()
     }
 
+    private fun kotlinx.serialization.json.JsonElement?.toIntOrNull(): Int? {
+        return (this as? JsonPrimitive)
+            ?.content
+            ?.toIntOrNull()
+    }
+
+    private data class SpotPageResult(
+        val items: List<SpotItemDto>,
+        val numOfRows: Int?,
+        val pageNo: Int?,
+        val totalCount: Int?,
+    )
+
     private companion object {
         const val RESULT_CODE_NO_DATA = "03"
+        const val MAX_ADDR_SEARCH_PAGE_COUNT = 5
     }
 }

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/remote/datasource/SpotRemoteDataSource.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/remote/datasource/SpotRemoteDataSource.kt
@@ -16,6 +16,20 @@ class SpotRemoteDataSource @Inject constructor(
         pageNo: Int = 1,
         numOfRows: Int = 100,
     ): List<SpotItemDto> {
+        return searchByKeywordResult(
+            serviceKey = serviceKey,
+            keyword = keyword,
+            pageNo = pageNo,
+            numOfRows = numOfRows,
+        ).items
+    }
+
+    suspend fun searchByKeywordResult(
+        serviceKey: String,
+        keyword: String,
+        pageNo: Int = 1,
+        numOfRows: Int = 100,
+    ): SpotKeywordSearchResult {
         val firstPage = fetchKeywordPage(
             serviceKey = serviceKey,
             keyword = keyword,
@@ -31,8 +45,9 @@ class SpotRemoteDataSource @Inject constructor(
             ((totalCount + effectiveNumOfRows - 1) / effectiveNumOfRows)
                 .coerceAtLeast(currentPageNo)
         }
-        val lastPage = totalPages.coerceAtMost(currentPageNo + MAX_ADDR_SEARCH_PAGE_COUNT - 1)
+        val lastPage = totalPages
         val mergedItems = firstPage.items.toMutableList()
+        var isPartial = false
 
         for (nextPageNo in (currentPageNo + 1)..lastPage) {
             val nextPage = try {
@@ -45,19 +60,23 @@ class SpotRemoteDataSource @Inject constructor(
             } catch (exception: Throwable) {
                 if (exception is CancellationException) throw exception
 
+                isPartial = true
                 break
             }
 
             mergedItems += nextPage.items
         }
 
-        return mergedItems.distinctBy { item ->
-            listOf(
-                item.spotNm.orEmpty().trim(),
-                item.addrBase.orEmpty().trim(),
-                item.addrDtl.orEmpty().trim(),
-            )
-        }
+        return SpotKeywordSearchResult(
+            items = mergedItems.distinctBy { item ->
+                listOf(
+                    item.spotNm.orEmpty().trim(),
+                    item.addrBase.orEmpty().trim(),
+                    item.addrDtl.orEmpty().trim(),
+                )
+            },
+            isPartial = isPartial,
+        )
     }
 
     suspend fun searchByLocation(
@@ -131,6 +150,10 @@ class SpotRemoteDataSource @Inject constructor(
 
     private companion object {
         const val RESULT_CODE_NO_DATA = "03"
-        const val MAX_ADDR_SEARCH_PAGE_COUNT = 5
     }
 }
+
+data class SpotKeywordSearchResult(
+    val items: List<SpotItemDto>,
+    val isPartial: Boolean,
+)

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.team.yeogibeoryeo.data.spot.geocoder.SpotGeocoder
 import com.team.yeogibeoryeo.data.spot.mapper.SpotMapper
 import com.team.yeogibeoryeo.data.spot.remote.datasource.SpotRemoteDataSource
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotSearchResult
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
@@ -28,16 +29,29 @@ class CollectionSpotRepositoryImpl @Inject constructor(
         keyword: String,
         types: Set<CollectionSpotType>,
     ): List<CollectionSpot> {
-        val spots = remoteDataSource.searchByKeyword(
+        return searchByKeywordResult(
+            keyword = keyword,
+            types = types,
+        ).spots
+    }
+
+    override suspend fun searchByKeywordResult(
+        keyword: String,
+        types: Set<CollectionSpotType>,
+    ): CollectionSpotSearchResult {
+        val result = remoteDataSource.searchByKeywordResult(
             serviceKey = publicDataKeyProvider.publicDataServiceKey,
             keyword = keyword,
-        ).let { dtoList ->
-            spotMapper.mapToDomainList(dtoList)
-        }
+        )
 
-        return spots
+        val spots = spotMapper.mapToDomainList(result.items)
             .filterByTypes(types)
             .geocodeAll()
+
+        return CollectionSpotSearchResult(
+            spots = spots,
+            isPartial = result.isPartial,
+        )
     }
 
     override suspend fun searchByLocation(

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/remote/datasource/SpotRemoteDataSourceTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/remote/datasource/SpotRemoteDataSourceTest.kt
@@ -8,6 +8,7 @@ import com.team.yeogibeoryeo.data.spot.remote.dto.SpotItemsDto
 import com.team.yeogibeoryeo.data.spot.remote.dto.SpotResponseBodyDto
 import com.team.yeogibeoryeo.data.spot.remote.dto.SpotResponseDto
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -27,6 +28,7 @@ class SpotRemoteDataSourceTest {
         )
 
         assertEquals("문래동", apiService.requestedAddr)
+        assertEquals(listOf(1), apiService.requestedPageNos)
         assertNull(apiService.requestedLatitude)
         assertNull(apiService.requestedLongitude)
         assertNull(apiService.requestedRadius)
@@ -49,6 +51,7 @@ class SpotRemoteDataSourceTest {
         )
 
         assertEquals(" ", apiService.requestedAddr)
+        assertEquals(listOf(1), apiService.requestedPageNos)
         assertEquals(37.5182396969791, apiService.requestedLatitude)
         assertEquals(126.895880210522, apiService.requestedLongitude)
         assertEquals(500, apiService.requestedRadius)
@@ -103,12 +106,160 @@ class SpotRemoteDataSourceTest {
         assertEquals(emptyList<SpotItemDto>(), result)
     }
 
+    @Test
+    fun `검색어 기반 조회 시 totalCount가 numOfRows 이하면 첫 페이지만 조회한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createNormalResponse(
+                pageNo = 1,
+                numOfRows = 100,
+                totalCount = 1,
+            ),
+        )
+        val dataSource = SpotRemoteDataSource(apiService)
+
+        val result = dataSource.searchByKeyword(
+            serviceKey = TEST_SERVICE_KEY,
+            keyword = "문래동",
+        )
+
+        assertEquals(listOf(1), apiService.requestedPageNos)
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `검색어 기반 조회 시 totalCount가 numOfRows를 초과하면 추가 페이지를 병합한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createResponse(
+                pageNo = 1,
+                numOfRows = 2,
+                totalCount = 3,
+                items = listOf(
+                    spotItem("1페이지 수거함", "서울특별시 영등포구 문래동", "주민센터 앞"),
+                    spotItem("1페이지 재활용센터", "서울특별시 영등포구 문래동", "학교 앞"),
+                ),
+            ),
+            responsesByPage = mapOf(
+                2 to createResponse(
+                    pageNo = 2,
+                    numOfRows = 2,
+                    totalCount = 3,
+                    items = listOf(
+                        spotItem("2페이지 수거함", "서울특별시 영등포구 문래동", "공원 앞"),
+                    ),
+                ),
+            ),
+        )
+        val dataSource = SpotRemoteDataSource(apiService)
+
+        val result = dataSource.searchByKeyword(
+            serviceKey = TEST_SERVICE_KEY,
+            keyword = "문래동",
+            numOfRows = 2,
+        )
+
+        assertEquals(listOf(1, 2), apiService.requestedPageNos)
+        assertEquals(
+            listOf("1페이지 수거함", "1페이지 재활용센터", "2페이지 수거함"),
+            result.map { item -> item.spotNm },
+        )
+    }
+
+    @Test
+    fun `검색어 기반 여러 페이지 결과는 기존 순서를 유지하며 중복을 제거한다`() = runBlocking {
+        val duplicateItem = spotItem("중복 수거함", "서울특별시 영등포구 문래동", "주민센터 앞")
+        val apiService = FakeSpotApiService(
+            response = createResponse(
+                pageNo = 1,
+                numOfRows = 2,
+                totalCount = 3,
+                items = listOf(
+                    duplicateItem,
+                    spotItem("1페이지 재활용센터", "서울특별시 영등포구 문래동", "학교 앞"),
+                ),
+            ),
+            responsesByPage = mapOf(
+                2 to createResponse(
+                    pageNo = 2,
+                    numOfRows = 2,
+                    totalCount = 3,
+                    items = listOf(
+                        duplicateItem,
+                        spotItem("2페이지 수거함", "서울특별시 영등포구 문래동", "공원 앞"),
+                    ),
+                ),
+            ),
+        )
+        val dataSource = SpotRemoteDataSource(apiService)
+
+        val result = dataSource.searchByKeyword(
+            serviceKey = TEST_SERVICE_KEY,
+            keyword = "문래동",
+            numOfRows = 2,
+        )
+
+        assertEquals(listOf(1, 2), apiService.requestedPageNos)
+        assertEquals(
+            listOf("중복 수거함", "1페이지 재활용센터", "2페이지 수거함"),
+            result.map { item -> item.spotNm },
+        )
+    }
+
+    @Test
+    fun `검색어 기반 추가 페이지 실패 시 조회된 페이지 결과를 반환한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createResponse(
+                pageNo = 1,
+                numOfRows = 2,
+                totalCount = 3,
+                items = listOf(
+                    spotItem("1페이지 수거함", "서울특별시 영등포구 문래동", "주민센터 앞"),
+                ),
+            ),
+            failurePages = setOf(2),
+        )
+        val dataSource = SpotRemoteDataSource(apiService)
+
+        val result = dataSource.searchByKeyword(
+            serviceKey = TEST_SERVICE_KEY,
+            keyword = "문래동",
+            numOfRows = 2,
+        )
+
+        assertEquals(listOf(1, 2), apiService.requestedPageNos)
+        assertEquals(listOf("1페이지 수거함"), result.map { item -> item.spotNm })
+    }
+
+    @Test
+    fun `현재 위치 기반 조회는 totalCount가 커도 추가 페이지를 조회하지 않는다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createNormalResponse(
+                pageNo = 1,
+                numOfRows = 100,
+                totalCount = 300,
+            ),
+        )
+        val dataSource = SpotRemoteDataSource(apiService)
+
+        val result = dataSource.searchByLocation(
+            serviceKey = TEST_SERVICE_KEY,
+            latitude = 37.5182396969791,
+            longitude = 126.895880210522,
+            radiusMeter = 500,
+        )
+
+        assertEquals(listOf(1), apiService.requestedPageNos)
+        assertEquals(1, result.size)
+    }
+
     private class FakeSpotApiService(
         private val response: SpotResponseDto,
+        private val responsesByPage: Map<Int, SpotResponseDto> = emptyMap(),
+        private val failurePages: Set<Int> = emptySet(),
     ) : SpotApiService {
 
         var requestedServiceKey: String? = null
         var requestedPageNo: Int? = null
+        val requestedPageNos = mutableListOf<Int>()
         var requestedNumOfRows: Int? = null
         var requestedAddr: String? = null
         var requestedLatitude: Double? = null
@@ -128,6 +279,7 @@ class SpotRemoteDataSourceTest {
         ): SpotResponseDto {
             requestedServiceKey = serviceKey
             requestedPageNo = pageNo
+            requestedPageNos += pageNo
             requestedNumOfRows = numOfRows
             requestedAddr = addr
             requestedLatitude = latitude
@@ -135,30 +287,31 @@ class SpotRemoteDataSourceTest {
             requestedRadius = radius
             requestedType = type
 
-            return response
+            if (pageNo in failurePages) {
+                error("page failed")
+            }
+
+            return responsesByPage[pageNo] ?: response
         }
     }
 
     private companion object {
         const val TEST_SERVICE_KEY = "test-service-key"
 
-        fun createNormalResponse(): SpotResponseDto {
-            return SpotResponseDto(
-                response = SpotResponseBodyDto(
-                    header = SpotHeaderDto(
-                        resultCode = "00",
-                        resultMsg = "NORMAL SERVICE",
-                    ),
-                    body = SpotBodyDto(
-                        items = SpotItemsDto(
-                            item = listOf(
-                                SpotItemDto(
-                                    spotNm = "폐건전지 수거함",
-                                    addrBase = "서울특별시 영등포구 문래동",
-                                    addrDtl = "주민센터 앞",
-                                ),
-                            ),
-                        ),
+        fun createNormalResponse(
+            pageNo: Int? = null,
+            numOfRows: Int? = null,
+            totalCount: Int? = null,
+        ): SpotResponseDto {
+            return createResponse(
+                pageNo = pageNo,
+                numOfRows = numOfRows,
+                totalCount = totalCount,
+                items = listOf(
+                    spotItem(
+                        name = "폐건전지 수거함",
+                        address = "서울특별시 영등포구 문래동",
+                        detailAddress = "주민센터 앞",
                     ),
                 ),
             )
@@ -173,6 +326,9 @@ class SpotRemoteDataSourceTest {
                     ),
                     body = SpotBodyDto(
                         items = null,
+                        numOfRows = null,
+                        pageNo = null,
+                        totalCount = null,
                     ),
                 ),
             )
@@ -189,6 +345,40 @@ class SpotRemoteDataSourceTest {
                         items = null,
                     ),
                 ),
+            )
+        }
+
+        fun createResponse(
+            pageNo: Int?,
+            numOfRows: Int?,
+            totalCount: Int?,
+            items: List<SpotItemDto>,
+        ): SpotResponseDto {
+            return SpotResponseDto(
+                response = SpotResponseBodyDto(
+                    header = SpotHeaderDto(
+                        resultCode = "00",
+                        resultMsg = "NORMAL SERVICE",
+                    ),
+                    body = SpotBodyDto(
+                        items = SpotItemsDto(item = items),
+                        numOfRows = numOfRows?.let(::JsonPrimitive),
+                        pageNo = pageNo?.let(::JsonPrimitive),
+                        totalCount = totalCount?.let(::JsonPrimitive),
+                    ),
+                ),
+            )
+        }
+
+        fun spotItem(
+            name: String,
+            address: String,
+            detailAddress: String,
+        ): SpotItemDto {
+            return SpotItemDto(
+                spotNm = name,
+                addrBase = address,
+                addrDtl = detailAddress,
             )
         }
     }

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/remote/datasource/SpotRemoteDataSourceTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/remote/datasource/SpotRemoteDataSourceTest.kt
@@ -205,6 +205,41 @@ class SpotRemoteDataSourceTest {
     }
 
     @Test
+    fun `검색어 기반 조회는 5페이지를 초과해도 전체 페이지를 조회한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createResponse(
+                pageNo = 1,
+                numOfRows = 2,
+                totalCount = 12,
+                items = listOf(spotItem("1페이지 수거함", "서울특별시 영등포구 문래동", "1")),
+            ),
+            responsesByPage = (2..6).associateWith { pageNo ->
+                createResponse(
+                    pageNo = pageNo,
+                    numOfRows = 2,
+                    totalCount = 12,
+                    items = listOf(
+                        spotItem("${pageNo}페이지 수거함", "서울특별시 영등포구 문래동", pageNo.toString()),
+                    ),
+                )
+            },
+        )
+        val dataSource = SpotRemoteDataSource(apiService)
+
+        val result = dataSource.searchByKeyword(
+            serviceKey = TEST_SERVICE_KEY,
+            keyword = "상동",
+            numOfRows = 2,
+        )
+
+        assertEquals(listOf(1, 2, 3, 4, 5, 6), apiService.requestedPageNos)
+        assertEquals(
+            listOf("1페이지 수거함", "2페이지 수거함", "3페이지 수거함", "4페이지 수거함", "5페이지 수거함", "6페이지 수거함"),
+            result.map { item -> item.spotNm },
+        )
+    }
+
+    @Test
     fun `검색어 기반 추가 페이지 실패 시 조회된 페이지 결과를 반환한다`() = runBlocking {
         val apiService = FakeSpotApiService(
             response = createResponse(
@@ -219,14 +254,15 @@ class SpotRemoteDataSourceTest {
         )
         val dataSource = SpotRemoteDataSource(apiService)
 
-        val result = dataSource.searchByKeyword(
+        val result = dataSource.searchByKeywordResult(
             serviceKey = TEST_SERVICE_KEY,
             keyword = "문래동",
             numOfRows = 2,
         )
 
         assertEquals(listOf(1, 2), apiService.requestedPageNos)
-        assertEquals(listOf("1페이지 수거함"), result.map { item -> item.spotNm })
+        assertEquals(listOf("1페이지 수거함"), result.items.map { item -> item.spotNm })
+        assertEquals(true, result.isPartial)
     }
 
     @Test

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImplTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImplTest.kt
@@ -14,6 +14,7 @@ import com.team.yeogibeoryeo.data.spot.remote.dto.SpotResponseDto
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -63,6 +64,42 @@ class CollectionSpotRepositoryImplTest {
         assertEquals(1, result.size)
         assertEquals("재활용센터", result.first().name)
         assertEquals(CollectionSpotType.RECYCLING_CENTER, result.first().type)
+    }
+
+    @Test
+    fun `검색어 기반 조회 시 여러 페이지 결과를 변환하고 반환한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createResponse(
+                pageNo = 1,
+                numOfRows = 2,
+                totalCount = 3,
+                items = listOf(
+                    spotItem("1페이지 수거함", "서울특별시 영등포구 문래동", "주민센터 앞"),
+                    spotItem("1페이지 재활용센터", "서울특별시 영등포구 문래동", "학교 앞"),
+                ),
+            ),
+            responsesByPage = mapOf(
+                2 to createResponse(
+                    pageNo = 2,
+                    numOfRows = 2,
+                    totalCount = 3,
+                    items = listOf(
+                        spotItem("2페이지 수거함", "서울특별시 영등포구 문래동", "공원 앞"),
+                    ),
+                ),
+            ),
+        )
+        val repository = createRepository(apiService)
+
+        val result = repository.searchByKeyword(
+            keyword = "문래동",
+        )
+
+        assertEquals(listOf(1, 2), apiService.requestedPageNos)
+        assertEquals(
+            listOf("1페이지 수거함", "1페이지 재활용센터", "2페이지 수거함"),
+            result.map { spot -> spot.name },
+        )
     }
 
     @Test
@@ -268,10 +305,12 @@ class CollectionSpotRepositoryImplTest {
 
     private class FakeSpotApiService(
         private val response: SpotResponseDto,
+        private val responsesByPage: Map<Int, SpotResponseDto> = emptyMap(),
     ) : SpotApiService {
 
         var requestedServiceKey: String? = null
         var requestedPageNo: Int? = null
+        val requestedPageNos = mutableListOf<Int>()
         var requestedNumOfRows: Int? = null
         var requestedAddr: String? = null
         var requestedLatitude: Double? = null
@@ -291,6 +330,7 @@ class CollectionSpotRepositoryImplTest {
         ): SpotResponseDto {
             requestedServiceKey = serviceKey
             requestedPageNo = pageNo
+            requestedPageNos += pageNo
             requestedNumOfRows = numOfRows
             requestedAddr = addr
             requestedLatitude = latitude
@@ -298,7 +338,7 @@ class CollectionSpotRepositoryImplTest {
             requestedRadius = radius
             requestedType = type
 
-            return response
+            return responsesByPage[pageNo] ?: response
         }
     }
 
@@ -405,6 +445,40 @@ class CollectionSpotRepositoryImplTest {
                         ),
                     ),
                 ),
+            )
+        }
+
+        fun createResponse(
+            pageNo: Int?,
+            numOfRows: Int?,
+            totalCount: Int?,
+            items: List<SpotItemDto>,
+        ): SpotResponseDto {
+            return SpotResponseDto(
+                response = SpotResponseBodyDto(
+                    header = SpotHeaderDto(
+                        resultCode = "00",
+                        resultMsg = "NORMAL SERVICE",
+                    ),
+                    body = SpotBodyDto(
+                        items = SpotItemsDto(item = items),
+                        numOfRows = numOfRows?.let(::JsonPrimitive),
+                        pageNo = pageNo?.let(::JsonPrimitive),
+                        totalCount = totalCount?.let(::JsonPrimitive),
+                    ),
+                ),
+            )
+        }
+
+        fun spotItem(
+            name: String,
+            address: String,
+            detailAddress: String,
+        ): SpotItemDto {
+            return SpotItemDto(
+                spotNm = name,
+                addrBase = address,
+                addrDtl = detailAddress,
             )
         }
 

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/CollectionSpotSearchResult.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/model/CollectionSpotSearchResult.kt
@@ -1,0 +1,6 @@
+package com.team.yeogibeoryeo.domain.spot.model
+
+data class CollectionSpotSearchResult(
+    val spots: List<CollectionSpot>,
+    val isPartial: Boolean = false,
+)

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/CollectionSpotRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/CollectionSpotRepository.kt
@@ -1,6 +1,7 @@
 package com.team.yeogibeoryeo.domain.spot.repository
 
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotSearchResult
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 
@@ -10,6 +11,18 @@ interface CollectionSpotRepository {
         keyword: String,
         types: Set<CollectionSpotType> = emptySet()
     ): List<CollectionSpot>
+
+    suspend fun searchByKeywordResult(
+        keyword: String,
+        types: Set<CollectionSpotType> = emptySet()
+    ): CollectionSpotSearchResult {
+        return CollectionSpotSearchResult(
+            spots = searchByKeyword(
+                keyword = keyword,
+                types = types,
+            ),
+        )
+    }
 
     suspend fun searchByLocation(
         coordinate: Coordinate,

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
@@ -2,6 +2,7 @@ package com.team.yeogibeoryeo.domain.spot.usecase
 
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotAddressSearchPolicy
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotSearchResult
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
@@ -16,14 +17,30 @@ class SearchCollectionSpotsByKeywordUseCase @Inject constructor(
         types: Set<CollectionSpotType> = emptySet(),
         selectedRegionCandidate: MapRegionSearchCandidate? = null,
     ): List<CollectionSpot> {
-        val normalizedKeyword = normalizeKeywordUseCase(keyword)
+        return searchWithResult(
+            keyword = keyword,
+            types = types,
+            selectedRegionCandidate = selectedRegionCandidate,
+        ).spots
+    }
 
-        return repository.searchByKeyword(
+    suspend fun searchWithResult(
+        keyword: String,
+        types: Set<CollectionSpotType> = emptySet(),
+        selectedRegionCandidate: MapRegionSearchCandidate? = null,
+    ): CollectionSpotSearchResult {
+        val normalizedKeyword = normalizeKeywordUseCase(keyword)
+        val result = repository.searchByKeywordResult(
             keyword = normalizedKeyword,
             types = types,
         )
-            .filterByExplicitRegionKeyword(normalizedKeyword)
-            .filterBySelectedRegionCandidate(selectedRegionCandidate)
+
+        return CollectionSpotSearchResult(
+            spots = result.spots
+                .filterByExplicitRegionKeyword(normalizedKeyword)
+                .filterBySelectedRegionCandidate(selectedRegionCandidate),
+            isPartial = result.isPartial,
+        )
     }
 
     private fun List<CollectionSpot>.filterByExplicitRegionKeyword(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapScreen.kt
@@ -448,6 +448,7 @@ private fun CollectionSpotMapContent(
                             regionSearchCandidates = uiState.regionSearchCandidates,
                             locationNotice = uiState.locationNotice,
                             errorMessageResId = uiState.errorMessageResId,
+                            partialWarningMessageResId = uiState.partialWarningMessageResId,
                             onTypeClick = onTypeClick,
                             onRegionCandidateClick = onRegionCandidateClick,
                             onLocationNoticeActionClick = onLocationNoticeActionClick,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapUiState.kt
@@ -14,6 +14,7 @@ data class CollectionSpotMapUiState(
     val selectedTypes: Set<CollectionSpotType> = emptySet(),
     val isLoading: Boolean = false,
     @param:StringRes val errorMessageResId: Int? = null,
+    @param:StringRes val partialWarningMessageResId: Int? = null,
     val hasSearched: Boolean = false,
     val locationNotice: MapLocationNotice? = null,
     val favoriteSpotMoveRequestId: String? = null,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -7,6 +7,7 @@ import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
 import com.team.yeogibeoryeo.domain.favorite.usecase.ObserveFavoritesUseCase
 import com.team.yeogibeoryeo.domain.favorite.usecase.ToggleCollectionSpotFavoriteUseCase
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotSearchResult
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
@@ -108,6 +109,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     it.hasSearched
                 },
                 errorMessageResId = null,
+                partialWarningMessageResId = null,
                 locationNotice = null,
                 isFavoriteSpotNearbyLoading = false,
                 searchMode = if (shouldCancelSpotSearch) {
@@ -134,6 +136,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     isLoading = false,
                     hasSearched = false,
                     errorMessageResId = R.string.map_search_blank_keyword_message,
+                    partialWarningMessageResId = null,
                     locationNotice = null,
                     regionSearchCandidates = emptyList(),
                     isFavoriteSpotNearbyLoading = false,
@@ -183,8 +186,8 @@ class CollectionSpotMapViewModel @Inject constructor(
                 keyword = keyword,
                 selectedRegionCandidate = selectedRegionCandidate,
             )
-        }.onSuccess { spots ->
-            updateSpotResult(spots)
+        }.onSuccess { result ->
+            updateSpotResult(result)
         }.onFailure { throwable ->
             if (throwable is CancellationException) throw throwable
 
@@ -200,6 +203,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isLoading = true,
                 hasSearched = true,
                 errorMessageResId = null,
+                partialWarningMessageResId = null,
                 locationNotice = null,
                 regionSearchCandidates = emptyList(),
                 selectedSpot = null,
@@ -212,21 +216,25 @@ class CollectionSpotMapViewModel @Inject constructor(
     private suspend fun searchByCandidateKeywords(
         keyword: String,
         selectedRegionCandidate: MapRegionSearchCandidate?,
-    ): List<CollectionSpot> {
+    ): CollectionSpotSearchResult {
         val searchKeywords = selectedRegionCandidate
             ?.searchKeywords
             ?.takeIf { keywords -> keywords.isNotEmpty() }
             ?: listOf(keyword)
+        val results = searchKeywords.map { searchKeyword ->
+            searchCollectionSpotsByKeywordUseCase.searchWithResult(
+                keyword = searchKeyword,
+                types = emptySet(),
+                selectedRegionCandidate = selectedRegionCandidate,
+            )
+        }
 
-        return searchKeywords
-            .flatMap { searchKeyword ->
-                searchCollectionSpotsByKeywordUseCase(
-                    keyword = searchKeyword,
-                    types = emptySet(),
-                    selectedRegionCandidate = selectedRegionCandidate,
-                )
-            }
-            .distinctBy { spot -> spot.id }
+        return CollectionSpotSearchResult(
+            spots = results
+                .flatMap { result -> result.spots }
+                .distinctBy { spot -> spot.id },
+            isPartial = results.any { result -> result.isPartial },
+        )
     }
 
     private fun showRegionSearchCandidates(candidates: List<MapRegionSearchCandidate>) {
@@ -240,6 +248,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isLoading = false,
                 hasSearched = false,
                 errorMessageResId = null,
+                partialWarningMessageResId = null,
                 locationNotice = null,
                 isFavoriteSpotNearbyLoading = false,
                 searchMode = MapSearchMode.KEYWORD,
@@ -280,6 +289,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     isLoading = true,
                     hasSearched = true,
                     errorMessageResId = null,
+                    partialWarningMessageResId = null,
                     locationNotice = null,
                     regionSearchCandidates = emptyList(),
                     selectedSpot = null,
@@ -295,7 +305,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     types = emptySet(),
                 )
             }.onSuccess { spots ->
-                updateSpotResult(spots)
+                updateSpotResult(CollectionSpotSearchResult(spots = spots))
             }.onFailure { throwable ->
                 if (throwable is CancellationException) throw throwable
 
@@ -321,7 +331,7 @@ class CollectionSpotMapViewModel @Inject constructor(
 
             val spotsWithDistance = spots.withDistanceFrom(coordinate)
 
-            updateSpotResult(spotsWithDistance)
+            updateSpotResult(CollectionSpotSearchResult(spots = spotsWithDistance))
             saveRecentCurrentLocationSpotsUseCase(spotsWithDistance)
         } catch (throwable: Throwable) {
             if (throwable is CancellationException) throw throwable
@@ -387,6 +397,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 ),
                 isLoading = false,
                 errorMessageResId = null,
+                partialWarningMessageResId = null,
                 locationNotice = null,
                 regionSearchCandidates = emptyList(),
                 favoriteSpotMoveRequestId = request.targetId,
@@ -439,6 +450,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isLoading = false,
                 hasSearched = false,
                 errorMessageResId = null,
+                partialWarningMessageResId = null,
                 locationNotice = MapLocationNotices.PermissionDenied,
                 regionSearchCandidates = emptyList(),
                 isFavoriteSpotNearbyLoading = false,
@@ -522,6 +534,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isLoading = false,
                 hasSearched = false,
                 errorMessageResId = null,
+                partialWarningMessageResId = null,
                 locationNotice = MapLocationNotices.CurrentLocationUnavailable,
                 regionSearchCandidates = emptyList(),
                 isFavoriteSpotNearbyLoading = false,
@@ -540,6 +553,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isLoading = false,
                 hasSearched = false,
                 errorMessageResId = null,
+                partialWarningMessageResId = null,
                 locationNotice = MapLocationNotices.LocationServiceDisabled,
                 regionSearchCandidates = emptyList(),
                 isFavoriteSpotNearbyLoading = false,
@@ -548,8 +562,8 @@ class CollectionSpotMapViewModel @Inject constructor(
         }
     }
 
-    private fun updateSpotResult(spots: List<CollectionSpot>) {
-        originalSpots = spots.withFavoriteState()
+    private fun updateSpotResult(result: CollectionSpotSearchResult) {
+        originalSpots = result.spots.withFavoriteState()
 
         val filteredSpots = filterCollectionSpotsUseCase(
             spots = originalSpots,
@@ -563,6 +577,11 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isLoading = false,
                 hasSearched = true,
                 errorMessageResId = null,
+                partialWarningMessageResId = if (result.isPartial) {
+                    R.string.map_spot_search_partial_failure_message
+                } else {
+                    null
+                },
                 locationNotice = null,
                 regionSearchCandidates = emptyList(),
                 isFavoriteSpotNearbyLoading = false,
@@ -601,6 +620,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                         isFavoriteSpotNearbyLoading = false,
                         hasSearched = true,
                         errorMessageResId = null,
+                        partialWarningMessageResId = null,
                         locationNotice = null,
                         regionSearchCandidates = emptyList(),
                         searchMode = MapSearchMode.CURRENT_LOCATION,
@@ -626,6 +646,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isLoading = false,
                 hasSearched = true,
                 errorMessageResId = messageResId,
+                partialWarningMessageResId = null,
                 locationNotice = null,
                 regionSearchCandidates = emptyList(),
                 isFavoriteSpotNearbyLoading = false,
@@ -643,6 +664,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                     isLoading = true,
                     hasSearched = true,
                     errorMessageResId = null,
+                    partialWarningMessageResId = null,
                     locationNotice = null,
                     regionSearchCandidates = emptyList(),
                     selectedSpot = null,
@@ -693,6 +715,7 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isLoading = false,
                 hasSearched = true,
                 errorMessageResId = null,
+                partialWarningMessageResId = null,
                 locationNotice = null,
                 regionSearchCandidates = emptyList(),
                 isFavoriteSpotNearbyLoading = false,

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/components/SpotBottomSheetContent.kt
@@ -43,6 +43,7 @@ fun SpotBottomSheetContent(
     regionSearchCandidates: List<MapRegionSearchCandidate>,
     locationNotice: MapLocationNotice?,
     @StringRes errorMessageResId: Int?,
+    @StringRes partialWarningMessageResId: Int? = null,
     onTypeClick: (CollectionSpotType) -> Unit,
     onRegionCandidateClick: (MapRegionSearchCandidate) -> Unit,
     onLocationNoticeActionClick: (MapLocationNoticeAction) -> Unit,
@@ -53,6 +54,11 @@ fun SpotBottomSheetContent(
 ) {
     val hasNoticeOrError = locationNotice != null ||
         errorMessageResId != null
+    val shouldShowPartialWarning = partialWarningMessageResId != null &&
+        spots.isNotEmpty() &&
+        !isLoading &&
+        !hasNoticeOrError &&
+        regionSearchCandidates.isEmpty()
 
     Column(
         modifier = modifier.fillMaxSize(),
@@ -61,6 +67,15 @@ fun SpotBottomSheetContent(
             resultCount = spots.size,
             hasSearched = hasSearched,
         )
+
+        if (shouldShowPartialWarning) {
+            Text(
+                text = stringResource(partialWarningMessageResId),
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
 
         if (
             hasSearched &&

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -213,6 +213,7 @@ SOFTWARE.]]></string>
     <string name="map_search_loading_map_center">현 지도 주변을 찾고 있어요</string>
     <string name="map_search_blank_keyword_message">검색어를 입력해주세요.</string>
     <string name="map_spot_search_failure_message">잠시 후 다시 시도하거나 네트워크 연결을 확인해 주세요.</string>
+    <string name="map_spot_search_partial_failure_message">일부 결과를 불러오지 못했어요. 다시 검색해 주세요.</string>
     <string name="map_current_location_spot_search_failure_message">네트워크 연결을 확인한 뒤 다시 시도하거나 직접 동/읍/면을 검색해 주세요.</string>
     <string name="map_spot_search_title">수거 장소 검색</string>
     <string name="map_spot_result_count">검색 결과 %1$d개</string>

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapSearchViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapSearchViewModelTest.kt
@@ -5,6 +5,7 @@ import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
+import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.map.location.CurrentLocationResult
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -466,6 +467,31 @@ class CollectionSpotMapSearchViewModelTest : CollectionSpotMapViewModelTestFixtu
                 viewModel.uiState.value.errorMessageResId,
             )
             assertNull(viewModel.uiState.value.locationNotice)
+        }
+
+    @Test
+    fun `키워드 검색이 일부 실패하면 조회된 결과와 일부 실패 안내를 함께 표시한다`() =
+        runTest {
+            val expectedSpots = listOf(sampleSpot("partial", CollectionSpotType.BATTERY_BIN))
+            val repository = FakeCollectionSpotRepository(
+                keywordSpots = expectedSpots,
+                isKeywordSearchPartial = true,
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+            )
+
+            viewModel.onSearchKeywordChanged("상동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            assertEquals(expectedSpots, viewModel.uiState.value.spots)
+            assertEquals(
+                R.string.map_spot_search_partial_failure_message,
+                viewModel.uiState.value.partialWarningMessageResId,
+            )
+            assertNull(viewModel.uiState.value.errorMessageResId)
         }
 
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapSearchViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapSearchViewModelTest.kt
@@ -210,6 +210,52 @@ class CollectionSpotMapSearchViewModelTest : CollectionSpotMapViewModelTestFixtu
         }
 
     @Test
+    fun `지역 후보 선택 후 다건 검색 결과를 선택 지역 필터와 함께 표시한다`() =
+        runTest {
+            val selectedRegionSpot = sampleSpot("gwangju-geumho", CollectionSpotType.STANDARD_BAG_STORE)
+                .copy(address = "광주광역시 서구 금호동")
+            val selectedRegionRoadAddressSpot = sampleSpot("gwangju-geumho-road", CollectionSpotType.BATTERY_BIN)
+                .copy(address = "광주광역시 서구 운천로 10")
+            val otherRegionSpot = sampleSpot("seoul-geumho", CollectionSpotType.STANDARD_BAG_STORE)
+                .copy(address = "서울특별시 성동구 금호동")
+            val repository = FakeCollectionSpotRepository(
+                keywordSpots = listOf(
+                    selectedRegionSpot,
+                    selectedRegionRoadAddressSpot,
+                    otherRegionSpot,
+                ),
+            )
+            val regionOptionsRepository = FakeMapRegionOptionsRepository(
+                eupmyeondongCandidates = mapOf(
+                    "금호동" to listOf(
+                        Region(sido = "서울특별시", sigungu = "성동구", eupmyeondong = "금호동"),
+                        Region(sido = "광주광역시", sigungu = "서구", eupmyeondong = "금호동"),
+                    ),
+                ),
+            )
+            val viewModel = createViewModel(
+                repository = repository,
+                currentLocationResult = CurrentLocationResult.NotFound,
+                regionOptionsRepository = regionOptionsRepository,
+            )
+
+            viewModel.onSearchKeywordChanged("금호동")
+            viewModel.searchByKeyword()
+            advanceUntilIdle()
+
+            val candidate = viewModel.uiState.value.regionSearchCandidates
+                .first { it.displayName == "광주광역시 서구 금호동" }
+            viewModel.onRegionSearchCandidateClick(candidate)
+            advanceUntilIdle()
+
+            assertEquals(listOf("금호동"), repository.keywords)
+            assertEquals(
+                listOf(selectedRegionSpot, selectedRegionRoadAddressSpot),
+                viewModel.uiState.value.spots,
+            )
+        }
+
+    @Test
     fun `지역 범위가 포함된 동 검색어는 후보를 좁혀 바로 검색한다`() =
         runTest {
             val expectedSpot = sampleSpot("seoul-myeongdong", CollectionSpotType.STANDARD_BAG_STORE)

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTestFixture.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTestFixture.kt
@@ -12,6 +12,7 @@ import com.team.yeogibeoryeo.domain.favorite.usecase.ToggleCollectionSpotFavorit
 import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.region.repository.RegionOptionsRepository
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotSearchResult
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.model.RecentCurrentLocationSpotCacheEntry
@@ -220,6 +221,7 @@ internal class FakeRecentCurrentLocationSpotCacheRepository(
 internal class FakeCollectionSpotRepository(
     internal val keywordSpots: List<CollectionSpot> = emptyList(),
     internal val locationSpots: List<CollectionSpot> = emptyList(),
+    internal val isKeywordSearchPartial: Boolean = false,
     internal val keywordSearchThrowable: Throwable? = null,
     internal val locationSearchThrowable: Throwable? = null,
     internal val locationSearchResultProvider: (suspend () -> List<CollectionSpot>)? = null,
@@ -236,6 +238,19 @@ internal class FakeCollectionSpotRepository(
         keywords += keyword
         keywordSearchThrowable?.let { throw it }
         return keywordSpots
+    }
+
+    override suspend fun searchByKeywordResult(
+        keyword: String,
+        types: Set<CollectionSpotType>,
+    ): CollectionSpotSearchResult {
+        return CollectionSpotSearchResult(
+            spots = searchByKeyword(
+                keyword = keyword,
+                types = types,
+            ),
+            isPartial = isKeywordSearchPartial,
+        )
     }
 
     override suspend fun searchByLocation(


### PR DESCRIPTION
Related: #244

## 작업 내용

- `/getSpot addr` 검색에서 `totalCount` 기준으로 추가 페이지를 반복 조회하도록 개선했습니다.
- 여러 페이지 결과를 병합하고, 동일 수거 장소가 중복 표시되지 않도록 중복 제거를 적용했습니다.
- 추가 페이지 조회 중 일부 실패가 발생해도 앱이 실패 상태로 전환되지 않고, 이미 조회된 결과를 유지하도록 처리했습니다.
- 후보 선택 검색과 일반 키워드 검색의 `addr` 기반 검색 결과 누락을 함께 보완했습니다.
- 현재 위치 검색 / 현 지도 검색의 좌표 기반 검색 흐름은 기존 동작을 유지했습니다.

## 좌표 기반 보강 검색 미적용 사유

이번 작업에서는 좌표 기반 보강 검색을 구현하지 않았습니다.

페이지 반복 조회 적용 후 `삼성동 → 대전광역시 동구 삼성동` 케이스에서 기대하던 80건 결과와 마커가 정상적으로 표시되는 것을 확인했습니다.  
즉, 이번 이슈의 주요 누락 원인은 좌표 기반 검색 부재보다 `/getSpot addr` 검색의 페이지 반복 조회 누락으로 판단했습니다.

좌표 기반 보강 검색은 현재 단계에서 다음 위험이 더 크다고 봤습니다.

- 후보 지역 중심 좌표를 안정적으로 확보하는 구조가 아직 없음
- 보강 반경 기준을 잘못 잡으면 선택 지역 밖 결과가 섞일 수 있음
- `addr` 결과와 좌표 결과의 의미가 달라 사용자에게 혼란을 줄 수 있음
- 현재 지도에서 검색 기능과 역할이 겹칠 수 있음
- 결과 병합, 중복 제거, 지역 필터링, 안내 문구까지 함께 설계해야 해서 변경 범위가 커짐

따라서 이번 PR에서는 `/getSpot addr` 페이지 반복 조회로 확인된 누락을 먼저 해결하고, 좌표 기반 보강 검색은 적용하지 않는 것으로 결정했습니다.

## 테스트 결과

### 실기기 확인

| 금호동 후보 선택 | 금호동 검색 결과 개선 |
| --- | --- |
| <img width="260" height="550" alt="금호동 검색 및 광주광역시 서구 금호동 후보 선택" src="https://github.com/user-attachments/assets/4bfec8d0-c74f-4cfc-a670-91dc40f6f7e8" /> | <img width="260" height="550" alt="금호동 후보 선택 후 검색 결과 마커 개선" src="https://github.com/user-attachments/assets/f6c9d873-ef5d-476c-a33c-75135e726973" /> |
| `금호동` 검색 후 `광주광역시 서구 금호동` 후보 선택 | 초기 11건 수준으로 적게 나오던 것과 달리 다수의 검색 결과 마커 표시 확인 |

| 삼성동 후보 선택 | 삼성동 검색 결과 개선 |
| --- | --- |
| <img width="320" alt="삼성동 검색 및 대전광역시 동구 삼성동 후보 선택" src="https://github.com/user-attachments/assets/b2149801-8ca9-4081-b242-c01aff3809ed" /> | <img width="320" alt="삼성동 후보 선택 후 검색 결과 개선" src="https://github.com/user-attachments/assets/ed575b7e-0ce5-42a3-9a14-ef663713934b" /> |
| `삼성동` 검색 후 `대전광역시 동구 삼성동` 후보 선택 | 기대 결과인 80건 검색 결과와 마커 표시 확인 |

### 확인한 시나리오

- [x] `금호동` → `광주광역시 서구 금호동` 후보 선택
- [x] `삼성동` → `대전광역시 동구 삼성동` 후보 선택
- [x] `신사동` → `서울특별시 강남구 신사동` 후보 선택
- [x] `대흥동` → `대전광역시 중구 대흥동` 후보 선택
- [x] 후보 선택 결과와 `현재 지도에서 검색` 결과 비교
- [x] `성동구 금호동` 검색 결과 회귀 확인
- [x] `서울 중구 명동` 검색 결과 회귀 확인
- [x] 페이지 반복 조회 결과 중복 제거 확인
- [x] 선택 지역 밖 결과가 과도하게 섞이지 않는지 확인
- [x] 현재 위치 검색 / 현 지도 검색 / 필터 / 마커 / BottomSheet / 즐겨찾기 동작 유지 확인

### 실행한 검증 명령

- [x] `./gradlew.bat :data:testDebugUnitTest --tests com.team.yeogibeoryeo.data.spot.remote.datasource.SpotRemoteDataSourceTest --tests com.team.yeogibeoryeo.data.spot.repository.CollectionSpotRepositoryImplTest`
- [x] `./gradlew.bat :presentation:testDebugUnitTest --tests com.team.yeogibeoryeo.presentation.map.CollectionSpotMapSearchViewModelTest`
- [x] `./gradlew.bat :domain:test`
- [x] `./gradlew.bat :data:testDebugUnitTest`
- [x] `./gradlew.bat :presentation:testDebugUnitTest`
- [x] `./gradlew.bat :presentation:compileDebugKotlin`
- [x] `./gradlew.bat :app:assembleDebug`
- [x] `git diff --check`