### PR TITLE
[Feat/Fix] 품목 검색 화면 레이아웃 고도화 및 UI/UX 개선

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -63,10 +63,12 @@ fun YeogiBeoryeoNavHost(
     val currentBackStackEntry = navController.currentBackStackEntryAsState().value
     val currentDestination = currentBackStackEntry?.destination
     val isMapScreen = currentDestination?.hasRoute<MapRoute>() == true
+    val isItemSearchScreen = currentDestination?.hasRoute<ItemSearchRoute>() == true
     val isItemDetailScreen = currentDestination?.hasRoute<ItemGuideDetailRoute>() == true
     val isUsefulGuideScreen = currentDestination?.hasRoute<ItemUsefulGuideRoute>() == true
     val isSettingsDetailScreen = currentDestination?.hasRoute<SettingsDetailRoute>() == true
-    val hidesBottomBarOnScroll = isItemDetailScreen || isUsefulGuideScreen || isSettingsDetailScreen
+    val hidesBottomBarOnScroll =
+        isItemSearchScreen || isItemDetailScreen || isUsefulGuideScreen || isSettingsDetailScreen
     var isBottomBarVisible by remember { mutableStateOf(true) }
 
     LaunchedEffect(currentBackStackEntry) {
@@ -210,6 +212,11 @@ fun YeogiBeoryeoNavHost(
                     },
                     onSettingsClick = {
                         navController.navigate(SettingsRoute)
+                    },
+                    onBottomBarVisibilityChanged = { isVisible ->
+                        if (isItemSearchScreen) {
+                            isBottomBarVisible = isVisible
+                        }
                     },
                 )
             }

--- a/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreenTest.kt
+++ b/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreenTest.kt
@@ -93,6 +93,7 @@ class ItemSearchScreenTest {
                 ItemSearchScreen(
                     uiState =
                         ItemSearchUiState(
+                            query = "유리",
                             hasSearched = true,
                             guides = listOf(sampleGuide("유리병")),
                         ),
@@ -104,8 +105,69 @@ class ItemSearchScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("검색 결과 1건").assertIsDisplayed()
         composeTestRule.onNodeWithText("유리병").assertIsDisplayed()
+    }
+
+    @Test
+    fun 검색_결과_화면에서_뒤로가기_버튼을_누르면_검색을_초기화한다() {
+        var backClickCount = 0
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                ItemSearchScreen(
+                    uiState =
+                        ItemSearchUiState(
+                            query = "유리",
+                            hasSearched = true,
+                            guides = listOf(sampleGuide("유리병")),
+                        ),
+                    onQueryChange = {},
+                    onSearchClick = {},
+                    onGuideClick = {},
+                    onQuickCategoryClick = {},
+                    onBackClick = { backClickCount += 1 },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("품목 검색").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("뒤로가기").performClick()
+
+        assertEquals(1, backClickCount)
+    }
+
+    @Test
+    fun 검색_결과에서_초기_상태로_돌아오면_하단_네비게이션을_다시_보이게_요청한다() {
+        var uiState by mutableStateOf(
+            ItemSearchUiState(
+                query = "유리",
+                hasSearched = true,
+                guides = listOf(sampleGuide("유리병")),
+            ),
+        )
+        var isBottomBarVisible = false
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                ItemSearchScreen(
+                    uiState = uiState,
+                    onQueryChange = {},
+                    onSearchClick = {},
+                    onGuideClick = {},
+                    onQuickCategoryClick = {},
+                    onBottomBarVisibilityChanged = { isBottomBarVisible = it },
+                )
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            isBottomBarVisible = false
+            uiState = ItemSearchUiState()
+        }
+
+        composeTestRule.runOnIdle {
+            assertEquals(true, isBottomBarVisible)
+        }
     }
 
     @Test

--- a/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreenTest.kt
+++ b/presentation/src/androidTest/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreenTest.kt
@@ -229,7 +229,7 @@ class ItemSearchScreenTest {
     @Test
     fun 결과_카드를_누르면_선택한_가이드를_전달한다() {
         var clickedGuide: DisposalItemGuide? = null
-        val guide = sampleGuide("유리병")
+        val guide = sampleGuide("플라스틱병")
 
         composeTestRule.setContent {
             MaterialTheme {
@@ -243,7 +243,7 @@ class ItemSearchScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("유리병").performClick()
+        composeTestRule.onNodeWithText("플라스틱병").performClick()
 
         assertEquals(guide, clickedGuide)
     }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/effects/BottomBarVisibilityOnScrollEffect.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/common/effects/BottomBarVisibilityOnScrollEffect.kt
@@ -17,16 +17,20 @@ internal fun BottomBarVisibilityOnScrollEffect(
 
     LaunchedEffect(scrollState) {
         var previousOffset = 0
+        var previousVisibility = true
         onBottomBarVisibilityChangedState(true)
 
         snapshotFlow { scrollState.value }
             .collect { currentOffset ->
-                when {
-                    currentOffset == 0 -> onBottomBarVisibilityChangedState(true)
-                    currentOffset > previousOffset -> onBottomBarVisibilityChangedState(false)
-                    currentOffset < previousOffset -> {
-                        onBottomBarVisibilityChangedState(true)
-                    }
+                val isVisible = when {
+                    currentOffset == 0 -> true
+                    currentOffset > previousOffset -> false
+                    currentOffset < previousOffset -> true
+                    else -> previousVisibility
+                }
+                if (isVisible != previousVisibility) {
+                    onBottomBarVisibilityChangedState(isVisible)
+                    previousVisibility = isVisible
                 }
                 previousOffset = currentOffset
             }
@@ -42,6 +46,7 @@ internal fun BottomBarVisibilityOnScrollEffect(
 
     LaunchedEffect(listState) {
         var previousPosition = 0L
+        var previousVisibility = true
         onBottomBarVisibilityChangedState(true)
 
         snapshotFlow {
@@ -49,12 +54,15 @@ internal fun BottomBarVisibilityOnScrollEffect(
                 listState.firstVisibleItemScrollOffset
             position to (listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0)
         }.collect { (currentPosition, isAtTop) ->
-            when {
-                isAtTop -> onBottomBarVisibilityChangedState(true)
-                currentPosition > previousPosition -> onBottomBarVisibilityChangedState(false)
-                currentPosition < previousPosition -> {
-                    onBottomBarVisibilityChangedState(true)
-                }
+            val isVisible = when {
+                isAtTop -> true
+                currentPosition > previousPosition -> false
+                currentPosition < previousPosition -> true
+                else -> previousVisibility
+            }
+            if (isVisible != previousVisibility) {
+                onBottomBarVisibilityChangedState(isVisible)
+                previousVisibility = isVisible
             }
             previousPosition = currentPosition
         }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.AssistChip
@@ -28,12 +29,14 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.common.components.AppTopBarDefaults
 import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
@@ -163,7 +166,12 @@ fun ItemSearchInitialContent(
                     placeholder = stringResource(R.string.item_search_query_label),
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = metrics.horizontalPadding),
+                        .padding(horizontal = metrics.horizontalPadding)
+                        .shadow(
+                            elevation = 6.dp,
+                            shape = RoundedCornerShape(12.dp),
+                            clip = false,
+                        ),
                     iconSize = metrics.searchIconSize,
                 )
             }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -1,35 +1,56 @@
 package com.team.yeogibeoryeo.presentation.search
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.team.yeogibeoryeo.domain.item.model.DisposalItemGuide
 import com.team.yeogibeoryeo.presentation.R
-import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
+import com.team.yeogibeoryeo.presentation.common.components.AppBackButton
+import com.team.yeogibeoryeo.presentation.common.components.AppTopBar
+import com.team.yeogibeoryeo.presentation.common.effects.BottomBarVisibilityOnScrollEffect
 import com.team.yeogibeoryeo.presentation.search.components.DisposalItemCard
 import com.team.yeogibeoryeo.presentation.search.components.EmptySearchResult
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchBar
@@ -37,6 +58,7 @@ import com.team.yeogibeoryeo.presentation.search.components.ItemSearchLoadingCon
 import com.team.yeogibeoryeo.presentation.search.model.HomeRegionalGuideSummaryUiState
 import com.team.yeogibeoryeo.presentation.search.model.ItemUsefulGuideContent
 import com.team.yeogibeoryeo.presentation.search.model.RepresentativeGuideCategory
+import kotlinx.coroutines.launch
 
 @Composable
 fun ItemSearchRoute(
@@ -47,6 +69,7 @@ fun ItemSearchRoute(
     onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
     initialQuery: String? = null,
+    onBottomBarVisibilityChanged: (Boolean) -> Unit = {},
     viewModel: ItemSearchViewModel = hiltViewModel(),
     regionalGuideSummaryViewModel: HomeRegionalGuideSummaryViewModel = hiltViewModel(),
 ) {
@@ -102,12 +125,15 @@ fun ItemSearchRoute(
             viewModel::resetQuickCategoryFixedCollapsedItemCountIfCollapsed,
         onQuickCategorySettingsClick = onQuickCategorySettingsClick,
         onSettingsClick = onSettingsClick,
+        onBackClick = viewModel::clearSearch,
         searchResultListState = searchResultListState,
         categoryListState = categoryListState,
-        modifier = modifier.statusBarsPadding(),
+        onBottomBarVisibilityChanged = onBottomBarVisibilityChanged,
+        modifier = modifier,
     )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ItemSearchScreen(
     uiState: ItemSearchUiState,
@@ -125,9 +151,17 @@ fun ItemSearchScreen(
     onQuickCategoryViewportChanged: () -> Unit = {},
     onQuickCategorySettingsClick: (Int) -> Unit = {},
     onSettingsClick: (() -> Unit)? = null,
+    onBackClick: () -> Unit = {},
     searchResultListState: LazyListState = rememberLazyListState(),
     categoryListState: LazyListState = rememberLazyListState(),
+    onBottomBarVisibilityChanged: (Boolean) -> Unit = {},
 ) {
+    LaunchedEffect(uiState.hasSearched, uiState.guides.isEmpty()) {
+        if (!uiState.hasSearched || uiState.guides.isEmpty()) {
+            onBottomBarVisibilityChanged(true)
+        }
+    }
+
     if (!uiState.hasSearched && !uiState.isLoading && uiState.errorMessageResId == null) {
         ItemSearchInitialContent(
             query = uiState.query,
@@ -152,7 +186,7 @@ fun ItemSearchScreen(
             onQuickCategoryViewportChanged = onQuickCategoryViewportChanged,
             onSettingsClick = onSettingsClick,
             listState = categoryListState,
-            modifier = modifier,
+            modifier = modifier.statusBarsPadding(),
         )
         return
     }
@@ -164,78 +198,186 @@ fun ItemSearchScreen(
     ) {
         val spacing = ItemSearchLayoutDefaults.spacing
         val metrics = itemSearchScreenMetrics(maxWidth = maxWidth)
+        val density = LocalDensity.current
+        val coroutineScope = rememberCoroutineScope()
+
+        if (uiState.guides.isNotEmpty()) {
+            val statusBarTopPadding = with(density) {
+                WindowInsets.statusBars.getTop(this).toDp()
+            }
+            val stuckHeaderTopPadding = statusBarTopPadding + spacing.xs
+            val isSearchResultHeaderStuck by remember(searchResultListState) {
+                derivedStateOf {
+                    searchResultListState.firstVisibleItemIndex >= SearchResultHeaderItemIndex
+                }
+            }
+            val searchResultHeaderTopPadding by animateDpAsState(
+                targetValue = if (isSearchResultHeaderStuck) stuckHeaderTopPadding else 0.dp,
+                label = "searchResultHeaderTopPadding",
+            )
+            val showScrollToTopButton by remember(searchResultListState) {
+                derivedStateOf {
+                    searchResultListState.firstVisibleItemIndex > 0 ||
+                        searchResultListState.firstVisibleItemScrollOffset > 0
+                }
+            }
+
+            BottomBarVisibilityOnScrollEffect(
+                listState = searchResultListState,
+                onBottomBarVisibilityChanged = onBottomBarVisibilityChanged,
+            )
+
+            Box(modifier = Modifier.fillMaxSize()) {
+                LazyColumn(
+                    state = searchResultListState,
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(bottom = metrics.listBottomPadding),
+                    verticalArrangement = Arrangement.spacedBy(spacing.sm),
+                ) {
+                    item {
+                        ItemSearchTopBar(onBackClick = onBackClick)
+                    }
+
+                    stickyHeader {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .zIndex(SearchResultHeaderZIndex)
+                                .padding(bottom = metrics.sectionVerticalSpace)
+                        ) {
+                            ItemSearchBar(
+                                keyword = uiState.query,
+                                onKeywordChange = onQueryChange,
+                                onSearchClick = {
+                                    onSearchClick()
+                                },
+                                placeholder = stringResource(R.string.item_search_query_label),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = searchResultHeaderTopPadding)
+                                    .padding(horizontal = metrics.horizontalPadding)
+                                    .shadow(
+                                        elevation = 6.dp,
+                                        shape = RoundedCornerShape(12.dp),
+                                        clip = false,
+                                    ),
+                                iconSize = metrics.searchIconSize,
+                            )
+                        }
+                    }
+
+                    items(uiState.guides, key = { it.id }) { guide ->
+                        DisposalItemCard(
+                            guide = guide,
+                            onClick = { onGuideClick(guide) },
+                            isFavorite = guide.id in uiState.favoriteGuideIds,
+                            modifier = Modifier.padding(horizontal = metrics.horizontalPadding),
+                        )
+                    }
+                }
+
+                if (showScrollToTopButton) {
+                    FloatingActionButton(
+                        onClick = {
+                            coroutineScope.launch {
+                                searchResultListState.animateScrollToItem(0)
+                            }
+                        },
+                        modifier = Modifier
+                            .align(Alignment.BottomEnd)
+                            .padding(spacing.md),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.KeyboardArrowUp,
+                            contentDescription = stringResource(R.string.scroll_to_top_action),
+                        )
+                    }
+                }
+            }
+            return@BoxWithConstraints
+        }
 
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = metrics.horizontalPadding)
-                .padding(top = metrics.topPadding),
+                .fillMaxSize(),
             verticalArrangement = Arrangement.spacedBy(metrics.screenVerticalSpace),
         ) {
-            ItemSearchHeader()
-
-            ItemSearchBar(
-                keyword = uiState.query,
-                onKeywordChange = onQueryChange,
-                onSearchClick = {
-                    onSearchClick()
-                },
-                placeholder = stringResource(R.string.item_search_query_label),
-                modifier = Modifier.fillMaxWidth(),
-                iconSize = metrics.searchIconSize,
-            )
+            ItemSearchTopBar(onBackClick = onBackClick)
 
             Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(metrics.sectionVerticalSpace),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = metrics.horizontalPadding),
+                verticalArrangement = Arrangement.spacedBy(metrics.screenVerticalSpace),
             ) {
-                when {
-                    uiState.isLoading -> {
-                        ItemSearchLoadingContent(modifier = Modifier.fillMaxSize())
-                    }
+                ItemSearchBar(
+                    keyword = uiState.query,
+                    onKeywordChange = onQueryChange,
+                    onSearchClick = {
+                        onSearchClick()
+                    },
+                    placeholder = stringResource(R.string.item_search_query_label),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .shadow(
+                            elevation = 6.dp,
+                            shape = RoundedCornerShape(12.dp),
+                            clip = false,
+                        ),
+                    iconSize = metrics.searchIconSize,
+                )
 
-                    uiState.errorMessageResId != null -> {
-                        EmptySearchResult(
-                            title = stringResource(uiState.errorMessageResId),
-                            description = stringResource(R.string.retry_later_message),
-                        )
-                    }
-
-                    uiState.guides.isEmpty() -> {
-                        EmptySearchResult(
-                            title = stringResource(R.string.no_search_results_title),
-                            description = stringResource(R.string.no_search_results_description),
-                        )
-                    }
-
-                    else -> {
-                        val searchResultCountText = stringResource(
-                            R.string.search_results_count,
-                            uiState.guides.size,
-                        )
-                        KoreanLineBreakText(
-                            text = searchResultCountText,
-                            style = MaterialTheme.typography.titleLarge.copy(
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onSurface,
-                            ),
-                        )
-                        LazyColumn(
-                            state = searchResultListState,
-                            contentPadding = PaddingValues(bottom = metrics.listBottomPadding),
-                            verticalArrangement = Arrangement.spacedBy(spacing.sm),
-                        ) {
-                            items(uiState.guides, key = { it.id }) { guide ->
-                                DisposalItemCard(
-                                    guide = guide,
-                                    onClick = { onGuideClick(guide) },
-                                    isFavorite = guide.id in uiState.favoriteGuideIds,
-                                )
-                            }
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(metrics.sectionVerticalSpace),
+                ) {
+                    when {
+                        uiState.isLoading -> {
+                            ItemSearchLoadingContent(modifier = Modifier.fillMaxSize())
                         }
+
+                        uiState.errorMessageResId != null -> {
+                            EmptySearchResult(
+                                title = stringResource(uiState.errorMessageResId),
+                                description = stringResource(R.string.retry_later_message),
+                            )
+                        }
+
+                        uiState.guides.isEmpty() -> {
+                            EmptySearchResult(
+                                title = stringResource(R.string.no_search_results_title),
+                                description = stringResource(R.string.no_search_results_description),
+                            )
+                        }
+
+                        else -> Unit
                     }
                 }
             }
         }
     }
 }
+
+@Composable
+private fun ItemSearchTopBar(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AppTopBar(
+        modifier = modifier,
+        navigationIcon = {
+            AppBackButton(onClick = onBackClick)
+        },
+        title = {
+            Text(
+                text = stringResource(R.string.item_search_screen_title),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        },
+    )
+}
+
+private const val SearchResultHeaderItemIndex = 1
+private const val SearchResultHeaderZIndex = 1f

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -243,6 +243,7 @@ fun ItemSearchScreen(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .zIndex(SearchResultHeaderZIndex)
+                                .background(MaterialTheme.colorScheme.background)
                                 .padding(bottom = metrics.sectionVerticalSpace)
                         ) {
                             ItemSearchBar(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModel.kt
@@ -74,9 +74,7 @@ constructor(
         _uiState.update {
             it.copy(
                 query = query,
-                guides = emptyList(),
                 isLoading = false,
-                hasSearched = false,
                 errorMessageResId = null,
             )
         }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -41,6 +42,7 @@ fun DisposalItemCard(
 ) {
     val stroke = ItemSearchLayoutDefaults.stroke
     val elevation = ItemSearchLayoutDefaults.elevation
+    val shape = MaterialTheme.shapes.large
     val favoriteStateDescription =
         stringResource(
             if (isFavorite) {
@@ -54,6 +56,7 @@ fun DisposalItemCard(
     Card(
         modifier = modifier
             .fillMaxWidth()
+            .clip(shape)
             .semantics {
                 stateDescription = favoriteStateDescription
             }
@@ -62,7 +65,7 @@ fun DisposalItemCard(
                 role = Role.Button,
                 onClick = onClick,
             ),
-        shape = MaterialTheme.shapes.large,
+        shape = shape,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface,
         ),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/DisposalItemCard.kt
@@ -139,7 +139,7 @@ private fun BoxScope.FavoriteIndicator() {
 }
 
 @Composable
-private fun ColumnScope.DisposalItemTitle(text: String) {
+private fun DisposalItemTitle(text: String) {
     KoreanLineBreakText(
         text = text,
         modifier = Modifier
@@ -154,7 +154,7 @@ private fun ColumnScope.DisposalItemTitle(text: String) {
 }
 
 @Composable
-private fun ColumnScope.DisposalItemDescription(text: String) {
+private fun DisposalItemDescription(text: String) {
     KoreanLineBreakText(
         text = text,
         style = MaterialTheme.typography.bodyMedium.copy(

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -1,10 +1,12 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="item_search_query_label">무엇을 버리시나요?</string>
+    <string name="item_search_screen_title">품목 검색</string>
     <string name="item_search_title">여기 버려</string>
     <string name="item_search_description">품목 검색, 수거 장소, 지역별 배출 정보를 한 곳에서 확인하세요.</string>
     <string name="item_search_greeting">어서오세요!</string>
     <string name="item_search_prompt">무엇을 도와드릴까요?</string>
     <string name="search_action">검색</string>
+    <string name="scroll_to_top_action">맨 위로 이동</string>
     <string name="loading_action">로딩 중</string>
     <string name="retry_later_message">잠시 후 다시 시도해주세요.</string>
     <string name="search_load_failed_message">검색 결과를 불러오지 못했어요.</string>
@@ -75,7 +77,6 @@
     <string name="home_regional_guide_summary_retry_action">배출 정보 다시 불러오기</string>
     <string name="no_search_results_title">검색 결과가 없어요.</string>
     <string name="no_search_results_description">다른 이름으로 다시 검색해보세요.</string>
-    <string name="search_results_count">검색 결과 %1$d건</string>
     <string name="disposal_method_title">버리는 방법</string>
     <string name="features_title">품목 특징</string>
     <string name="disposal_steps_title">배출 절차</string>

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchViewModelTest.kt
@@ -142,7 +142,7 @@ class ItemSearchViewModelTest {
         }
 
     @Test
-    fun `검색어 변경 시 이전 결과를 초기화하고 초기 상태로 돌아간다`() =
+    fun `검색 결과 화면에서 검색어를 수정해도 이전 결과와 검색 상태를 유지한다`() =
         runTest {
             val repository = FakeRepository(onSearch = { listOf(sampleGuide("유리병")) })
             val viewModel = createViewModel(repository)
@@ -152,8 +152,8 @@ class ItemSearchViewModelTest {
             viewModel.onQueryChange("비닐")
 
             assertEquals("비닐", viewModel.uiState.value.query)
-            assertEquals(emptyList<DisposalItemGuide>(), viewModel.uiState.value.guides)
-            assertFalse(viewModel.uiState.value.hasSearched)
+            assertEquals(listOf("유리병"), viewModel.uiState.value.guides.map { it.name })
+            assertEquals(true, viewModel.uiState.value.hasSearched)
             assertFalse(viewModel.uiState.value.isLoading)
         }
 


### PR DESCRIPTION
## 작업 내용

- 품목 검색 결과 화면을 `LazyColumn`과 `stickyHeader` 기반 구조로 바꿨습니다.
- 검색 결과 화면에 전용 TopBar, 뒤로가기, 맨 위로 이동 FAB를 추가했습니다.
- 검색 결과 스크롤 방향에 따라 하단 네비게이션 바가 숨김/표시되도록 연결했습니다.
- 검색바 그림자, 라운드, 여백을 지도 화면 검색바와 맞추고 카드 리스트 정렬을 정리했습니다.
- `DisposalItemCard`의 불필요한 `ColumnScope` 수신 객체를 제거하고 터치 피드백 클리핑을 보정했습니다.
- UI 변경 흐름에 맞춰 `ItemSearchScreenTest`를 보강하고 테스트 샘플 중복을 줄였습니다.
- 검색 결과 화면에서 검색어를 수정할 때 초기 품목 화면으로 돌아가던 문제를 수정했습니다.

## 주요 변경 사항

### 품목 검색 결과 화면

- 검색 결과가 있을 때 TopBar, 검색바, 결과 리스트를 하나의 `LazyColumn`에서 렌더링합니다.
- 검색바는 `stickyHeader`로 고정해 스크롤 중에도 다시 검색할 수 있게 했습니다.
- 리스트가 내려간 상태에서 FAB를 누르면 최상단으로 이동합니다.
- 검색 결과 화면에서 뒤로가기를 누르면 검색 상태를 초기화합니다.

### 하단 네비게이션 바

- `ItemSearchRoute`에서 검색 결과 리스트 스크롤 상태를 `YeogiBeoryeoNavHost`로 전달합니다.
- 검색 결과 스크롤 시 하단 바를 숨기고, 위로 스크롤하거나 최상단에 도달하면 다시 보이게 했습니다.
- 검색 전 상태, 빈 결과, 오류 상태로 돌아오면 하단 바가 다시 보이도록 처리했습니다.
- `BottomBarVisibilityOnScrollEffect`는 같은 visibility 값을 반복 전달하지 않도록 가드를 추가했습니다.

### UI 정리

- 검색 결과 개수 문구와 불필요한 divider를 제거했습니다.
- 검색바에 `shadow(6.dp)`와 `RoundedCornerShape(12.dp)`를 적용했습니다.
- 검색 결과 카드에 `clip(shape)`를 적용해 터치 피드백이 카드 영역 밖으로 번지지 않게 했습니다.
- 검색어 입력 변경 시 기존 검색 결과 상태를 유지해 검색어 수정 중 화면이 초기화되지 않도록 했습니다.

## 확인 사항

### 홈 화면

<table>
<tr>
<th align="center">변경 후</th>
</tr>
<tr>
<td align="center">
<img src="https://github.com/user-attachments/assets/e1200ad8-70e5-42e9-a3bd-548f9fe3143a" width="280" />
</td>
</tr>
</table>

### 품목 검색 화면

<table>
<tr>
<th align="center" width="50%">Before</th>
<th align="center" width="50%">After</th>
</tr>

<tr>
<td align="center">
<img src="https://github.com/user-attachments/assets/3c77e452-1d60-4fe8-b15c-f869055937ad" width="260" />
</td>
<td align="center">
<img src="https://github.com/user-attachments/assets/13c2d5d6-9c42-4b9b-a7f0-454a9b3ceb54" width="260" />
</td>
</tr>

<tr>
<th align="center">Before (스크롤)</th>
<th align="center">After (스크롤)</th>
</tr>

<tr>
<td align="center">
<img src="https://github.com/user-attachments/assets/c84a0b15-8f4a-4c0d-80b9-61b999a212d7" width="260" />
</td>
<td align="center">
<img src="https://github.com/user-attachments/assets/21fa5959-b254-44fa-906e-a06c8817a1fd" width="260" />
</td>
</tr>
</table>

## 테스트

- [x] 검색 결과 스크롤 시 검색바 상단 고정 확인
- [x] 검색 결과 스크롤 시 하단 바 숨김/표시 확인
- [x] FAB 클릭 시 리스트 최상단 이동 확인
- [x] 검색 결과에서 초기 상태로 돌아올 때 하단 바 재노출 확인
- [x] 뒤로가기 클릭 시 검색 초기화 확인
- [x] 검색 결과 화면에서 검색어 수정 시 결과 화면 유지 확인
- [x] `./gradlew.bat :presentation:testDebugUnitTest`
- [x] `./gradlew.bat :presentation:compileDebugKotlin`

## 관련 이슈

Related #258
