### PR TITLE
feat: 지역 가이드 수거 유형 후보 안내 UX 개선

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -3,6 +3,15 @@ package com.team.yeogibeoryeo.navigation
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -10,16 +19,6 @@ import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.core.net.toUri
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -33,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -42,8 +42,8 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.team.yeogibeoryeo.BuildConfig
 import com.team.yeogibeoryeo.common.navigation.AppBottomNavigationBar
-import com.team.yeogibeoryeo.presentation.favorites.FavoritesRoute as FavoritesScreenRoute
 import com.team.yeogibeoryeo.presentation.map.CollectionSpotMapScreen
+import com.team.yeogibeoryeo.presentation.favorites.FavoritesRoute as FavoritesScreenRoute
 import com.team.yeogibeoryeo.presentation.regionalguide.RegionalGuideRoute as RegionalGuideScreenRoute
 import com.team.yeogibeoryeo.presentation.search.ItemGuideDetailRoute as ItemGuideDetailScreenRoute
 import com.team.yeogibeoryeo.presentation.search.ItemSearchRoute as ItemSearchScreenRoute

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapper.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapper.kt
@@ -84,7 +84,7 @@ internal object RegionOptionsMapper {
         if (targetKeyword.isBlank()) return emptyList()
 
         val administrativeMatches = administrativeRegions
-            .filter { region -> region.eupmyeondongName == targetKeyword }
+            .filter { region -> region.eupmyeondongName.matchesEupmyeondongKeyword(targetKeyword) }
             .map { region ->
                 RegionNormalizer.normalize(
                     Region(
@@ -96,13 +96,20 @@ internal object RegionOptionsMapper {
             }
 
         val legalMatches = legalAdminDongMappings
-            .filter { mapping -> mapping.legalDongName.trim().matchesLegalDongKeyword(targetKeyword) }
-            .map { mapping ->
+            .mapNotNull { mapping ->
+                val legalDongName = mapping.legalDongName
+                    .trim()
+                    .matchedLegalDongNameForKeyword(
+                        targetKeyword = targetKeyword,
+                        allowSuffixlessDongMatch = administrativeMatches.isEmpty()
+                    )
+                    ?: return@mapNotNull null
+
                 RegionNormalizer.normalize(
                     Region(
                         sido = mapping.sidoName.trim(),
                         sigungu = mapping.sigunguName.trimToNull(),
-                        eupmyeondong = targetKeyword
+                        eupmyeondong = legalDongName
                     )
                 )
             }
@@ -128,7 +135,7 @@ internal object RegionOptionsMapper {
             .filter { mapping ->
                 (sido == null || mapping.sidoName.trim() == sido) &&
                     (sigungu == null || mapping.sigunguName.trim() == sigungu) &&
-                    mapping.legalDongName.trim().matchesLegalDongKeyword(targetKeyword)
+                    mapping.legalDongName.trim().matchedLegalDongNameForKeyword(targetKeyword) != null
             }
             .map { mapping -> mapping.legalDongName.trim() }
             .filter { legalDongName -> legalDongName.isNotBlank() }
@@ -308,9 +315,23 @@ internal object RegionOptionsMapper {
         }
     }
 
-    private fun String.matchesLegalDongKeyword(targetKeyword: String): Boolean {
-        return this == targetKeyword ||
-            (startsWith(targetKeyword) && LEGAL_DONG_GA_REGEX.matches(this))
+    private fun String.matchedLegalDongNameForKeyword(
+        targetKeyword: String,
+        allowSuffixlessDongMatch: Boolean = true
+    ): String? =
+        when {
+            this == targetKeyword -> this
+            allowSuffixlessDongMatch && matchesEupmyeondongKeyword(targetKeyword) -> this
+            startsWith(targetKeyword) && LEGAL_DONG_GA_REGEX.matches(this) -> targetKeyword
+            else -> null
+        }
+
+    private fun String.matchesEupmyeondongKeyword(targetKeyword: String): Boolean {
+        if (this == targetKeyword) return true
+
+        return startsWith(targetKeyword) &&
+            length > targetKeyword.length &&
+            last() in EUPMYEONDONG_SUFFIXES
     }
 
     private fun String?.trimToNull(): String? =
@@ -392,5 +413,6 @@ internal object RegionOptionsMapper {
     private const val SEJONG_SIDO = "세종특별자치시"
     private const val NO_SIGUNGU_NAME = "없음"
     private const val CITY_SUFFIX = "시"
+    private val EUPMYEONDONG_SUFFIXES = setOf('읍', '면', '동')
     private val LEGAL_DONG_GA_REGEX = """[가-힣]+\d+가""".toRegex()
 }

--- a/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapperTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/region/RegionOptionsMapperTest.kt
@@ -582,6 +582,70 @@ class RegionOptionsMapperTest {
     }
 
     @Test
+    fun `접미사 없는 동 검색어도 행정동 후보로 반환한다`() {
+        val regions = RegionOptionsMapper.findEupmyeondongRegions(
+            administrativeRegions = listOf(
+                administrativeRegion(
+                    sidoName = "부산광역시",
+                    sigunguName = "사하구",
+                    eupmyeondongName = "괴정제1동"
+                ),
+                administrativeRegion(
+                    sidoName = "부산광역시",
+                    sigunguName = "사하구",
+                    eupmyeondongName = "괴정제2동"
+                )
+            ),
+            legalAdminDongMappings = listOf(
+                legalAdminMapping(
+                    sidoName = "부산광역시",
+                    sigunguName = "사하구",
+                    legalDongName = "괴정동",
+                    adminDongName = "괴정제1동"
+                )
+            ),
+            keyword = "괴정"
+        )
+
+        assertEquals(
+            listOf(
+                Region(sido = "부산광역시", sigungu = "사하구", eupmyeondong = "괴정제1동"),
+                Region(sido = "부산광역시", sigungu = "사하구", eupmyeondong = "괴정제2동")
+            ),
+            regions
+        )
+    }
+
+    @Test
+    fun `접미사 없는 법정동 검색어는 실제 법정동 이름을 후보에 유지한다`() {
+        val regions = RegionOptionsMapper.findEupmyeondongRegions(
+            administrativeRegions = emptyList(),
+            legalAdminDongMappings = listOf(
+                legalAdminMapping(
+                    sidoName = "부산광역시",
+                    sigunguName = "사하구",
+                    legalDongName = "괴정동",
+                    adminDongName = "괴정제1동"
+                ),
+                legalAdminMapping(
+                    sidoName = "부산광역시",
+                    sigunguName = "사하구",
+                    legalDongName = "괴정동",
+                    adminDongName = "괴정제2동"
+                )
+            ),
+            keyword = "괴정"
+        )
+
+        assertEquals(
+            listOf(
+                Region(sido = "부산광역시", sigungu = "사하구", eupmyeondong = "괴정동")
+            ),
+            regions
+        )
+    }
+
+    @Test
     fun `legal dong keyword lookup returns ga aliases but excludes ri aliases`() {
         val keywords = RegionOptionsMapper.findLegalDongKeywordsByRegion(
             mappings = listOf(

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalGuideLookupResult.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/model/RegionalGuideLookupResult.kt
@@ -6,7 +6,8 @@ sealed interface RegionalGuideLookupResult {
     ) : RegionalGuideLookupResult
 
     data class Candidates(
-        val guides: List<RegionalDisposalGuide>
+        val guides: List<RegionalDisposalGuide>,
+        val reason: RegionalGuideCandidateLookupReason = RegionalGuideCandidateLookupReason.MULTIPLE_CANDIDATES
     ) : RegionalGuideLookupResult
 
     data object NotFound : RegionalGuideLookupResult
@@ -17,6 +18,12 @@ sealed interface RegionalGuideLookupResult {
         val reason: RegionalGuideFailureReason = RegionalGuideFailureReason.UNKNOWN,
         val throwable: Throwable? = null
     ) : RegionalGuideLookupResult
+}
+
+enum class RegionalGuideCandidateLookupReason {
+    MULTIPLE_CANDIDATES,
+    MULTIPLE_EXACT_MATCHES,
+    FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND,
 }
 
 enum class RegionalGuideFailureReason {

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
@@ -2,6 +2,7 @@ package com.team.yeogibeoryeo.domain.regionalguide.usecase
 
 import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideCandidateLookupReason
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideLookupResult
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideQuery
 import javax.inject.Inject
@@ -32,7 +33,10 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
                     preferredTargetRegionName = preferredTargetRegionName,
                     preferredManagementZoneName = preferredManagementZoneName
                 )
-                .toSingleSuccessOrCandidates(query.displayRegion)
+                .toSingleSuccessOrCandidates(
+                    displayRegion = query.displayRegion,
+                    candidateReason = RegionalGuideCandidateLookupReason.MULTIPLE_EXACT_MATCHES
+                )
                 ?: RegionalGuideLookupResult.CandidateNotFound
         }
 
@@ -45,7 +49,10 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
         }
 
         filteredCandidates.selectOverallCandidates(query.sigunguQuery)
-            .toSingleSuccessOrCandidates(query.displayRegion)
+            .toSingleSuccessOrCandidates(
+                displayRegion = query.displayRegion,
+                candidateReason = query.displayRegion.toOverallCandidateReason()
+            )
             ?.let { result -> return result }
 
         selectByTargetRegion(
@@ -85,7 +92,10 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
         if (!eupmyeondong.isNullOrBlank()) {
             candidates
                 .filterByRequestedEupmyeondong(eupmyeondong)
-                .toSingleSuccessOrCandidates(requestedRegion)
+                .toSingleSuccessOrCandidates(
+                    displayRegion = requestedRegion,
+                    candidateReason = RegionalGuideCandidateLookupReason.MULTIPLE_EXACT_MATCHES
+                )
                 ?.let { result -> return result }
 
             candidates
@@ -93,20 +103,32 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
                     guide.targetRegionName.isSejongDongArea() &&
                         eupmyeondong in SEJONG_DONG_AREA_NAMES
                 }
-                .toSingleSuccessOrCandidates(requestedRegion)
+                .toSingleSuccessOrCandidates(
+                    displayRegion = requestedRegion,
+                    candidateReason = RegionalGuideCandidateLookupReason.MULTIPLE_EXACT_MATCHES
+                )
                 ?.let { result -> return result }
 
             candidates
                 .filterByMappedAdminDongs(mappedAdminDongCandidates)
-                .toSingleSuccessOrCandidates(requestedRegion)
+                .toSingleSuccessOrCandidates(
+                    displayRegion = requestedRegion,
+                    candidateReason = RegionalGuideCandidateLookupReason.MULTIPLE_EXACT_MATCHES
+                )
                 ?.let { result -> return result }
 
             return candidates
                 .selectOverallCandidates(sigunguQuery)
-                .toSingleSuccessOrCandidates(requestedRegion)
+                .toSingleSuccessOrCandidates(
+                    displayRegion = requestedRegion,
+                    candidateReason = RegionalGuideCandidateLookupReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND
+                )
                 ?: candidates
                     .selectUnmatchedSelectorFallbackCandidates()
-                    .toCandidateListOrNull(requestedRegion)
+                    .toCandidateListOrNull(
+                        displayRegion = requestedRegion,
+                        candidateReason = RegionalGuideCandidateLookupReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND
+                    )
         }
 
         return null
@@ -184,22 +206,27 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
         }
 
         return RegionalGuideLookupResult.Candidates(
-            guides = map { guide -> guide.withDisplayRegion(displayRegion) }
+            guides = map { guide -> guide.withDisplayRegion(displayRegion) },
+            reason = RegionalGuideCandidateLookupReason.MULTIPLE_CANDIDATES
         )
     }
 
     private fun List<RegionalDisposalGuide>.toCandidateListOrNull(
-        displayRegion: Region
+        displayRegion: Region,
+        candidateReason: RegionalGuideCandidateLookupReason
     ): RegionalGuideLookupResult.Candidates? {
         if (isEmpty()) return null
 
         return RegionalGuideLookupResult.Candidates(
-            guides = map { guide -> guide.withDisplayRegion(displayRegion) }
+            guides = map { guide -> guide.withDisplayRegion(displayRegion) },
+            reason = candidateReason
         )
     }
 
     private fun List<RegionalDisposalGuide>.toSingleSuccessOrCandidates(
-        displayRegion: Region
+        displayRegion: Region,
+        candidateReason: RegionalGuideCandidateLookupReason =
+            RegionalGuideCandidateLookupReason.MULTIPLE_CANDIDATES
     ): RegionalGuideLookupResult? {
         return when (size) {
             0 -> null
@@ -207,10 +234,18 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
                 guide = first().withDisplayRegion(displayRegion)
             )
             else -> RegionalGuideLookupResult.Candidates(
-                guides = map { guide -> guide.withDisplayRegion(displayRegion) }
+                guides = map { guide -> guide.withDisplayRegion(displayRegion) },
+                reason = candidateReason
             )
         }
     }
+
+    private fun Region.toOverallCandidateReason(): RegionalGuideCandidateLookupReason =
+        if (eupmyeondong.isNullOrBlank()) {
+            RegionalGuideCandidateLookupReason.MULTIPLE_CANDIDATES
+        } else {
+            RegionalGuideCandidateLookupReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND
+        }
 
     private fun List<RegionalDisposalGuide>.filterByPreferredCandidate(
         preferredTargetRegionName: String?,

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
@@ -1,6 +1,7 @@
 ﻿package com.team.yeogibeoryeo.domain.regionalguide.usecase
 
 import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideCandidateLookupReason
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideLookupResult
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteSchedule
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalWasteType
@@ -960,6 +961,46 @@ class SelectRegionalGuideCandidateIdentityUseCaseTest {
         assertEquals("사천면", candidates[0].region.eupmyeondong)
         assertEquals("문전수거", candidates[0].disposalPlaceType)
         assertEquals("거점수거", candidates[1].disposalPlaceType)
+    }
+
+    @Test
+    fun `직접 매칭 실패 후 없음 전체 기준 수거 유형 후보만 있으면 fallback 후보 목록을 반환한다`() {
+        val result = useCase(
+            candidates = listOf(
+                regionalDisposalGuide(
+                    sido = "강원특별자치도",
+                    sigungu = "양구군",
+                    managementZoneName = "없음",
+                    targetRegionName = "없음",
+                    disposalPlaceType = "문전수거"
+                ),
+                regionalDisposalGuide(
+                    sido = "강원특별자치도",
+                    sigungu = "양구군",
+                    managementZoneName = "없음",
+                    targetRegionName = "없음",
+                    disposalPlaceType = "거점수거"
+                )
+            ),
+            query = regionalGuideQuery(
+                displayRegion = Region(
+                    sido = "강원특별자치도",
+                    sigungu = "양구군",
+                    eupmyeondong = "양구읍"
+                ),
+                sigunguQuery = "양구군"
+            )
+        )
+
+        val candidatesResult = result as RegionalGuideLookupResult.Candidates
+
+        assertEquals(
+            RegionalGuideCandidateLookupReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND,
+            candidatesResult.reason
+        )
+        assertEquals(2, candidatesResult.guides.size)
+        assertEquals(listOf("문전수거", "거점수거"), candidatesResult.guides.map { guide -> guide.disposalPlaceType })
+        assertEquals(listOf("양구읍", "양구읍"), candidatesResult.guides.map { guide -> guide.region.eupmyeondong })
     }
 
     @Test

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateDisplayPolicy.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateDisplayPolicy.kt
@@ -1,0 +1,25 @@
+package com.team.yeogibeoryeo.presentation.regionalguide
+
+internal fun RegionalGuideUiState.GuideCandidates.shouldShowCollectionTypeSelectionPanel(): Boolean =
+    when (reason) {
+        RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND ->
+            hasOnlyCollectionTypeSelectionCandidates()
+
+        RegionalGuideCandidateReason.MULTIPLE_CANDIDATES ->
+            isOverallCollectionTypeSelection()
+
+        RegionalGuideCandidateReason.MULTIPLE_EXACT_MATCHES,
+        RegionalGuideCandidateReason.FAVORITE_RESTORE_AMBIGUOUS -> false
+    }
+
+private fun RegionalGuideUiState.GuideCandidates.isOverallCollectionTypeSelection(): Boolean =
+    hasOnlyCollectionTypeSelectionCandidates() &&
+        candidates.all { candidate -> candidate.isOverallCollectionTypeCandidate }
+
+private fun RegionalGuideUiState.GuideCandidates.hasOnlyCollectionTypeSelectionCandidates(): Boolean =
+    candidates.size > 1 &&
+        candidates.all { candidate -> candidate.isCollectionTypeSelectionCandidate } &&
+        candidates
+            .mapNotNull { candidate -> candidate.guide.disposalPlaceType?.trim() }
+            .distinct()
+            .size > 1

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateMessage.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateMessage.kt
@@ -1,0 +1,26 @@
+package com.team.yeogibeoryeo.presentation.regionalguide
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.team.yeogibeoryeo.presentation.R
+
+@StringRes
+internal fun RegionalGuideCandidateReason.messageResId(): Int =
+    when (this) {
+        RegionalGuideCandidateReason.MULTIPLE_CANDIDATES ->
+            R.string.regional_guide_candidate_multiple_message
+
+        RegionalGuideCandidateReason.MULTIPLE_EXACT_MATCHES ->
+            R.string.regional_guide_candidate_multiple_exact_message
+
+        RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND ->
+            R.string.regional_guide_candidate_fallback_message
+
+        RegionalGuideCandidateReason.FAVORITE_RESTORE_AMBIGUOUS ->
+            R.string.regional_guide_candidate_favorite_restore_ambiguous_message
+    }
+
+@Composable
+internal fun RegionalGuideCandidateReason.candidateMessage(): String =
+    stringResource(id = messageResId())

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateMessage.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateMessage.kt
@@ -5,6 +5,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.team.yeogibeoryeo.presentation.R
 
+internal data class RegionalGuideCandidateMessageSpec(
+    @param:StringRes val titleResId: Int,
+    val titleArgs: List<String> = emptyList(),
+    @param:StringRes val descriptionResId: Int? = null,
+    val descriptionArgs: List<String> = emptyList(),
+    @param:StringRes val sectionTitleResId: Int? = null,
+)
+
 @StringRes
 internal fun RegionalGuideCandidateReason.messageResId(): Int =
     when (this) {
@@ -21,6 +29,66 @@ internal fun RegionalGuideCandidateReason.messageResId(): Int =
             R.string.regional_guide_candidate_favorite_restore_ambiguous_message
     }
 
+internal fun RegionalGuideUiState.GuideCandidates.candidateMessageSpec(): RegionalGuideCandidateMessageSpec =
+    when (reason) {
+        RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND -> {
+            val selectedEupmyeondong = candidates.firstNotNullOfOrNull { candidate ->
+                candidate.eupmyeondong?.takeIf { value -> value.isNotBlank() }
+            }
+            val selectedSigungu = candidates.firstNotNullOfOrNull { candidate ->
+                candidate.sigungu?.takeIf { value -> value.isNotBlank() }
+            }
+
+            RegionalGuideCandidateMessageSpec(
+                titleResId = R.string.regional_guide_candidate_fallback_panel_title,
+                descriptionResId = if (selectedEupmyeondong != null && selectedSigungu != null) {
+                    R.string.regional_guide_candidate_fallback_panel_description
+                } else {
+                    R.string.regional_guide_candidate_fallback_panel_description_without_region
+                },
+                descriptionArgs = if (selectedEupmyeondong != null && selectedSigungu != null) {
+                    listOf(selectedEupmyeondong, selectedSigungu)
+                } else {
+                    emptyList()
+                },
+                sectionTitleResId = R.string.regional_guide_candidate_fallback_section_title,
+            )
+        }
+
+        else -> RegionalGuideCandidateMessageSpec(titleResId = reason.messageResId())
+    }
+
+internal fun RegionalGuideUiState.GuideCandidates.collectionTypeSelectionMessageSpec():
+    RegionalGuideCandidateMessageSpec =
+    if (reason == RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND) {
+        candidateMessageSpec()
+    } else {
+        val selectedSigungu = candidates.firstNotNullOfOrNull { candidate ->
+            candidate.sigungu?.takeIf { value -> value.isNotBlank() }
+        }
+
+        RegionalGuideCandidateMessageSpec(
+            titleResId = R.string.regional_guide_candidate_collection_type_panel_title,
+            descriptionResId = if (selectedSigungu != null) {
+                R.string.regional_guide_candidate_collection_type_panel_description
+            } else {
+                R.string.regional_guide_candidate_collection_type_panel_description_without_region
+            },
+            descriptionArgs = listOfNotNull(selectedSigungu),
+            sectionTitleResId = R.string.regional_guide_candidate_fallback_section_title,
+        )
+    }
+
 @Composable
-internal fun RegionalGuideCandidateReason.candidateMessage(): String =
-    stringResource(id = messageResId())
+internal fun RegionalGuideCandidateMessageSpec.title(): String =
+    stringResource(id = titleResId, *titleArgs.toTypedArray())
+
+@Composable
+internal fun RegionalGuideCandidateMessageSpec.description(): String? =
+    descriptionResId?.let { resId ->
+        stringResource(id = resId, *descriptionArgs.toTypedArray())
+    }
+
+@Composable
+internal fun RegionalGuideCandidateMessageSpec.sectionTitle(): String? =
+    sectionTitleResId?.let { resId -> stringResource(id = resId) }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -40,6 +42,7 @@ import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionSelectorSection
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideAmbiguousResult
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideCandidateResult
+import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideCollectionTypeCandidateResult
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideEmptyResult
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideSearchBar
 import com.team.yeogibeoryeo.presentation.regionalguide.components.RegionalGuideSummaryCard
@@ -137,21 +140,27 @@ fun RegionalGuideScreen(
             !isRegionSelectorExpanded &&
             compactRegionText != null
 
-    LaunchedEffect(uiState) {
-        if (uiState is RegionalGuideUiState.Loading) {
-            isRegionSelectorExpanded = false
-        }
-    }
-
     fun clearSearchFocus() {
         focusManager.clearFocus()
         keyboardController?.hide()
     }
 
+    fun collapseRegionSelector() {
+        if (isRegionSelectorExpanded) {
+            isRegionSelectorExpanded = false
+        }
+    }
+
+    LaunchedEffect(uiState) {
+        if (uiState is RegionalGuideUiState.Loading) {
+            collapseRegionSelector()
+        }
+    }
+
     fun handleEmptyAction(actionType: RegionalGuideEmptyActionType) {
         when (actionType) {
             RegionalGuideEmptyActionType.SEARCH_AGAIN -> {
-                isRegionSelectorExpanded = false
+                collapseRegionSelector()
                 onRegionSelectorDropdownDismissed()
                 onEmptySearchActionClick()
             }
@@ -163,16 +172,29 @@ fun RegionalGuideScreen(
         }
     }
 
+    val collectionTypePanelScrollState = rememberScrollState()
+
     Column(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
     ) {
+        val headerModifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+            .padding(top = 20.dp)
+            .then(
+                if (collectionTypeGuideCandidatesState != null) {
+                    Modifier
+                        .weight(1f)
+                        .verticalScroll(collectionTypePanelScrollState)
+                } else {
+                    Modifier
+                }
+            )
+
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 20.dp)
-                .padding(top = 20.dp)
+            modifier = headerModifier
         ) {
             Text(
                 text = "지역별 배출 가이드",
@@ -196,7 +218,7 @@ fun RegionalGuideScreen(
                 onKeywordChange = onSearchKeywordChange,
                 onSearchClick = { submittedKeyword ->
                     clearSearchFocus()
-                    isRegionSelectorExpanded = false
+                    collapseRegionSelector()
                     onRegionSelectorDropdownDismissed()
                     onSearchClick(submittedKeyword)
                 },
@@ -207,7 +229,7 @@ fun RegionalGuideScreen(
                                 candidates = ambiguousState.candidates,
                                 onCandidateClick = { candidate ->
                                     clearSearchFocus()
-                                    isRegionSelectorExpanded = false
+                                    collapseRegionSelector()
                                     onRegionSelectorDropdownDismissed()
                                     onCandidateClick(candidate)
                                 },
@@ -215,16 +237,11 @@ fun RegionalGuideScreen(
                         }
 
                         if (listGuideCandidatesState != null) {
-                            val candidateMessageSpec = listGuideCandidatesState.candidateMessageSpec()
-
                             RegionalGuideCandidateResult(
-                                message = candidateMessageSpec.title(),
-                                messageDescription = candidateMessageSpec.description(),
-                                sectionTitle = candidateMessageSpec.sectionTitle(),
                                 candidates = listGuideCandidatesState.candidates,
                                 onCandidateClick = { candidate ->
                                     clearSearchFocus()
-                                    isRegionSelectorExpanded = false
+                                    collapseRegionSelector()
                                     onRegionSelectorDropdownDismissed()
                                     onGuideCandidateClick(candidate)
                                 },
@@ -242,7 +259,7 @@ fun RegionalGuideScreen(
                 val candidateMessageSpec =
                     collectionTypeGuideCandidatesState.collectionTypeSelectionMessageSpec()
 
-                RegionalGuideCandidateResult(
+                RegionalGuideCollectionTypeCandidateResult(
                     message = candidateMessageSpec.title(),
                     messageDescription = candidateMessageSpec.description(),
                     sectionTitle = candidateMessageSpec.sectionTitle(),
@@ -251,11 +268,10 @@ fun RegionalGuideScreen(
                     candidates = collectionTypeGuideCandidatesState.candidates,
                     onCandidateClick = { candidate ->
                         clearSearchFocus()
-                        isRegionSelectorExpanded = false
+                        collapseRegionSelector()
                         onRegionSelectorDropdownDismissed()
                         onGuideCandidateClick(candidate)
                     },
-                    showCollectionTypeHelp = true,
                 )
             }
 
@@ -270,7 +286,7 @@ fun RegionalGuideScreen(
                     onDropdownExpanded = onRegionSelectorDropdownExpanded,
                     onDropdownDismissed = onRegionSelectorDropdownDismissed,
                     onSearchClick = {
-                        isRegionSelectorExpanded = false
+                        collapseRegionSelector()
                         onRegionSelectorDropdownDismissed()
                         onRegionSelectionSearchClick()
                     },
@@ -283,17 +299,17 @@ fun RegionalGuideScreen(
             Spacer(modifier = Modifier.height(20.dp))
         }
 
-        RegionalGuideContent(
-            uiState = uiState,
-            onRetryClick = onRetryClick,
-            onEmptyActionClick = ::handleEmptyAction,
-            onCandidateClick = onCandidateClick,
-            onGuideCandidateClick = onGuideCandidateClick,
-            onFavoriteClick = onFavoriteClick,
-            modifier = Modifier
-                .weight(1f)
-                .padding(horizontal = 20.dp),
-        )
+        if (collectionTypeGuideCandidatesState == null) {
+            RegionalGuideContent(
+                uiState = uiState,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 20.dp),
+                onRetryClick = onRetryClick,
+                onEmptyActionClick = ::handleEmptyAction,
+                onFavoriteClick = onFavoriteClick,
+            )
+        }
     }
 }
 
@@ -322,30 +338,13 @@ private fun RegionalGuideUiState.GuideCandidates.selectedRegionText(): String? =
 private fun String?.takeIfNotBlank(): String? =
     this?.takeIf { value -> value.isNotBlank() }
 
-private fun RegionalGuideUiState.GuideCandidates.isFallbackBecauseDirectMatchNotFound(): Boolean =
-    reason == RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND
-
-private fun RegionalGuideUiState.GuideCandidates.shouldShowCollectionTypeSelectionPanel(): Boolean =
-    isFallbackBecauseDirectMatchNotFound() || isOverallCollectionTypeSelection()
-
-private fun RegionalGuideUiState.GuideCandidates.isOverallCollectionTypeSelection(): Boolean =
-    reason == RegionalGuideCandidateReason.MULTIPLE_CANDIDATES &&
-        candidates.size > 1 &&
-        candidates.all { candidate -> candidate.isOverallCollectionTypeCandidate } &&
-        candidates
-            .mapNotNull { candidate -> candidate.guide.disposalPlaceType?.trim() }
-            .distinct()
-            .size > 1
-
 @Composable
 private fun RegionalGuideContent(
     uiState: RegionalGuideUiState,
+    modifier: Modifier = Modifier,
     onRetryClick: () -> Unit,
     onEmptyActionClick: (RegionalGuideEmptyActionType) -> Unit,
-    onCandidateClick: (RegionSearchCandidateUiModel) -> Unit,
-    onGuideCandidateClick: (RegionalGuideCandidateUiModel) -> Unit,
     onFavoriteClick: () -> Unit,
-    modifier: Modifier = Modifier
 ) {
     when (uiState) {
         RegionalGuideUiState.Idle -> {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
@@ -212,6 +212,7 @@ fun RegionalGuideScreen(
 
                         if (guideCandidatesState != null) {
                             RegionalGuideCandidateResult(
+                                message = guideCandidatesState.reason.candidateMessage(),
                                 candidates = guideCandidatesState.candidates,
                                 onCandidateClick = { candidate ->
                                     clearSearchFocus()
@@ -219,6 +220,9 @@ fun RegionalGuideScreen(
                                     onRegionSelectorDropdownDismissed()
                                     onGuideCandidateClick(candidate)
                                 },
+                                showCollectionTypeHelp =
+                                    guideCandidatesState.reason ==
+                                        RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND,
                             )
                         }
                     }
@@ -635,7 +639,7 @@ private fun RegionalGuideScreenGuideCandidatesPreview() {
         RegionalGuideScreen(
             uiState = RegionalGuideUiState.GuideCandidates(
                 query = "울주군",
-                message = "여러 배출 권역이 검색됩니다. 해당하는 권역을 선택해주세요.",
+                reason = RegionalGuideCandidateReason.MULTIPLE_CANDIDATES,
                 candidates = listOf(
                     RegionalGuideCandidateUiModel(
                         guide = previewRegionalGuide(
@@ -660,6 +664,58 @@ private fun RegionalGuideScreenGuideCandidatesPreview() {
             searchKeyword = "울주군",
             regionSelectorUiState = RegionSelectorUiState(
                 sidoOptions = listOf("서울특별시", "울산광역시", "경기도"),
+            ),
+            onSearchKeywordChange = {},
+            onSearchClick = {},
+            onRetryClick = {},
+            onEmptySearchActionClick = {},
+            onSidoSelected = {},
+            onSigunguSelected = {},
+            onEupmyeondongSelected = {},
+            onRegionSelectionSearchClick = {},
+            onCandidateClick = {},
+            onGuideCandidateClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RegionalGuideScreenFallbackGuideCandidatesPreview() {
+    MaterialTheme {
+        RegionalGuideScreen(
+            uiState = RegionalGuideUiState.GuideCandidates(
+                query = "사천면",
+                reason = RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND,
+                candidates = listOf(
+                    RegionalGuideCandidateUiModel(
+                        guide = previewRegionalGuide(
+                            regionName = "강원특별자치도 강릉시",
+                            targetRegionName = "없음"
+                        ),
+                        sido = "강원특별자치도",
+                        sigungu = "강릉시",
+                        eupmyeondong = "사천면"
+                    ),
+                    RegionalGuideCandidateUiModel(
+                        guide = previewRegionalGuide(
+                            regionName = "강원특별자치도 강릉시",
+                            targetRegionName = "없음"
+                        ).copy(disposalPlaceType = "거점수거"),
+                        sido = "강원특별자치도",
+                        sigungu = "강릉시",
+                        eupmyeondong = "사천면"
+                    ),
+                )
+            ),
+            searchKeyword = "사천면",
+            regionSelectorUiState = RegionSelectorUiState(
+                sidoOptions = listOf("강원특별자치도"),
+                sigunguOptions = listOf("강릉시"),
+                eupmyeondongOptions = listOf("사천면"),
+                selectedSido = "강원특별자치도",
+                selectedSigungu = "강릉시",
+                selectedEupmyeondong = "사천면",
             ),
             onSearchKeywordChange = {},
             onSearchClick = {},

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideScreen.kt
@@ -119,7 +119,11 @@ fun RegionalGuideScreen(
     val keyboardController = LocalSoftwareKeyboardController.current
     val ambiguousState = uiState as? RegionalGuideUiState.Ambiguous
     val guideCandidatesState = uiState as? RegionalGuideUiState.GuideCandidates
-    val hasSearchCandidates = ambiguousState != null || guideCandidatesState != null
+    val collectionTypeGuideCandidatesState = guideCandidatesState
+        ?.takeIf { state -> state.shouldShowCollectionTypeSelectionPanel() }
+    val listGuideCandidatesState = guideCandidatesState
+        ?.takeUnless { state -> state.shouldShowCollectionTypeSelectionPanel() }
+    val hasSearchCandidates = ambiguousState != null || listGuideCandidatesState != null
     val compactRegionText = when (uiState) {
         is RegionalGuideUiState.Success ->
             regionSelectorUiState.selectedRegionText ?: uiState.query
@@ -210,19 +214,20 @@ fun RegionalGuideScreen(
                             )
                         }
 
-                        if (guideCandidatesState != null) {
+                        if (listGuideCandidatesState != null) {
+                            val candidateMessageSpec = listGuideCandidatesState.candidateMessageSpec()
+
                             RegionalGuideCandidateResult(
-                                message = guideCandidatesState.reason.candidateMessage(),
-                                candidates = guideCandidatesState.candidates,
+                                message = candidateMessageSpec.title(),
+                                messageDescription = candidateMessageSpec.description(),
+                                sectionTitle = candidateMessageSpec.sectionTitle(),
+                                candidates = listGuideCandidatesState.candidates,
                                 onCandidateClick = { candidate ->
                                     clearSearchFocus()
                                     isRegionSelectorExpanded = false
                                     onRegionSelectorDropdownDismissed()
                                     onGuideCandidateClick(candidate)
                                 },
-                                showCollectionTypeHelp =
-                                    guideCandidatesState.reason ==
-                                        RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND,
                             )
                         }
                     }
@@ -233,24 +238,47 @@ fun RegionalGuideScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            RegionSelectorSection(
-                uiState = regionSelectorUiState,
-                compact = isRegionSelectorCompact,
-                compactRegionText = compactRegionText,
-                onSidoSelected = onSidoSelected,
-                onSigunguSelected = onSigunguSelected,
-                onEupmyeondongSelected = onEupmyeondongSelected,
-                onDropdownExpanded = onRegionSelectorDropdownExpanded,
-                onDropdownDismissed = onRegionSelectorDropdownDismissed,
-                onSearchClick = {
-                    isRegionSelectorExpanded = false
-                    onRegionSelectorDropdownDismissed()
-                    onRegionSelectionSearchClick()
-                },
-                onChangeClick = {
-                    isRegionSelectorExpanded = true
-                },
-            )
+            if (collectionTypeGuideCandidatesState != null) {
+                val candidateMessageSpec =
+                    collectionTypeGuideCandidatesState.collectionTypeSelectionMessageSpec()
+
+                RegionalGuideCandidateResult(
+                    message = candidateMessageSpec.title(),
+                    messageDescription = candidateMessageSpec.description(),
+                    sectionTitle = candidateMessageSpec.sectionTitle(),
+                    selectedRegionText = regionSelectorUiState.selectedRegionText
+                        ?: collectionTypeGuideCandidatesState.selectedRegionText(),
+                    candidates = collectionTypeGuideCandidatesState.candidates,
+                    onCandidateClick = { candidate ->
+                        clearSearchFocus()
+                        isRegionSelectorExpanded = false
+                        onRegionSelectorDropdownDismissed()
+                        onGuideCandidateClick(candidate)
+                    },
+                    showCollectionTypeHelp = true,
+                )
+            }
+
+            if (collectionTypeGuideCandidatesState == null) {
+                RegionSelectorSection(
+                    uiState = regionSelectorUiState,
+                    compact = isRegionSelectorCompact,
+                    compactRegionText = compactRegionText,
+                    onSidoSelected = onSidoSelected,
+                    onSigunguSelected = onSigunguSelected,
+                    onEupmyeondongSelected = onEupmyeondongSelected,
+                    onDropdownExpanded = onRegionSelectorDropdownExpanded,
+                    onDropdownDismissed = onRegionSelectorDropdownDismissed,
+                    onSearchClick = {
+                        isRegionSelectorExpanded = false
+                        onRegionSelectorDropdownDismissed()
+                        onRegionSelectionSearchClick()
+                    },
+                    onChangeClick = {
+                        isRegionSelectorExpanded = true
+                    },
+                )
+            }
 
             Spacer(modifier = Modifier.height(20.dp))
         }
@@ -279,6 +307,35 @@ private fun RegionalGuideUiState.queryOrNull(): String? =
         is RegionalGuideUiState.GuideCandidates -> query
         is RegionalGuideUiState.Error -> query
     }?.takeIf { query -> query.isNotBlank() }
+
+private fun RegionalGuideUiState.GuideCandidates.selectedRegionText(): String? =
+    candidates.firstNotNullOfOrNull { candidate ->
+        listOfNotNull(
+            candidate.sido.takeIfNotBlank(),
+            candidate.sigungu.takeIfNotBlank(),
+            candidate.eupmyeondong.takeIfNotBlank(),
+        )
+            .takeIf { parts -> parts.isNotEmpty() }
+            ?.joinToString(" > ")
+    }
+
+private fun String?.takeIfNotBlank(): String? =
+    this?.takeIf { value -> value.isNotBlank() }
+
+private fun RegionalGuideUiState.GuideCandidates.isFallbackBecauseDirectMatchNotFound(): Boolean =
+    reason == RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND
+
+private fun RegionalGuideUiState.GuideCandidates.shouldShowCollectionTypeSelectionPanel(): Boolean =
+    isFallbackBecauseDirectMatchNotFound() || isOverallCollectionTypeSelection()
+
+private fun RegionalGuideUiState.GuideCandidates.isOverallCollectionTypeSelection(): Boolean =
+    reason == RegionalGuideCandidateReason.MULTIPLE_CANDIDATES &&
+        candidates.size > 1 &&
+        candidates.all { candidate -> candidate.isOverallCollectionTypeCandidate } &&
+        candidates
+            .mapNotNull { candidate -> candidate.guide.disposalPlaceType?.trim() }
+            .distinct()
+            .size > 1
 
 @Composable
 private fun RegionalGuideContent(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideUiState.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideUiState.kt
@@ -2,9 +2,9 @@ package com.team.yeogibeoryeo.presentation.regionalguide
 
 import androidx.annotation.StringRes
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionSearchCandidateUiModel
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideCandidateUiModel
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
-import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionSearchCandidateUiModel
 
 sealed interface RegionalGuideUiState {
     data object Idle : RegionalGuideUiState
@@ -34,7 +34,7 @@ sealed interface RegionalGuideUiState {
 
     data class GuideCandidates(
         val query: String,
-        val message: String,
+        val reason: RegionalGuideCandidateReason,
         val candidates: List<RegionalGuideCandidateUiModel>
     ) : RegionalGuideUiState
 
@@ -52,4 +52,11 @@ data class RegionalGuideEmptyActionUiModel(
 enum class RegionalGuideEmptyActionType {
     SEARCH_AGAIN,
     SELECT_REGION,
+}
+
+enum class RegionalGuideCandidateReason {
+    MULTIPLE_CANDIDATES,
+    MULTIPLE_EXACT_MATCHES,
+    FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND,
+    FAVORITE_RESTORE_AMBIGUOUS,
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
@@ -18,6 +18,7 @@ import com.team.yeogibeoryeo.domain.region.usecase.NormalizeRegionForRegionalGui
 import com.team.yeogibeoryeo.domain.region.usecase.RegionSearchInputType
 import com.team.yeogibeoryeo.domain.region.usecase.ResolveRegionFromKeywordResult
 import com.team.yeogibeoryeo.domain.region.usecase.ResolveRegionFromKeywordUseCase
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideCandidateLookupReason
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideFailureReason
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideLookupResult
 import com.team.yeogibeoryeo.domain.regionalguide.usecase.GetRegionalDisposalGuideUseCase
@@ -655,7 +656,10 @@ class RegionalGuideViewModel @Inject constructor(
 
             is RegionalGuideLookupResult.Candidates -> RegionalGuideUiState.GuideCandidates(
                 query = query,
-                message = "여러 배출 권역이 검색됩니다. 해당하는 권역을 선택해주세요.",
+                reason = toUiCandidateReason(
+                    lookupReason = reason,
+                    emptyContext = emptyContext,
+                ),
                 candidates = guides.map { guide ->
                     RegionalGuideCandidateUiModel(
                         guide = guide.toUiModel(),
@@ -698,6 +702,33 @@ class RegionalGuideViewModel @Inject constructor(
             )
         }
     }
+
+    private fun toUiCandidateReason(
+        lookupReason: RegionalGuideCandidateLookupReason,
+        emptyContext: RegionalGuideEmptyContext,
+    ): RegionalGuideCandidateReason =
+        emptyContext.favoriteRestoreCandidateReason()
+            ?: lookupReason.toDefaultUiCandidateReason()
+
+    private fun RegionalGuideEmptyContext.favoriteRestoreCandidateReason(): RegionalGuideCandidateReason? =
+        when (this) {
+            RegionalGuideEmptyContext.FAVORITE_RESTORE ->
+                RegionalGuideCandidateReason.FAVORITE_RESTORE_AMBIGUOUS
+
+            RegionalGuideEmptyContext.DEFAULT -> null
+        }
+
+    private fun RegionalGuideCandidateLookupReason.toDefaultUiCandidateReason(): RegionalGuideCandidateReason =
+        when (this) {
+            RegionalGuideCandidateLookupReason.MULTIPLE_CANDIDATES ->
+                RegionalGuideCandidateReason.MULTIPLE_CANDIDATES
+
+            RegionalGuideCandidateLookupReason.MULTIPLE_EXACT_MATCHES ->
+                RegionalGuideCandidateReason.MULTIPLE_EXACT_MATCHES
+
+            RegionalGuideCandidateLookupReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND ->
+                RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND
+        }
 
     private fun RegionalGuideFailureReason.toErrorMessage(): String {
         return when (this) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideViewModel.kt
@@ -186,7 +186,8 @@ class RegionalGuideViewModel @Inject constructor(
 
         searchBySelectedRegion(
             query = query,
-            region = region
+            region = region,
+            syncSearchKeyword = true,
         )
     }
 
@@ -480,8 +481,12 @@ class RegionalGuideViewModel @Inject constructor(
 
     private fun searchBySelectedRegion(
         query: String,
-        region: Region
+        region: Region,
+        syncSearchKeyword: Boolean = false,
     ) {
+        if (syncSearchKeyword) {
+            _searchKeyword.value = query
+        }
         keywordSuggestionJob?.cancel()
         guideLookupJob?.cancel()
         collapseRegionSelectorDropdowns()

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideAmbiguousResult.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideAmbiguousResult.kt
@@ -24,7 +24,7 @@ fun RegionalGuideAmbiguousResult(
 
     RegionalGuideCandidateList(
         candidates = validCandidates,
-        key = { candidate -> candidate.displayText },
+        key = { candidate -> candidate.stableKey },
         onCandidateClick = onCandidateClick,
         modifier = modifier
     ) { candidate ->

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideCandidateList.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideCandidateList.kt
@@ -48,7 +48,7 @@ internal fun <T> RegionalGuideCandidateList(
         ) {
             itemsIndexed(
                 items = candidates,
-                key = { index, candidate -> "${key(candidate)}-$index" }
+                key = { _, candidate -> key(candidate) }
             ) { index, candidate ->
                 Box(
                     modifier = Modifier

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideCandidateResult.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideCandidateResult.kt
@@ -1,5 +1,6 @@
 package com.team.yeogibeoryeo.presentation.regionalguide.components
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
@@ -7,40 +8,54 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideCandidateCollectionTypeHint
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideCandidateUiModel
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
 
 @Composable
 fun RegionalGuideCandidateResult(
+    message: String,
     candidates: List<RegionalGuideCandidateUiModel>,
     onCandidateClick: (RegionalGuideCandidateUiModel) -> Unit,
+    showCollectionTypeHelp: Boolean = false,
     modifier: Modifier = Modifier
 ) {
+    Text(
+        text = message,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    )
+
     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
 
     RegionalGuideCandidateList(
         candidates = candidates,
-        key = { candidate -> candidate.displayText },
+        key = { candidate -> candidate.stableKey },
         onCandidateClick = onCandidateClick,
         modifier = modifier
     ) { candidate ->
-        RegionalGuideCandidateRowText(text = candidate.displayText)
+        RegionalGuideCandidateRowText(
+            text = candidate.displayText,
+            supportingText = candidate.collectionTypeSupportingText(showCollectionTypeHelp)
+        )
     }
 }
 
 @Composable
 private fun RegionalGuideCandidateRowText(
     text: String,
+    supportingText: String?,
     modifier: Modifier = Modifier
 ) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.bodyLarge,
-        color = MaterialTheme.colorScheme.onSurface,
-        fontWeight = FontWeight.Medium,
+    Column(
         modifier = modifier
             .fillMaxWidth()
             .padding(
@@ -49,7 +64,40 @@ private fun RegionalGuideCandidateRowText(
                 top = 14.dp,
                 bottom = 14.dp
             )
-    )
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Medium,
+        )
+
+        if (supportingText != null) {
+            Text(
+                text = supportingText,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun RegionalGuideCandidateUiModel.collectionTypeSupportingText(
+    enabled: Boolean
+): String? {
+    if (!enabled) return null
+
+    return when (collectionTypeHint) {
+        RegionalGuideCandidateCollectionTypeHint.DOOR_TO_DOOR ->
+            stringResource(id = R.string.regional_guide_candidate_door_to_door_supporting_text)
+
+        RegionalGuideCandidateCollectionTypeHint.BASE_POINT ->
+            stringResource(id = R.string.regional_guide_candidate_base_point_supporting_text)
+
+        null -> null
+    }
 }
 
 @Preview(showBackground = true)
@@ -57,6 +105,7 @@ private fun RegionalGuideCandidateRowText(
 private fun RegionalGuideCandidateResultPreview() {
     MaterialTheme {
         RegionalGuideCandidateResult(
+            message = "여러 배출 권역이 검색됩니다. 해당하는 권역을 선택해주세요.",
             candidates = listOf(
                 RegionalGuideCandidateUiModel(
                     guide = previewGuide("범서, 온양, 웅촌, 언양, 삼남, 상북, 온산, 청량, 서생"),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideCandidateResult.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideCandidateResult.kt
@@ -22,43 +22,50 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideCandidateCollectionTypeHint
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideCandidateDistinguishingLabel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideCandidateDistinguishingText
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideCandidateUiModel
 import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
 
 @Composable
 fun RegionalGuideCandidateResult(
-    message: String,
-    messageDescription: String? = null,
-    sectionTitle: String? = null,
-    selectedRegionText: String? = null,
     candidates: List<RegionalGuideCandidateUiModel>,
     onCandidateClick: (RegionalGuideCandidateUiModel) -> Unit,
-    showCollectionTypeHelp: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
-        if (showCollectionTypeHelp) {
-            RegionalGuideFallbackCandidatePanel(
-                message = message,
-                description = messageDescription,
-                selectedRegionText = selectedRegionText,
-                sectionTitle = sectionTitle,
-                candidates = candidates,
-                onCandidateClick = onCandidateClick,
+        RegionalGuideCandidateList(
+            candidates = candidates,
+            key = { candidate -> candidate.stableKey },
+            onCandidateClick = onCandidateClick,
+        ) { candidate ->
+            RegionalGuideCandidateRowText(
+                text = candidate.displayText,
+                supportingText = null
             )
-        } else {
-            RegionalGuideCandidateList(
-                candidates = candidates,
-                key = { candidate -> candidate.stableKey },
-                onCandidateClick = onCandidateClick,
-            ) { candidate ->
-                RegionalGuideCandidateRowText(
-                    text = candidate.displayText,
-                    supportingText = null
-                )
-            }
         }
     }
+}
+
+@Composable
+fun RegionalGuideCollectionTypeCandidateResult(
+    message: String,
+    candidates: List<RegionalGuideCandidateUiModel>,
+    onCandidateClick: (RegionalGuideCandidateUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+    messageDescription: String? = null,
+    sectionTitle: String? = null,
+    selectedRegionText: String? = null,
+) {
+    RegionalGuideFallbackCandidatePanel(
+        message = message,
+        description = messageDescription,
+        selectedRegionText = selectedRegionText,
+        sectionTitle = sectionTitle,
+        candidates = candidates,
+        onCandidateClick = onCandidateClick,
+        modifier = modifier,
+    )
 }
 
 @Composable
@@ -213,6 +220,12 @@ private fun RegionalGuideFallbackCandidateCards(
     onCandidateClick: (RegionalGuideCandidateUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val duplicatedOptionTexts = candidates
+        .groupingBy { candidate -> candidate.collectionTypeOptionText }
+        .eachCount()
+        .filterValues { count -> count > 1 }
+        .keys
+
     Column(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -221,6 +234,7 @@ private fun RegionalGuideFallbackCandidateCards(
             key(candidate.stableKey) {
                 RegionalGuideFallbackCandidateCard(
                     candidate = candidate,
+                    showDistinguishingText = candidate.collectionTypeOptionText in duplicatedOptionTexts,
                     onClick = { onCandidateClick(candidate) },
                 )
             }
@@ -231,6 +245,7 @@ private fun RegionalGuideFallbackCandidateCards(
 @Composable
 private fun RegionalGuideFallbackCandidateCard(
     candidate: RegionalGuideCandidateUiModel,
+    showDistinguishingText: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -271,6 +286,16 @@ private fun RegionalGuideFallbackCandidateCard(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
+
+                if (showDistinguishingText) {
+                    candidate.collectionTypeDistinguishingText?.let { distinguishingText ->
+                        Text(
+                            text = distinguishingText.labelText(),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
             }
 
             Surface(
@@ -304,6 +329,29 @@ private fun RegionalGuideCandidateUiModel.collectionTypeSupportingText(
 
         null -> null
     }
+}
+
+@Composable
+private fun RegionalGuideCandidateDistinguishingText.labelText(): String {
+    val labelText = when (label) {
+        RegionalGuideCandidateDistinguishingLabel.DISPOSAL_PLACE ->
+            stringResource(id = R.string.regional_guide_candidate_distinguishing_disposal_place)
+
+        RegionalGuideCandidateDistinguishingLabel.UNCOLLECTED_DAYS ->
+            stringResource(id = R.string.regional_guide_candidate_distinguishing_uncollected_days)
+
+        RegionalGuideCandidateDistinguishingLabel.SCHEDULE ->
+            stringResource(id = R.string.regional_guide_candidate_distinguishing_schedule)
+
+        RegionalGuideCandidateDistinguishingLabel.DEPARTMENT ->
+            stringResource(id = R.string.regional_guide_candidate_distinguishing_department)
+    }
+
+    return stringResource(
+        id = R.string.regional_guide_candidate_distinguishing_format,
+        labelText,
+        value,
+    )
 }
 
 private fun previewFallbackCandidates(): List<RegionalGuideCandidateUiModel> =
@@ -348,14 +396,13 @@ private fun previewFallbackCandidates(): List<RegionalGuideCandidateUiModel> =
 @Composable
 private fun RegionalGuideCandidateResultFallbackPreview() {
     MaterialTheme {
-        RegionalGuideCandidateResult(
+        RegionalGuideCollectionTypeCandidateResult(
             message = "직접 안내를 찾지 못했어요",
             messageDescription = "사천면의 직접 배출 안내가 없어 강릉시 기준 수거 유형을 선택해 주세요.",
             selectedRegionText = "강원특별자치도 > 강릉시 > 사천면",
             sectionTitle = "수거 유형 선택",
             candidates = previewFallbackCandidates(),
             onCandidateClick = {},
-            showCollectionTypeHelp = true,
             modifier = Modifier.padding(16.dp)
         )
     }
@@ -366,7 +413,6 @@ private fun RegionalGuideCandidateResultFallbackPreview() {
 private fun RegionalGuideCandidateResultPreview() {
     MaterialTheme {
         RegionalGuideCandidateResult(
-            message = "여러 배출 권역이 검색됩니다. 해당하는 권역을 선택해주세요.",
             candidates = listOf(
                 RegionalGuideCandidateUiModel(
                     guide = previewGuide("범서, 온양, 웅촌, 언양, 삼남, 상북, 온산, 청량, 서생"),

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideCandidateResult.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/components/RegionalGuideCandidateResult.kt
@@ -1,12 +1,20 @@
 package com.team.yeogibeoryeo.presentation.regionalguide.components
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -20,32 +28,36 @@ import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiMod
 @Composable
 fun RegionalGuideCandidateResult(
     message: String,
+    messageDescription: String? = null,
+    sectionTitle: String? = null,
+    selectedRegionText: String? = null,
     candidates: List<RegionalGuideCandidateUiModel>,
     onCandidateClick: (RegionalGuideCandidateUiModel) -> Unit,
     showCollectionTypeHelp: Boolean = false,
     modifier: Modifier = Modifier
 ) {
-    Text(
-        text = message,
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp)
-    )
-
-    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-
-    RegionalGuideCandidateList(
-        candidates = candidates,
-        key = { candidate -> candidate.stableKey },
-        onCandidateClick = onCandidateClick,
-        modifier = modifier
-    ) { candidate ->
-        RegionalGuideCandidateRowText(
-            text = candidate.displayText,
-            supportingText = candidate.collectionTypeSupportingText(showCollectionTypeHelp)
-        )
+    Column(modifier = modifier.fillMaxWidth()) {
+        if (showCollectionTypeHelp) {
+            RegionalGuideFallbackCandidatePanel(
+                message = message,
+                description = messageDescription,
+                selectedRegionText = selectedRegionText,
+                sectionTitle = sectionTitle,
+                candidates = candidates,
+                onCandidateClick = onCandidateClick,
+            )
+        } else {
+            RegionalGuideCandidateList(
+                candidates = candidates,
+                key = { candidate -> candidate.stableKey },
+                onCandidateClick = onCandidateClick,
+            ) { candidate ->
+                RegionalGuideCandidateRowText(
+                    text = candidate.displayText,
+                    supportingText = null
+                )
+            }
+        }
     }
 }
 
@@ -84,6 +96,200 @@ private fun RegionalGuideCandidateRowText(
 }
 
 @Composable
+private fun RegionalGuideFallbackCandidatePanel(
+    message: String,
+    description: String?,
+    selectedRegionText: String?,
+    sectionTitle: String?,
+    candidates: List<RegionalGuideCandidateUiModel>,
+    onCandidateClick: (RegionalGuideCandidateUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(18.dp),
+        color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.12f),
+        border = BorderStroke(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.22f),
+        ),
+        shadowElevation = 0.dp,
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            RegionalGuideFallbackPanelIntro(
+                message = message,
+                description = description,
+            )
+
+            if (selectedRegionText != null) {
+                RegionalGuideFallbackSelectedRegion(
+                    selectedRegionText = selectedRegionText
+                )
+            }
+
+            HorizontalDivider(
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+            )
+
+            Column(
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Text(
+                    text = sectionTitle ?: stringResource(
+                        id = R.string.regional_guide_candidate_fallback_section_title
+                    ),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold,
+                )
+
+                RegionalGuideFallbackCandidateCards(
+                    candidates = candidates,
+                    onCandidateClick = onCandidateClick,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RegionalGuideFallbackPanelIntro(
+    message: String,
+    description: String?,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(5.dp),
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.Bold,
+        )
+
+        if (description != null) {
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RegionalGuideFallbackSelectedRegion(
+    selectedRegionText: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = stringResource(id = R.string.regional_guide_candidate_selected_region_label),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.Medium,
+        )
+
+        Text(
+            text = selectedRegionText,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@Composable
+private fun RegionalGuideFallbackCandidateCards(
+    candidates: List<RegionalGuideCandidateUiModel>,
+    onCandidateClick: (RegionalGuideCandidateUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        candidates.forEach { candidate ->
+            key(candidate.stableKey) {
+                RegionalGuideFallbackCandidateCard(
+                    candidate = candidate,
+                    onClick = { onCandidateClick(candidate) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RegionalGuideFallbackCandidateCard(
+    candidate: RegionalGuideCandidateUiModel,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(10.dp),
+        color = MaterialTheme.colorScheme.surface,
+        border = BorderStroke(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.24f)
+        ),
+        shadowElevation = 0.dp,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = candidate.collectionTypeOptionText,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Bold,
+                )
+
+                candidate.collectionTypeSupportingText(enabled = true)?.let { supportingText ->
+                    Text(
+                        text = supportingText,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            Surface(
+                shape = RoundedCornerShape(999.dp),
+                color = MaterialTheme.colorScheme.primaryContainer,
+            ) {
+                Text(
+                    text = stringResource(id = R.string.regional_guide_candidate_select_action),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
 private fun RegionalGuideCandidateUiModel.collectionTypeSupportingText(
     enabled: Boolean
 ): String? {
@@ -97,6 +303,61 @@ private fun RegionalGuideCandidateUiModel.collectionTypeSupportingText(
             stringResource(id = R.string.regional_guide_candidate_base_point_supporting_text)
 
         null -> null
+    }
+}
+
+private fun previewFallbackCandidates(): List<RegionalGuideCandidateUiModel> =
+    listOf(
+        RegionalGuideCandidateUiModel(
+            guide = RegionalGuideUiModel(
+                regionName = "강원특별자치도 강릉시",
+                managementZoneName = "거점수거 지역",
+                targetRegionName = "거점수거 지역",
+                disposalPlaceType = "거점수거",
+                disposalPlaceDescription = "거점",
+                schedules = emptyList(),
+                uncollectedDays = null,
+                departmentInfo = null
+            ),
+            sido = "강원특별자치도",
+            sigungu = "강릉시",
+            eupmyeondong = "사천면"
+        ),
+        RegionalGuideCandidateUiModel(
+            guide = RegionalGuideUiModel(
+                regionName = "강원특별자치도 강릉시",
+                managementZoneName = "문전수거 지역",
+                targetRegionName = "문전수거 지역",
+                disposalPlaceType = "문전수거",
+                disposalPlaceDescription = "문전",
+                schedules = emptyList(),
+                uncollectedDays = null,
+                departmentInfo = null
+            ),
+            sido = "강원특별자치도",
+            sigungu = "강릉시",
+            eupmyeondong = "사천면"
+        ),
+    )
+
+@Preview(
+    name = "fallback 후보 안내",
+    showBackground = true,
+    widthDp = 360
+)
+@Composable
+private fun RegionalGuideCandidateResultFallbackPreview() {
+    MaterialTheme {
+        RegionalGuideCandidateResult(
+            message = "직접 안내를 찾지 못했어요",
+            messageDescription = "사천면의 직접 배출 안내가 없어 강릉시 기준 수거 유형을 선택해 주세요.",
+            selectedRegionText = "강원특별자치도 > 강릉시 > 사천면",
+            sectionTitle = "수거 유형 선택",
+            candidates = previewFallbackCandidates(),
+            onCandidateClick = {},
+            showCollectionTypeHelp = true,
+            modifier = Modifier.padding(16.dp)
+        )
     }
 }
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionSearchCandidateUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionSearchCandidateUiModel.kt
@@ -5,6 +5,13 @@ data class RegionSearchCandidateUiModel(
     val sigungu: String?,
     val eupmyeondong: String?
 ) {
+    val stableKey: String =
+        listOf(
+            "sido=${sido.toStableKeyPart()}",
+            "sigungu=${sigungu.toStableKeyPart()}",
+            "eupmyeondong=${eupmyeondong.toStableKeyPart()}"
+        ).joinToString(STABLE_KEY_SEPARATOR)
+
     val displayText: String =
         listOfNotNull(
             sido,
@@ -17,3 +24,12 @@ data class RegionSearchCandidateUiModel(
     val isValid: Boolean
         get() = displayText.isNotBlank()
 }
+
+private fun String?.toStableKeyPart(): String =
+    this
+        ?.trim()
+        ?.takeIf { value -> value.isNotEmpty() }
+        ?: BLANK_KEY_PART
+
+private const val STABLE_KEY_SEPARATOR = "|"
+private const val BLANK_KEY_PART = "<blank>"

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
@@ -58,12 +58,33 @@ data class RegionalGuideCandidateUiModel(
             guide.targetRegionName.takeIfRegionalGuideDisplayValue() == null &&
             guide.disposalPlaceType.takeIfRegionalGuideDisplayValue() != null
 
+    internal val isCollectionTypeSelectionCandidate: Boolean =
+        isOverallCollectionTypeCandidate || isNamedCollectionTypeCandidate()
+
     internal val collectionTypeOptionText: String =
         if (isOverallCollectionTypeCandidate) {
             guide.disposalPlaceType.takeIfRegionalGuideDisplayValue() ?: displayText
         } else {
             displayText
         }
+
+    internal val collectionTypeDistinguishingText: RegionalGuideCandidateDistinguishingText? =
+        listOfNotNull(
+            guide.disposalPlaceDescription.toDistinguishingText(
+                RegionalGuideCandidateDistinguishingLabel.DISPOSAL_PLACE
+            ),
+            guide.uncollectedDays.toDistinguishingText(
+                RegionalGuideCandidateDistinguishingLabel.UNCOLLECTED_DAYS
+            ),
+            guide.schedules.firstNotNullOfOrNull { schedule ->
+                schedule.toCandidateSummary()
+            }?.toDistinguishingText(
+                RegionalGuideCandidateDistinguishingLabel.SCHEDULE
+            ),
+            guide.departmentInfo.toDistinguishingText(
+                RegionalGuideCandidateDistinguishingLabel.DEPARTMENT
+            ),
+        ).firstOrNull()
 
     private fun primaryDisplayParts(): List<String> =
         listOfNotNull(
@@ -91,6 +112,19 @@ data class RegionalGuideCandidateUiModel(
     private fun List<String>.appendDisambiguation(): List<String> =
         this + listOfNotNull(disambiguationText.takeIfRegionalGuideDisplayValue())
 
+    private fun isNamedCollectionTypeCandidate(): Boolean {
+        val disposalPlaceType = guide.disposalPlaceType.takeIfRegionalGuideDisplayValue()
+            ?: return false
+        if (collectionTypeHint == null) return false
+
+        val displayParts = primaryDisplayParts()
+        if (displayParts.isEmpty()) return false
+
+        return displayParts.all { displayPart ->
+            displayPart.isCollectionTypeDisplayName(disposalPlaceType)
+        }
+    }
+
     private fun RegionalWasteScheduleUiModel.toCandidateSummary(): String? {
         val criterion =
             disposalDays.takeIfRegionalGuideDisplayValue()
@@ -115,6 +149,18 @@ data class RegionalGuideCandidateUiModel(
     }
 }
 
+internal data class RegionalGuideCandidateDistinguishingText(
+    val label: RegionalGuideCandidateDistinguishingLabel,
+    val value: String
+)
+
+internal enum class RegionalGuideCandidateDistinguishingLabel {
+    DISPOSAL_PLACE,
+    UNCOLLECTED_DAYS,
+    SCHEDULE,
+    DEPARTMENT,
+}
+
 enum class RegionalGuideCandidateCollectionTypeHint {
     DOOR_TO_DOOR,
     BASE_POINT,
@@ -133,6 +179,28 @@ private fun String?.toStableKeyPart(): String =
         ?.trim()
         ?.takeIf { value -> value.isNotBlank() }
         ?: "<blank>"
+
+private fun String?.toDistinguishingText(
+    label: RegionalGuideCandidateDistinguishingLabel
+): RegionalGuideCandidateDistinguishingText? =
+    takeIfRegionalGuideDisplayValue()
+        ?.let { value ->
+            RegionalGuideCandidateDistinguishingText(
+                label = label,
+                value = value
+            )
+        }
+
+private fun String.isCollectionTypeDisplayName(disposalPlaceType: String): Boolean {
+    val normalizedDisplayName = toCollectionTypeComparableText()
+    val normalizedType = disposalPlaceType.toCollectionTypeComparableText()
+
+    return normalizedDisplayName == normalizedType ||
+        normalizedDisplayName == "${normalizedType}지역"
+}
+
+private fun String.toCollectionTypeComparableText(): String =
+    trim().replace(" ", "")
 
 internal fun List<RegionalGuideCandidateUiModel>.withDuplicateDisplayDisambiguation():
     List<RegionalGuideCandidateUiModel> {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
@@ -53,6 +53,18 @@ data class RegionalGuideCandidateUiModel(
             else -> null
         }
 
+    internal val isOverallCollectionTypeCandidate: Boolean =
+        guide.managementZoneName.takeIfRegionalGuideDisplayValue() == null &&
+            guide.targetRegionName.takeIfRegionalGuideDisplayValue() == null &&
+            guide.disposalPlaceType.takeIfRegionalGuideDisplayValue() != null
+
+    internal val collectionTypeOptionText: String =
+        if (isOverallCollectionTypeCandidate) {
+            guide.disposalPlaceType.takeIfRegionalGuideDisplayValue() ?: displayText
+        } else {
+            displayText
+        }
+
     private fun primaryDisplayParts(): List<String> =
         listOfNotNull(
             guide.managementZoneName.takeIfRegionalGuideDisplayValue(),
@@ -132,8 +144,6 @@ internal fun List<RegionalGuideCandidateUiModel>.withDuplicateDisplayDisambiguat
                 .distinct()
         }
         .filterValues { disambiguationTexts -> disambiguationTexts.size > 1 }
-
-    if (disambiguationByDisplayText.isEmpty()) return this
 
     return map { candidate ->
         if (candidate.displayText in disambiguationByDisplayText) {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModel.kt
@@ -7,6 +7,20 @@ data class RegionalGuideCandidateUiModel(
     val eupmyeondong: String?,
     internal val disambiguationText: String? = null
 ) {
+    val stableKey: String =
+        listOf(
+            "sido=${sido.toStableKeyPart()}",
+            "sigungu=${sigungu.toStableKeyPart()}",
+            "eupmyeondong=${eupmyeondong.toStableKeyPart()}",
+            "managementZone=${guide.managementZoneName.toStableKeyPart()}",
+            "targetRegion=${guide.targetRegionName.toStableKeyPart()}",
+            "placeType=${guide.disposalPlaceType.toStableKeyPart()}",
+            "placeDescription=${guide.disposalPlaceDescription.toStableKeyPart()}",
+            "uncollectedDays=${guide.uncollectedDays.toStableKeyPart()}",
+            "department=${guide.departmentInfo.toStableKeyPart()}",
+            "schedules=${guide.schedules.joinToString(SCHEDULE_KEY_SEPARATOR) { schedule -> schedule.stableKey }}",
+        ).joinToString(STABLE_KEY_SEPARATOR)
+
     val displayText: String =
         baseDisplayParts()
             .appendDisambiguation()
@@ -31,6 +45,13 @@ data class RegionalGuideCandidateUiModel(
                         listOf(managementZoneSortText, parts[1]).joinToString(CANDIDATE_LABEL_SEPARATOR)
                     }
             }
+
+    val collectionTypeHint: RegionalGuideCandidateCollectionTypeHint? =
+        when (guide.disposalPlaceType?.trim()) {
+            DOOR_TO_DOOR_COLLECTION_TYPE -> RegionalGuideCandidateCollectionTypeHint.DOOR_TO_DOOR
+            BASE_POINT_COLLECTION_TYPE -> RegionalGuideCandidateCollectionTypeHint.BASE_POINT
+            else -> null
+        }
 
     private fun primaryDisplayParts(): List<String> =
         listOfNotNull(
@@ -75,8 +96,31 @@ data class RegionalGuideCandidateUiModel(
     private companion object {
         const val CANDIDATE_LABEL_SEPARATOR = " / "
         const val SCHEDULE_SUMMARY_SEPARATOR = " "
+        const val STABLE_KEY_SEPARATOR = "|"
+        const val SCHEDULE_KEY_SEPARATOR = ";"
+        const val DOOR_TO_DOOR_COLLECTION_TYPE = "문전수거"
+        const val BASE_POINT_COLLECTION_TYPE = "거점수거"
     }
 }
+
+enum class RegionalGuideCandidateCollectionTypeHint {
+    DOOR_TO_DOOR,
+    BASE_POINT,
+}
+
+private val RegionalWasteScheduleUiModel.stableKey: String
+    get() = listOf(
+        wasteTypeName.toStableKeyPart(),
+        disposalDays.toStableKeyPart(),
+        disposalTime.toStableKeyPart(),
+        disposalMethod.toStableKeyPart(),
+    ).joinToString("/")
+
+private fun String?.toStableKeyPart(): String =
+    this
+        ?.trim()
+        ?.takeIf { value -> value.isNotBlank() }
+        ?: "<blank>"
 
 internal fun List<RegionalGuideCandidateUiModel>.withDuplicateDisplayDisambiguation():
     List<RegionalGuideCandidateUiModel> {

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -121,6 +121,11 @@
     <string name="regional_guide_candidate_favorite_restore_ambiguous_message">저장된 지역과 일치하는 배출 기준이 여러 개 있어요. 다시 확인할 권역을 선택해 주세요.</string>
     <string name="regional_guide_candidate_door_to_door_supporting_text">집 앞 또는 지정된 배출장소에 배출하는 지역</string>
     <string name="regional_guide_candidate_base_point_supporting_text">마을 거점 또는 지정 수거 장소를 이용하는 지역</string>
+    <string name="regional_guide_candidate_distinguishing_format">%1$s: %2$s</string>
+    <string name="regional_guide_candidate_distinguishing_disposal_place">배출장소</string>
+    <string name="regional_guide_candidate_distinguishing_uncollected_days">미수거일</string>
+    <string name="regional_guide_candidate_distinguishing_schedule">배출 기준</string>
+    <string name="regional_guide_candidate_distinguishing_department">담당부서</string>
     <string name="item_guide_detail_not_found_title">품목 가이드를 찾을 수 없습니다</string>
     <string name="item_guide_detail_select_again_message">다시 검색해서 품목을 선택해주세요.</string>
     <string name="item_guide_detail_load_failed_message">품목 정보를 불러오는 중 오류가 발생했습니다.</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -109,6 +109,15 @@
     <string name="regional_guide_candidate_multiple_message">여러 배출 권역이 검색됩니다. 해당하는 권역을 선택해 주세요.</string>
     <string name="regional_guide_candidate_multiple_exact_message">선택한 지역에 여러 배출 기준이 있어요. 해당하는 권역을 선택해 주세요.</string>
     <string name="regional_guide_candidate_fallback_message">선택한 읍면동의 직접 안내를 찾지 못했어요. 같은 시군구 기준 수거 유형을 선택해 주세요.</string>
+    <string name="regional_guide_candidate_fallback_panel_title">직접 안내를 찾지 못했어요</string>
+    <string name="regional_guide_candidate_fallback_panel_description">%1$s의 직접 배출 안내가 없어 %2$s 기준 수거 유형을 선택해 주세요.</string>
+    <string name="regional_guide_candidate_fallback_panel_description_without_region">선택한 지역의 직접 배출 안내가 없어 같은 시군구 기준 수거 유형을 선택해 주세요.</string>
+    <string name="regional_guide_candidate_collection_type_panel_title">수거 유형을 선택해 주세요</string>
+    <string name="regional_guide_candidate_collection_type_panel_description">%1$s 기준 수거 유형을 선택하면 안내를 확인할 수 있어요.</string>
+    <string name="regional_guide_candidate_collection_type_panel_description_without_region">수거 유형을 선택하면 안내를 확인할 수 있어요.</string>
+    <string name="regional_guide_candidate_selected_region_label">선택한 지역</string>
+    <string name="regional_guide_candidate_fallback_section_title">수거 유형 선택</string>
+    <string name="regional_guide_candidate_select_action">선택</string>
     <string name="regional_guide_candidate_favorite_restore_ambiguous_message">저장된 지역과 일치하는 배출 기준이 여러 개 있어요. 다시 확인할 권역을 선택해 주세요.</string>
     <string name="regional_guide_candidate_door_to_door_supporting_text">집 앞 또는 지정된 배출장소에 배출하는 지역</string>
     <string name="regional_guide_candidate_base_point_supporting_text">마을 거점 또는 지정 수거 장소를 이용하는 지역</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -106,6 +106,12 @@
     <string name="regional_guide_empty_action_select_region">지역 다시 선택하기</string>
     <string name="regional_guide_loading_default_message">배출 가이드를 불러오는 중입니다.</string>
     <string name="regional_guide_loading_region_message">\"%1$s\" 배출 가이드를 불러오는 중입니다.</string>
+    <string name="regional_guide_candidate_multiple_message">여러 배출 권역이 검색됩니다. 해당하는 권역을 선택해 주세요.</string>
+    <string name="regional_guide_candidate_multiple_exact_message">선택한 지역에 여러 배출 기준이 있어요. 해당하는 권역을 선택해 주세요.</string>
+    <string name="regional_guide_candidate_fallback_message">선택한 읍면동의 직접 안내를 찾지 못했어요. 같은 시군구 기준 수거 유형을 선택해 주세요.</string>
+    <string name="regional_guide_candidate_favorite_restore_ambiguous_message">저장된 지역과 일치하는 배출 기준이 여러 개 있어요. 다시 확인할 권역을 선택해 주세요.</string>
+    <string name="regional_guide_candidate_door_to_door_supporting_text">집 앞 또는 지정된 배출장소에 배출하는 지역</string>
+    <string name="regional_guide_candidate_base_point_supporting_text">마을 거점 또는 지정 수거 장소를 이용하는 지역</string>
     <string name="item_guide_detail_not_found_title">품목 가이드를 찾을 수 없습니다</string>
     <string name="item_guide_detail_select_again_message">다시 검색해서 품목을 선택해주세요.</string>
     <string name="item_guide_detail_load_failed_message">품목 정보를 불러오는 중 오류가 발생했습니다.</string>

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateDisplayPolicyTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateDisplayPolicyTest.kt
@@ -1,0 +1,146 @@
+package com.team.yeogibeoryeo.presentation.regionalguide
+
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideCandidateUiModel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RegionalGuideCandidateDisplayPolicyTest {
+
+    @Test
+    fun `직접 매칭 실패 후보가 수거 유형 후보이면 수거 유형 패널을 표시한다`() {
+        val state = guideCandidates(
+            reason = RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND,
+            candidates = listOf(
+                candidate(
+                    managementZoneName = "문전수거 지역",
+                    targetRegionName = "문전수거 지역",
+                    disposalPlaceType = "문전수거"
+                ),
+                candidate(
+                    managementZoneName = "거점수거 지역",
+                    targetRegionName = "거점수거 지역",
+                    disposalPlaceType = "거점수거"
+                )
+            )
+        )
+
+        assertTrue(state.shouldShowCollectionTypeSelectionPanel())
+    }
+
+    @Test
+    fun `직접 매칭 실패 후보라도 일반 권역 후보이면 기존 리스트를 유지한다`() {
+        val state = guideCandidates(
+            reason = RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND,
+            candidates = listOf(
+                candidate(
+                    managementZoneName = "1권역",
+                    targetRegionName = "갑천면",
+                    disposalPlaceType = "문전수거"
+                ),
+                candidate(
+                    managementZoneName = "2권역",
+                    targetRegionName = "공근면",
+                    disposalPlaceType = "거점수거"
+                )
+            )
+        )
+
+        assertFalse(state.shouldShowCollectionTypeSelectionPanel())
+    }
+
+    @Test
+    fun `시군구 전체 기준 수거 유형 후보만 있으면 수거 유형 패널을 표시한다`() {
+        val state = guideCandidates(
+            reason = RegionalGuideCandidateReason.MULTIPLE_CANDIDATES,
+            candidates = listOf(
+                candidate(
+                    managementZoneName = "없음",
+                    targetRegionName = "없음",
+                    disposalPlaceType = "거점수거"
+                ),
+                candidate(
+                    managementZoneName = "없음",
+                    targetRegionName = "없음",
+                    disposalPlaceType = "문전수거"
+                )
+            )
+        )
+
+        assertTrue(state.shouldShowCollectionTypeSelectionPanel())
+    }
+
+    @Test
+    fun `복수 정확 매칭 후보는 수거 유형 패널로 표시하지 않는다`() {
+        val state = guideCandidates(
+            reason = RegionalGuideCandidateReason.MULTIPLE_EXACT_MATCHES,
+            candidates = listOf(
+                candidate(
+                    managementZoneName = "노은2동",
+                    targetRegionName = "반석동",
+                    disposalPlaceType = "문전수거"
+                ),
+                candidate(
+                    managementZoneName = "노은3동",
+                    targetRegionName = "반석동",
+                    disposalPlaceType = "문전수거"
+                )
+            )
+        )
+
+        assertFalse(state.shouldShowCollectionTypeSelectionPanel())
+    }
+
+    @Test
+    fun `즐겨찾기 복원 모호 후보는 수거 유형 패널로 표시하지 않는다`() {
+        val state = guideCandidates(
+            reason = RegionalGuideCandidateReason.FAVORITE_RESTORE_AMBIGUOUS,
+            candidates = listOf(
+                candidate(
+                    managementZoneName = "문전수거 지역",
+                    targetRegionName = "문전수거 지역",
+                    disposalPlaceType = "문전수거"
+                ),
+                candidate(
+                    managementZoneName = "거점수거 지역",
+                    targetRegionName = "거점수거 지역",
+                    disposalPlaceType = "거점수거"
+                )
+            )
+        )
+
+        assertFalse(state.shouldShowCollectionTypeSelectionPanel())
+    }
+
+    private fun guideCandidates(
+        reason: RegionalGuideCandidateReason,
+        candidates: List<RegionalGuideCandidateUiModel>
+    ): RegionalGuideUiState.GuideCandidates =
+        RegionalGuideUiState.GuideCandidates(
+            query = "검색어",
+            reason = reason,
+            candidates = candidates,
+        )
+
+    private fun candidate(
+        managementZoneName: String?,
+        targetRegionName: String?,
+        disposalPlaceType: String?
+    ): RegionalGuideCandidateUiModel =
+        RegionalGuideCandidateUiModel(
+            guide = RegionalGuideUiModel(
+                regionName = "강원특별자치도 양구군",
+                managementZoneName = managementZoneName,
+                targetRegionName = targetRegionName,
+                disposalPlaceType = disposalPlaceType,
+                disposalPlaceDescription = null,
+                schedules = emptyList(),
+                uncollectedDays = null,
+                departmentInfo = null,
+            ),
+            sido = "강원특별자치도",
+            sigungu = "양구군",
+            eupmyeondong = null,
+        )
+}

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateMessageTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateMessageTest.kt
@@ -1,0 +1,24 @@
+package com.team.yeogibeoryeo.presentation.regionalguide
+
+import com.team.yeogibeoryeo.presentation.R
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RegionalGuideCandidateMessageTest {
+
+    @Test
+    fun `대체 후보 사유는 대체 안내 문구 리소스로 매핑된다`() {
+        assertEquals(
+            R.string.regional_guide_candidate_fallback_message,
+            RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND.messageResId()
+        )
+    }
+
+    @Test
+    fun `즐겨찾기 복원 모호 사유는 즐겨찾기 복원 안내 문구 리소스로 매핑된다`() {
+        assertEquals(
+            R.string.regional_guide_candidate_favorite_restore_ambiguous_message,
+            RegionalGuideCandidateReason.FAVORITE_RESTORE_AMBIGUOUS.messageResId()
+        )
+    }
+}

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateMessageTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateMessageTest.kt
@@ -1,6 +1,8 @@
 package com.team.yeogibeoryeo.presentation.regionalguide
 
 import com.team.yeogibeoryeo.presentation.R
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideCandidateUiModel
+import com.team.yeogibeoryeo.presentation.regionalguide.model.RegionalGuideUiModel
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -21,4 +23,92 @@ class RegionalGuideCandidateMessageTest {
             RegionalGuideCandidateReason.FAVORITE_RESTORE_AMBIGUOUS.messageResId()
         )
     }
+
+    @Test
+    fun `fallback 후보 안내는 선택 읍면동과 시군구를 문구 인자로 전달한다`() {
+        val state = RegionalGuideUiState.GuideCandidates(
+            query = "사천면",
+            reason = RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND,
+            candidates = listOf(
+                candidate(
+                    sido = "강원특별자치도",
+                    sigungu = "강릉시",
+                    eupmyeondong = "사천면",
+                )
+            )
+        )
+
+        val spec = state.candidateMessageSpec()
+
+        assertEquals(R.string.regional_guide_candidate_fallback_panel_title, spec.titleResId)
+        assertEquals(emptyList<String>(), spec.titleArgs)
+        assertEquals(
+            R.string.regional_guide_candidate_fallback_panel_description,
+            spec.descriptionResId
+        )
+        assertEquals(listOf("사천면", "강릉시"), spec.descriptionArgs)
+        assertEquals(R.string.regional_guide_candidate_fallback_section_title, spec.sectionTitleResId)
+    }
+
+    @Test
+    fun `fallback 후보에 지역명이 없으면 기본 안내 문구를 사용한다`() {
+        val state = RegionalGuideUiState.GuideCandidates(
+            query = "검색어",
+            reason = RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND,
+            candidates = listOf(candidate())
+        )
+
+        val spec = state.candidateMessageSpec()
+
+        assertEquals(R.string.regional_guide_candidate_fallback_panel_title, spec.titleResId)
+        assertEquals(emptyList<String>(), spec.titleArgs)
+        assertEquals(
+            R.string.regional_guide_candidate_fallback_panel_description_without_region,
+            spec.descriptionResId
+        )
+        assertEquals(emptyList<String>(), spec.descriptionArgs)
+    }
+
+    @Test
+    fun `시군구 전체 기준 수거 유형 후보는 수거 유형 선택 안내 문구를 사용한다`() {
+        val state = RegionalGuideUiState.GuideCandidates(
+            query = "양구",
+            reason = RegionalGuideCandidateReason.MULTIPLE_CANDIDATES,
+            candidates = listOf(
+                candidate(sigungu = "양구군"),
+                candidate(sigungu = "양구군")
+            )
+        )
+
+        val spec = state.collectionTypeSelectionMessageSpec()
+
+        assertEquals(R.string.regional_guide_candidate_collection_type_panel_title, spec.titleResId)
+        assertEquals(
+            R.string.regional_guide_candidate_collection_type_panel_description,
+            spec.descriptionResId
+        )
+        assertEquals(listOf("양구군"), spec.descriptionArgs)
+        assertEquals(R.string.regional_guide_candidate_fallback_section_title, spec.sectionTitleResId)
+    }
+
+    private fun candidate(
+        sido: String? = null,
+        sigungu: String? = null,
+        eupmyeondong: String? = null,
+    ): RegionalGuideCandidateUiModel =
+        RegionalGuideCandidateUiModel(
+            guide = RegionalGuideUiModel(
+                regionName = "지역",
+                managementZoneName = "관리 권역",
+                targetRegionName = "대상 지역",
+                disposalPlaceType = "문전수거",
+                disposalPlaceDescription = "문전",
+                schedules = emptyList(),
+                uncollectedDays = null,
+                departmentInfo = null,
+            ),
+            sido = sido,
+            sigungu = sigungu,
+            eupmyeondong = eupmyeondong,
+        )
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateSelectionViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideCandidateSelectionViewModelTest.kt
@@ -1,6 +1,7 @@
 ﻿package com.team.yeogibeoryeo.presentation.regionalguide
 
 import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -18,7 +19,7 @@ class RegionalGuideCandidateSelectionViewModelTest {
     val mainDispatcherRule = RegionalGuideMainDispatcherRule()
 
     @Test
-    fun `regional guide lookup exposes multiple guide candidates`() = runTest {
+    fun `지역 가이드 조회 결과가 여러 후보이면 후보 목록을 보여준다`() = runTest {
         val viewModel = createViewModel(
             regionRepository = FakeRegionRepository(
                 resolvedRegion = Region(sigungu = "울주군")
@@ -47,6 +48,7 @@ class RegionalGuideCandidateSelectionViewModelTest {
         val state = viewModel.uiState.value as RegionalGuideUiState.GuideCandidates
 
         assertEquals("울주군", state.query)
+        assertEquals(RegionalGuideCandidateReason.MULTIPLE_CANDIDATES, state.reason)
         assertEquals(2, state.candidates.size)
         assertEquals(
             listOf(
@@ -58,7 +60,88 @@ class RegionalGuideCandidateSelectionViewModelTest {
     }
 
     @Test
-    fun `guide candidate list is cleared when keyword changes after guide candidate search`() = runTest {
+    fun `직접 매칭 실패 후 대체 후보 목록이 표시되면 대체 사유를 보여준다`() = runTest {
+        val region = Region(
+            sido = "강원특별자치도",
+            sigungu = "강릉시",
+            eupmyeondong = "사천면"
+        )
+        val viewModel = createViewModel(
+            regionRepository = FakeRegionRepository(resolvedRegion = region),
+            regionalGuideRepository = FakeRegionalDisposalGuideRepository(
+                candidates = listOf(
+                    RegionalDisposalGuide(
+                        region = region.copy(eupmyeondong = null),
+                        managementZoneName = "없음",
+                        targetRegionName = "없음",
+                        disposalPlaceType = "문전수거",
+                        schedules = emptyList()
+                    ),
+                    RegionalDisposalGuide(
+                        region = region.copy(eupmyeondong = null),
+                        managementZoneName = "없음",
+                        targetRegionName = "없음",
+                        disposalPlaceType = "거점수거",
+                        schedules = emptyList()
+                    )
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("사천면")
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value as RegionalGuideUiState.GuideCandidates
+
+        assertEquals(
+            RegionalGuideCandidateReason.FALLBACK_BECAUSE_DIRECT_MATCH_NOT_FOUND,
+            state.reason
+        )
+        assertEquals(2, state.candidates.size)
+    }
+
+    @Test
+    fun `정확 매칭 후보가 여러 개이면 복수 정확 매칭 사유를 보여준다`() = runTest {
+        val region = Region(
+            sido = "대전광역시",
+            sigungu = "유성구",
+            eupmyeondong = "반석동"
+        )
+        val viewModel = createViewModel(
+            regionRepository = FakeRegionRepository(resolvedRegion = region),
+            regionalGuideRepository = FakeRegionalDisposalGuideRepository(
+                candidates = listOf(
+                    RegionalDisposalGuide(
+                        region = region,
+                        managementZoneName = "노은2동",
+                        targetRegionName = "반석동",
+                        schedules = emptyList()
+                    ),
+                    RegionalDisposalGuide(
+                        region = region,
+                        managementZoneName = "노은3동",
+                        targetRegionName = "반석동",
+                        schedules = emptyList()
+                    )
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("반석동")
+        viewModel.searchCurrentKeyword()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value as RegionalGuideUiState.GuideCandidates
+
+        assertEquals(RegionalGuideCandidateReason.MULTIPLE_EXACT_MATCHES, state.reason)
+        assertEquals(2, state.candidates.size)
+    }
+
+    @Test
+    fun `가이드 후보 검색 후 검색어가 바뀌면 후보 목록을 초기화한다`() = runTest {
         val viewModel = createViewModel(
             regionRepository = FakeRegionRepository(
                 resolvedRegion = Region(sido = "SidoA", sigungu = "SigunguA")
@@ -93,7 +176,7 @@ class RegionalGuideCandidateSelectionViewModelTest {
     }
 
     @Test
-    fun `regional guide candidate selection shows selected guide`() = runTest {
+    fun `지역 가이드 후보를 선택하면 선택한 가이드를 보여준다`() = runTest {
         val viewModel = createViewModel(
             regionRepository = FakeRegionRepository(
                 resolvedRegion = Region(sigungu = "울주군")

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideFavoriteViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideFavoriteViewModelTest.kt
@@ -2,6 +2,8 @@
 
 import com.team.yeogibeoryeo.domain.favorite.model.Favorite
 import com.team.yeogibeoryeo.domain.favorite.model.FavoriteTargetType
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteKey
+import com.team.yeogibeoryeo.domain.favorite.model.RegionalGuideFavoriteSnapshot
 import com.team.yeogibeoryeo.domain.favorite.model.toFavoriteSnapshot
 import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
@@ -22,7 +24,7 @@ class RegionalGuideFavoriteViewModelTest {
     val mainDispatcherRule = RegionalGuideMainDispatcherRule()
 
     @Test
-    fun `favorite click stores regional guide favorite and observes state`() = runTest {
+    fun `즐겨찾기 클릭은 지역 가이드 즐겨찾기를 저장하고 상태를 관찰한다`() = runTest {
         val guide =
             RegionalDisposalGuide(
                 region = Region(sido = "Sido", sigungu = "Sigungu"),
@@ -62,7 +64,7 @@ class RegionalGuideFavoriteViewModelTest {
     }
 
     @Test
-    fun `favorite target id restores saved regional guide candidate`() = runTest {
+    fun `즐겨찾기 대상 아이디로 저장된 지역 가이드 후보를 복원한다`() = runTest {
         val region = Region(sido = "Sido", sigungu = "Sigungu")
         val firstGuide =
             RegionalDisposalGuide(
@@ -108,7 +110,7 @@ class RegionalGuideFavoriteViewModelTest {
     }
 
     @Test
-    fun `favorite target id restores candidate with same target region and different management zone`() = runTest {
+    fun `즐겨찾기 대상 아이디는 대상지역이 같고 관리구역이 다른 후보를 복원한다`() = runTest {
         val region = Region(sido = "대전광역시", sigungu = "유성구", eupmyeondong = "반석동")
         val firstGuide =
             RegionalDisposalGuide(
@@ -156,7 +158,7 @@ class RegionalGuideFavoriteViewModelTest {
     }
 
     @Test
-    fun `저장 후보 스냅샷이 없으면 복원 실패와 지역 다시 선택 action을 보여준다`() = runTest {
+    fun `저장 후보 스냅샷이 없으면 복원 실패와 지역 다시 선택 동작을 보여준다`() = runTest {
         val viewModel = createViewModel(
             regionalGuideSnapshotRepository = FakeRegionalGuideFavoriteSnapshotRepository()
         )
@@ -174,7 +176,7 @@ class RegionalGuideFavoriteViewModelTest {
     }
 
     @Test
-    fun `저장 후보가 info 후보와 더 이상 일치하지 않으면 복원 실패 action을 보여준다`() = runTest {
+    fun `저장 후보가 안내 후보와 더 이상 일치하지 않으면 복원 실패 동작을 보여준다`() = runTest {
         val savedGuide =
             RegionalDisposalGuide(
                 region = Region(sido = "대전광역시", sigungu = "유성구"),
@@ -207,7 +209,55 @@ class RegionalGuideFavoriteViewModelTest {
     }
 
     @Test
-    fun `favorite click after guide candidate selection keeps original none zone values in snapshot`() = runTest {
+    fun `즐겨찾기 복원 후보가 모호하면 즐겨찾기 복원 모호 사유를 보여준다`() = runTest {
+        val region = Region(sido = "대전광역시", sigungu = "유성구", eupmyeondong = "반석동")
+        val firstGuide =
+            RegionalDisposalGuide(
+                region = region,
+                targetRegionName = "반석동 일부지역",
+                managementZoneName = "노은2동",
+                schedules = emptyList(),
+            )
+        val secondGuide =
+            RegionalDisposalGuide(
+                region = region,
+                targetRegionName = "반석동 일부지역",
+                managementZoneName = "노은3동",
+                schedules = emptyList(),
+            )
+        val targetId = RegionalGuideFavoriteKey(
+            sido = region.sido,
+            sigungu = region.sigungu,
+            eupmyeondong = region.eupmyeondong,
+            targetRegionName = secondGuide.targetRegionName,
+            managementZoneName = null,
+        ).encode()
+        val snapshot = RegionalGuideFavoriteSnapshot(
+            targetId = targetId,
+            region = region,
+            targetRegionName = secondGuide.targetRegionName,
+            managementZoneName = null,
+        )
+        val viewModel =
+            createViewModel(
+                regionalGuideRepository =
+                    FakeRegionalDisposalGuideRepository(candidates = listOf(firstGuide, secondGuide)),
+                regionalGuideSnapshotRepository =
+                    FakeRegionalGuideFavoriteSnapshotRepository(snapshots = listOf(snapshot)),
+            )
+        advanceUntilIdle()
+
+        viewModel.loadByFavoriteTargetId(targetId)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value as RegionalGuideUiState.GuideCandidates
+
+        assertEquals(RegionalGuideCandidateReason.FAVORITE_RESTORE_AMBIGUOUS, state.reason)
+        assertEquals(2, state.candidates.size)
+    }
+
+    @Test
+    fun `가이드 후보 선택 후 즐겨찾기 클릭은 원본 없음 권역 값을 스냅샷에 유지한다`() = runTest {
         val region = Region(sido = "경기도", sigungu = "성남시")
         val doorToDoorGuide =
             RegionalDisposalGuide(
@@ -260,7 +310,7 @@ class RegionalGuideFavoriteViewModelTest {
     }
 
     @Test
-    fun `legacy regional guide favorite key is observed and removed with current snapshot`() = runTest {
+    fun `이전 형식 지역 가이드 즐겨찾기 키는 현재 스냅샷과 함께 관찰되고 삭제된다`() = runTest {
         val region = Region(sido = "서울특별시", sigungu = "노원구", eupmyeondong = "하계동")
         val guide =
             RegionalDisposalGuide(

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideSelectorViewModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/RegionalGuideSelectorViewModelTest.kt
@@ -143,6 +143,39 @@ class RegionalGuideSelectorViewModelTest {
     }
 
     @Test
+    fun `selected region search updates search keyword to selected region text`() = runTest {
+        val regionalGuideRepository = FakeRegionalDisposalGuideRepository(
+            candidates = listOf(
+                sampleGuide(
+                    sido = "광주광역시",
+                    sigungu = "동구",
+                    targetRegionName = "동구 전체"
+                )
+            )
+        )
+        val viewModel = createViewModel(
+            regionOptionsRepository = FakeRegionOptionsRepository(
+                sigunguOptionsBySido = mapOf(
+                    "광주광역시" to listOf("동구")
+                )
+            ),
+            regionalGuideRepository = regionalGuideRepository
+        )
+        advanceUntilIdle()
+
+        viewModel.onSearchKeywordChanged("금호동")
+        viewModel.onSidoSelected("광주광역시")
+        advanceUntilIdle()
+        viewModel.onSigunguSelected("동구")
+        advanceUntilIdle()
+        viewModel.onRegionSelectionSearchClick()
+        advanceUntilIdle()
+
+        assertEquals("광주광역시 > 동구", viewModel.searchKeyword.value)
+        assertTrue(viewModel.uiState.value is RegionalGuideUiState.Success)
+    }
+
+    @Test
     fun `keyword search collapses expanded region selector dropdown`() = runTest {
         val viewModel = createViewModel()
         advanceUntilIdle()

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionSearchCandidateUiModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionSearchCandidateUiModelTest.kt
@@ -1,0 +1,37 @@
+package com.team.yeogibeoryeo.presentation.regionalguide.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class RegionSearchCandidateUiModelTest {
+
+    @Test
+    fun `검색 후보 안정 키는 표시 문구가 아니라 지역 값 조합으로 만든다`() {
+        val candidate = RegionSearchCandidateUiModel(
+            sido = "경기도",
+            sigungu = "성남시",
+            eupmyeondong = "정자동"
+        )
+
+        assertEquals("경기도 > 성남시 > 정자동", candidate.displayText)
+        assertEquals("sido=경기도|sigungu=성남시|eupmyeondong=정자동", candidate.stableKey)
+        assertNotEquals(candidate.displayText, candidate.stableKey)
+    }
+
+    @Test
+    fun `검색 후보 안정 키는 빈 지역 값을 명시적으로 구분한다`() {
+        val sigunguCandidate = RegionSearchCandidateUiModel(
+            sido = "서울특별시",
+            sigungu = "중구",
+            eupmyeondong = null
+        )
+        val eupmyeondongCandidate = RegionSearchCandidateUiModel(
+            sido = "서울특별시",
+            sigungu = "중구",
+            eupmyeondong = "중구"
+        )
+
+        assertNotEquals(sigunguCandidate.stableKey, eupmyeondongCandidate.stableKey)
+    }
+}

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModelTest.kt
@@ -1,6 +1,7 @@
 package com.team.yeogibeoryeo.presentation.regionalguide.model
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 class RegionalGuideCandidateUiModelTest {
@@ -46,7 +47,7 @@ class RegionalGuideCandidateUiModelTest {
     }
 
     @Test
-    fun `관리구역명과 대상지역명이 모두 비어 있으면 시도 시군구 fallback을 표시한다`() {
+    fun `관리구역명과 대상지역명이 모두 비어 있으면 시도 시군구 대체 문구를 표시한다`() {
         val candidate = candidate(
             regionName = "대전광역시 유성구",
             managementZoneName = " ",
@@ -57,7 +58,7 @@ class RegionalGuideCandidateUiModelTest {
     }
 
     @Test
-    fun `관리구역명과 대상지역명이 모두 없음이면 시도 시군구 fallback을 표시한다`() {
+    fun `관리구역명과 대상지역명이 모두 없음이면 시도 시군구 대체 문구를 표시한다`() {
         val candidate = candidate(
             sido = "경기도",
             sigungu = "성남시",
@@ -89,7 +90,7 @@ class RegionalGuideCandidateUiModelTest {
     }
 
     @Test
-    fun `관리구역명과 대상지역명이 모두 없음이면 배출장소 유형으로 fallback 후보를 구분한다`() {
+    fun `관리구역명과 대상지역명이 모두 없음이면 배출장소 유형으로 대체 후보를 구분한다`() {
         val candidate = candidate(
             sido = "경기도",
             sigungu = "성남시",
@@ -102,7 +103,7 @@ class RegionalGuideCandidateUiModelTest {
     }
 
     @Test
-    fun `배출장소 유형이 없으면 배출장소 설명으로 fallback 후보를 구분한다`() {
+    fun `배출장소 유형이 없으면 배출장소 설명으로 대체 후보를 구분한다`() {
         val candidate = candidate(
             sido = "경상북도",
             sigungu = "성주군",
@@ -115,7 +116,7 @@ class RegionalGuideCandidateUiModelTest {
     }
 
     @Test
-    fun `배출장소 정보가 없으면 첫 배출 일정 요약으로 fallback 후보를 구분한다`() {
+    fun `배출장소 정보가 없으면 첫 배출 일정 요약으로 대체 후보를 구분한다`() {
         val candidate = candidate(
             sido = "대구광역시",
             sigungu = "군위군",
@@ -344,6 +345,63 @@ class RegionalGuideCandidateUiModelTest {
             listOf("대전광역시 / 서구", "대전광역시 / 서구"),
             candidates.map { candidate -> candidate.displayText }
         )
+    }
+
+    @Test
+    fun `안정 키는 표시명이 같은 후보도 식별 가능한 값 조합으로 구분한다`() {
+        val doorToDoorCandidate = candidate(
+            sido = "대전광역시",
+            sigungu = "서구",
+            managementZoneName = "대전광역시",
+            targetRegionName = "서구",
+            disposalPlaceType = "문전수거"
+        )
+        val basePointCandidate = candidate(
+            sido = "대전광역시",
+            sigungu = "서구",
+            managementZoneName = "대전광역시",
+            targetRegionName = "서구",
+            disposalPlaceType = "거점수거"
+        )
+
+        assertEquals(doorToDoorCandidate.displayText, basePointCandidate.displayText)
+        assertNotEquals(doorToDoorCandidate.displayText, doorToDoorCandidate.stableKey)
+        assertNotEquals(doorToDoorCandidate.stableKey, basePointCandidate.stableKey)
+    }
+
+    @Test
+    fun `문전수거와 거점수거 원본 유형은 후보 보조 설명 힌트로 구분한다`() {
+        val doorToDoorCandidate = candidate(
+            managementZoneName = "문전수거 지역",
+            targetRegionName = "문전수거 지역",
+            disposalPlaceType = "문전수거"
+        )
+        val basePointCandidate = candidate(
+            managementZoneName = "거점수거 지역",
+            targetRegionName = "거점수거 지역",
+            disposalPlaceType = "거점수거"
+        )
+
+        assertEquals(
+            RegionalGuideCandidateCollectionTypeHint.DOOR_TO_DOOR,
+            doorToDoorCandidate.collectionTypeHint
+        )
+        assertEquals(
+            RegionalGuideCandidateCollectionTypeHint.BASE_POINT,
+            basePointCandidate.collectionTypeHint
+        )
+    }
+
+    @Test
+    fun `수거 유형 보조 설명 힌트는 배출장소 설명만으로 임의 판정하지 않는다`() {
+        val candidate = candidate(
+            managementZoneName = "문전수거 지역",
+            targetRegionName = "문전수거 지역",
+            disposalPlaceType = null,
+            disposalPlaceDescription = "문전수거 방식으로 배출"
+        )
+
+        assertEquals(null, candidate.collectionTypeHint)
     }
 
     private fun candidate(

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModelTest.kt
@@ -103,6 +103,20 @@ class RegionalGuideCandidateUiModelTest {
     }
 
     @Test
+    fun `관리구역명과 대상지역명이 모두 없음이고 배출장소 유형이 있으면 전체 기준 수거 유형 후보로 본다`() {
+        val candidate = candidate(
+            sido = "강원특별자치도",
+            sigungu = "양구군",
+            managementZoneName = "없음",
+            targetRegionName = "없음",
+            disposalPlaceType = "거점수거"
+        )
+
+        assertEquals(true, candidate.isOverallCollectionTypeCandidate)
+        assertEquals("거점수거", candidate.collectionTypeOptionText)
+    }
+
+    @Test
     fun `배출장소 유형이 없으면 배출장소 설명으로 대체 후보를 구분한다`() {
         val candidate = candidate(
             sido = "경상북도",

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModelTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/regionalguide/model/RegionalGuideCandidateUiModelTest.kt
@@ -117,6 +117,65 @@ class RegionalGuideCandidateUiModelTest {
     }
 
     @Test
+    fun `수거 유형명 후보는 수거 유형 선택 후보로 본다`() {
+        val candidate = candidate(
+            managementZoneName = "거점수거 지역",
+            targetRegionName = "거점수거 지역",
+            disposalPlaceType = "거점수거"
+        )
+
+        assertEquals(true, candidate.isCollectionTypeSelectionCandidate)
+    }
+
+    @Test
+    fun `일반 권역 후보는 배출장소 유형이 있어도 수거 유형 선택 후보로 보지 않는다`() {
+        val candidate = candidate(
+            managementZoneName = "1권역",
+            targetRegionName = "갑천면",
+            disposalPlaceType = "거점수거"
+        )
+
+        assertEquals(false, candidate.isCollectionTypeSelectionCandidate)
+    }
+
+    @Test
+    fun `동일 수거 유형 후보 구분 정보는 배출장소 설명을 우선 사용한다`() {
+        val candidate = candidate(
+            managementZoneName = "없음",
+            targetRegionName = "없음",
+            disposalPlaceType = "거점수거",
+            disposalPlaceDescription = "지정 거점 장소 배출",
+            uncollectedDays = "일요일",
+        )
+
+        assertEquals(
+            RegionalGuideCandidateDistinguishingText(
+                label = RegionalGuideCandidateDistinguishingLabel.DISPOSAL_PLACE,
+                value = "지정 거점 장소 배출"
+            ),
+            candidate.collectionTypeDistinguishingText
+        )
+    }
+
+    @Test
+    fun `배출장소 설명이 없으면 미수거일로 동일 수거 유형 후보를 구분한다`() {
+        val candidate = candidate(
+            managementZoneName = "없음",
+            targetRegionName = "없음",
+            disposalPlaceType = "거점수거",
+            uncollectedDays = "일요일"
+        )
+
+        assertEquals(
+            RegionalGuideCandidateDistinguishingText(
+                label = RegionalGuideCandidateDistinguishingLabel.UNCOLLECTED_DAYS,
+                value = "일요일"
+            ),
+            candidate.collectionTypeDistinguishingText
+        )
+    }
+
+    @Test
     fun `배출장소 유형이 없으면 배출장소 설명으로 대체 후보를 구분한다`() {
         val candidate = candidate(
             sido = "경상북도",
@@ -426,6 +485,8 @@ class RegionalGuideCandidateUiModelTest {
         targetRegionName: String?,
         disposalPlaceType: String? = null,
         disposalPlaceDescription: String? = null,
+        uncollectedDays: String? = null,
+        departmentInfo: String? = null,
         schedules: List<RegionalWasteScheduleUiModel> = emptyList()
     ): RegionalGuideCandidateUiModel =
         RegionalGuideCandidateUiModel(
@@ -436,8 +497,8 @@ class RegionalGuideCandidateUiModelTest {
                 disposalPlaceType = disposalPlaceType,
                 disposalPlaceDescription = disposalPlaceDescription,
                 schedules = schedules,
-                uncollectedDays = null,
-                departmentInfo = null
+                uncollectedDays = uncollectedDays,
+                departmentInfo = departmentInfo
             ),
             sido = sido,
             sigungu = sigungu,


### PR DESCRIPTION
## 작업 내용

지역 가이드 후보 선택 화면에서 수거 유형을 선택해야 하는 상황을 더 명확히 이해할 수 있도록 fallback 후보 안내 UX를 개선했습니다.

직접 매칭되는 읍면동 안내를 찾지 못한 경우에는 선택한 지역과 안내 문구, 수거 유형 후보를 하나의 패널 안에서 보여주도록 정리했습니다.

또한 일반 후보 선택 UI와 수거 유형 선택 UI를 분리해, 여러 권역/읍면 후보나 법정동-행정동 매핑 후보는 기존 리스트형 UI를 유지하도록 했습니다.

## 변경 사항

- 후보 목록 표시 사유를 `RegionalGuideCandidateReason` 기반으로 명시
- ViewModel에서 사용자 노출 안내 문자열 직접 생성 제거
- UI에서 reason 또는 후보 형태에 따라 string resource 선택
- fallback 수거 유형 선택 케이스를 별도 패널 UI로 표시
- fallback 패널 안에 안내 문구, 선택한 지역, 수거 유형 선택 제목, 후보 카드 배치
- `문전수거`, `거점수거` 후보에 원본 배출장소 유형 기반 보조 설명 표시
- `없음/없음 + 문전수거/거점수거`처럼 시군구 전체 기준 수거 유형 후보만 있는 경우 수거 유형 선택 패널로 표시
- 일반 후보 선택 UI는 기존 리스트형 UI 유지
- 후보 UI 모델에 stable key 추가
- 후보 리스트 Compose key를 `displayText`가 아닌 stable key 기반으로 변경
- reason, stable key, 수거 유형 패널 관련 테스트 보강

## 유지한 기존 정책

- `/info` API 호출 방식 유지
- `/info` 원본 응답 데이터 유지
- 정확 매칭 우선 정책 유지
- 직접 매칭 실패 시 첫 번째 후보 자동 선택 금지
- 복수 후보 첫 번째 임의 선택 금지
- 같은 시군구 기준 fallback 후보 목록 표시
- `Region.eupmyeondong` 원본 값 유지
- Favorites key 및 재진입 흐름 유지
- 문전수거/거점수거 유형 임의 판정 금지
- 특정 지역 하드코딩 금지
- #158 selector fallback 정책 유지
- #155 법정동-행정동 매핑 후보 선택 흐름 유지

## 제외한 범위

- fallback 후보 선택 정책 변경
- `/info` API 요청/응답 구조 변경
- 후보 자동 선택 정책 변경
- 문전수거/거점수거 유형 임의 판정
- 행정구역 JSON 수정
- Favorites key 구조 변경
- 화면 전체 UX 리디자인
- unrelated refactoring

## 테스트

- [x] `git diff --check`
- [x] `./gradlew :domain:test`
- [x] `./gradlew :presentation:testDebugUnitTest`
- [x] `./gradlew :presentation:compileDebugKotlin`
- [x] `./gradlew :app:assembleDebug`

## 확인한 케이스

- `강원특별자치도 > 강릉시 > 사천면`
  - 직접 매칭 결과가 없어 수거 유형 선택 패널 표시
  - `거점수거 지역`, `문전수거 지역` 후보 표시
  - 후보 첫 번째 자동 선택 없이 사용자가 직접 선택

- `강원특별자치도 > 양구군`
  - `없음/없음 + 거점수거`, `없음/없음 + 문전수거` 형태의 전체 기준 수거 유형 후보를 수거 유형 선택 패널로 표시

- `횡성군`
  - 여러 권역/읍면 후보는 fallback 패널이 아닌 기존 리스트형 후보 UI 유지

- `괴정`, `다대`, `부곡`
  - 법정동-행정동 매핑 후보 선택 흐름 유지

## 스크린샷

| 직접 매칭 실패 fallback | 전체 기준 수거 유형 후보 |
| --- | --- |
| 사천면 | 양구군 | 
| <img width="720" alt="Image" src="https://github.com/user-attachments/assets/ceae2a49-dc79-4bef-a0bb-1f3bf2087f6c" /> | <img width="720" alt="Image" src="https://github.com/user-attachments/assets/bfab5e25-c819-476a-b14d-b72d948961cd" /> |

## 관련 이슈

- Related #245
- Follow-up of #158
- Related #155