### PR TITLE
[Refactor] 지도 검색 단계별 성능 계측 추가

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/remote/datasource/SpotRemoteDataSource.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/remote/datasource/SpotRemoteDataSource.kt
@@ -3,12 +3,14 @@ package com.team.yeogibeoryeo.data.spot.remote.datasource
 import com.team.yeogibeoryeo.data.spot.remote.SpotApiService
 import com.team.yeogibeoryeo.data.spot.remote.dto.SpotItemDto
 import com.team.yeogibeoryeo.data.spot.remote.dto.SpotResponseDto
+import com.team.yeogibeoryeo.domain.spot.log.MapSearchTimingLogger
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.JsonPrimitive
 
 class SpotRemoteDataSource @Inject constructor(
     private val apiService: SpotApiService,
+    private val mapSearchTimingLogger: MapSearchTimingLogger = MapSearchTimingLogger.NoOp,
 ) {
     suspend fun searchByKeyword(
         serviceKey: String,
@@ -30,6 +32,7 @@ class SpotRemoteDataSource @Inject constructor(
         pageNo: Int = 1,
         numOfRows: Int = 100,
     ): SpotKeywordSearchResult {
+        val searchStartedAtNanos = System.nanoTime()
         val firstPage = fetchKeywordPage(
             serviceKey = serviceKey,
             keyword = keyword,
@@ -48,6 +51,13 @@ class SpotRemoteDataSource @Inject constructor(
         val lastPage = totalPages
         val mergedItems = firstPage.items.toMutableList()
         var isPartial = false
+        var fetchedPageCount = 1
+
+        mapSearchTimingLogger.log(
+            "getSpot addr first page finished page=$currentPageNo " +
+                "count=${firstPage.items.size} totalCount=${totalCount ?: UNKNOWN_TOTAL_COUNT} " +
+                "elapsedMs=${searchStartedAtNanos.elapsedMs()}",
+        )
 
         for (nextPageNo in (currentPageNo + 1)..lastPage) {
             val nextPage = try {
@@ -65,16 +75,30 @@ class SpotRemoteDataSource @Inject constructor(
             }
 
             mergedItems += nextPage.items
+            fetchedPageCount += 1
         }
 
+        mapSearchTimingLogger.log(
+            "getSpot addr all pages finished pages=$fetchedPageCount " +
+                "rawCount=${mergedItems.size} elapsedMs=${searchStartedAtNanos.elapsedMs()} " +
+                "partial=$isPartial",
+        )
+
+        val mergeStartedAtNanos = System.nanoTime()
+        val dedupedItems = mergedItems.distinctBy { item ->
+            listOf(
+                item.spotNm.orEmpty().trim(),
+                item.addrBase.orEmpty().trim(),
+                item.addrDtl.orEmpty().trim(),
+            )
+        }
+        mapSearchTimingLogger.log(
+            "merge/dedup finished before=${mergedItems.size} after=${dedupedItems.size} " +
+                "elapsedMs=${mergeStartedAtNanos.elapsedMs()}",
+        )
+
         return SpotKeywordSearchResult(
-            items = mergedItems.distinctBy { item ->
-                listOf(
-                    item.spotNm.orEmpty().trim(),
-                    item.addrBase.orEmpty().trim(),
-                    item.addrDtl.orEmpty().trim(),
-                )
-            },
+            items = dedupedItems,
             isPartial = isPartial,
         )
     }
@@ -150,8 +174,14 @@ class SpotRemoteDataSource @Inject constructor(
 
     private companion object {
         const val RESULT_CODE_NO_DATA = "03"
+        const val UNKNOWN_TOTAL_COUNT = "unknown"
     }
 }
+
+private fun Long.elapsedMs(): Long =
+    (System.nanoTime() - this) / NANOS_PER_MILLISECOND
+
+private const val NANOS_PER_MILLISECOND = 1_000_000L
 
 data class SpotKeywordSearchResult(
     val items: List<SpotItemDto>,

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
@@ -8,12 +8,12 @@ import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotSearchResult
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.log.MapSearchTimingLogger
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.supervisorScope
@@ -23,6 +23,7 @@ class CollectionSpotRepositoryImpl @Inject constructor(
     private val spotMapper: SpotMapper,
     private val spotGeocoder: SpotGeocoder,
     private val publicDataKeyProvider: AppKeyProvider,
+    private val mapSearchTimingLogger: MapSearchTimingLogger = MapSearchTimingLogger.NoOp,
 ) : CollectionSpotRepository {
 
     override suspend fun searchByKeyword(
@@ -39,14 +40,27 @@ class CollectionSpotRepositoryImpl @Inject constructor(
         keyword: String,
         types: Set<CollectionSpotType>,
     ): CollectionSpotSearchResult {
+        val repositorySearchStartedAtNanos = System.nanoTime()
         val result = remoteDataSource.searchByKeywordResult(
             serviceKey = publicDataKeyProvider.publicDataServiceKey,
             keyword = keyword,
         )
 
-        val spots = spotMapper.mapToDomainList(result.items)
-            .filterByTypes(types)
+        val mappedSpots = spotMapper.mapToDomainList(result.items)
+        val typeFilterStartedAtNanos = System.nanoTime()
+        val typeFilteredSpots = mappedSpots.filterByTypes(types)
+        mapSearchTimingLogger.log(
+            "type filter finished before=${mappedSpots.size} after=${typeFilteredSpots.size} " +
+                "elapsedMs=${typeFilterStartedAtNanos.elapsedMs()}",
+        )
+
+        val spots = typeFilteredSpots
             .geocodeAll()
+
+        mapSearchTimingLogger.log(
+            "repository search finished finalCount=${spots.size} " +
+                "elapsedMs=${repositorySearchStartedAtNanos.elapsedMs()}",
+        )
 
         return CollectionSpotSearchResult(
             spots = spots,
@@ -59,18 +73,36 @@ class CollectionSpotRepositoryImpl @Inject constructor(
         radiusMeter: Int,
         types: Set<CollectionSpotType>,
     ): List<CollectionSpot> {
+        val repositorySearchStartedAtNanos = System.nanoTime()
+        val remoteSearchStartedAtNanos = System.nanoTime()
         val spots = remoteDataSource.searchByLocation(
             serviceKey = publicDataKeyProvider.publicDataServiceKey,
             latitude = coordinate.latitude,
             longitude = coordinate.longitude,
             radiusMeter = radiusMeter,
         ).let { dtoList ->
+            mapSearchTimingLogger.log(
+                "getSpot location finished count=${dtoList.size} " +
+                    "elapsedMs=${remoteSearchStartedAtNanos.elapsedMs()}",
+            )
             spotMapper.mapToDomainList(dtoList)
         }
 
-        return spots
-            .filterByTypes(types)
+        val typeFilterStartedAtNanos = System.nanoTime()
+        val typeFilteredSpots = spots.filterByTypes(types)
+        mapSearchTimingLogger.log(
+            "type filter finished before=${spots.size} after=${typeFilteredSpots.size} " +
+                "elapsedMs=${typeFilterStartedAtNanos.elapsedMs()}",
+        )
+
+        return typeFilteredSpots
             .geocodeAll()
+            .also { geocodedSpots ->
+                mapSearchTimingLogger.log(
+                    "repository search finished finalCount=${geocodedSpots.size} " +
+                        "elapsedMs=${repositorySearchStartedAtNanos.elapsedMs()}",
+                )
+            }
     }
 
     override suspend fun geocodeSpot(
@@ -99,12 +131,18 @@ class CollectionSpotRepositoryImpl @Inject constructor(
         if (isEmpty()) return this
 
         return supervisorScope {
+            val addressKeys = mapNotNull { spot -> spot.address.toGeocodeKey() }
+                .distinct()
             val geocodeJobsByAddress = LinkedHashMap<String, Deferred<Coordinate?>>()
-            val geocodeSemaphore = Semaphore(MAX_CONCURRENT_GEOCODING_COUNT)
+            val geocodeSemaphore = Semaphore(GEOCODING_CONCURRENCY_LIMIT)
+            val geocodingStartedAtNanos = System.nanoTime()
 
-            forEach { spot ->
-                val addressKey = spot.address.toGeocodeKey() ?: return@forEach
+            mapSearchTimingLogger.log(
+                "geocoding started targetCount=${addressKeys.size} " +
+                    "concurrency=$GEOCODING_CONCURRENCY_LIMIT",
+            )
 
+            addressKeys.forEach { addressKey ->
                 geocodeJobsByAddress.getOrPut(addressKey) {
                     async {
                         geocodeSafely(
@@ -115,12 +153,20 @@ class CollectionSpotRepositoryImpl @Inject constructor(
                 }
             }
 
-            geocodeJobsByAddress.values.awaitAll()
+            val coordinatesByAddress = geocodeJobsByAddress
+                .mapValues { (_, geocodeJob) -> geocodeJob.await() }
+            val geocodeSuccessCount = coordinatesByAddress.values.count { coordinate -> coordinate != null }
+
+            mapSearchTimingLogger.log(
+                "geocoding finished success=$geocodeSuccessCount " +
+                    "null=${coordinatesByAddress.size - geocodeSuccessCount} " +
+                    "elapsedMs=${geocodingStartedAtNanos.elapsedMs()}",
+            )
 
             map { spot ->
                 val addressKey = spot.address.toGeocodeKey()
                     ?: return@map spot
-                val coordinate = geocodeJobsByAddress[addressKey]?.await()
+                val coordinate = coordinatesByAddress[addressKey]
 
                 spot.copy(
                     coordinate = coordinate,
@@ -152,8 +198,13 @@ class CollectionSpotRepositoryImpl @Inject constructor(
     }
 
     private companion object {
-        const val MAX_CONCURRENT_GEOCODING_COUNT = 3
+        const val GEOCODING_CONCURRENCY_LIMIT = 3
         val PARENTHESIZED_TEXT_REGEX = "\\([^)]*\\)".toRegex()
         val WHITESPACE_REGEX = "\\s+".toRegex()
     }
 }
+
+private fun Long.elapsedMs(): Long =
+    (System.nanoTime() - this) / NANOS_PER_MILLISECOND
+
+private const val NANOS_PER_MILLISECOND = 1_000_000L

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/log/MapSearchTimingLogger.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/log/MapSearchTimingLogger.kt
@@ -1,0 +1,11 @@
+package com.team.yeogibeoryeo.domain.spot.log
+
+interface MapSearchTimingLogger {
+    fun log(message: String)
+
+    companion object {
+        val NoOp: MapSearchTimingLogger = object : MapSearchTimingLogger {
+            override fun log(message: String) = Unit
+        }
+    }
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
@@ -5,12 +5,14 @@ import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotAddressSearchPolicy
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotSearchResult
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
+import com.team.yeogibeoryeo.domain.spot.log.MapSearchTimingLogger
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import javax.inject.Inject
 
 class SearchCollectionSpotsByKeywordUseCase @Inject constructor(
     private val repository: CollectionSpotRepository,
     private val normalizeKeywordUseCase: NormalizeCollectionSpotSearchKeywordUseCase,
+    private val mapSearchTimingLogger: MapSearchTimingLogger = MapSearchTimingLogger.NoOp,
 ) {
     suspend operator fun invoke(
         keyword: String,
@@ -34,11 +36,22 @@ class SearchCollectionSpotsByKeywordUseCase @Inject constructor(
             keyword = normalizedKeyword,
             types = types,
         )
+        val explicitRegionFilteredSpots = result.spots
+            .filterByExplicitRegionKeyword(normalizedKeyword)
+        val selectedRegionFilterStartedAtNanos = System.nanoTime()
+        val selectedRegionFilteredSpots = explicitRegionFilteredSpots
+            .filterBySelectedRegionCandidate(selectedRegionCandidate)
+
+        if (selectedRegionCandidate != null) {
+            mapSearchTimingLogger.log(
+                "selected region filter finished before=${explicitRegionFilteredSpots.size} " +
+                    "after=${selectedRegionFilteredSpots.size} " +
+                    "elapsedMs=${selectedRegionFilterStartedAtNanos.elapsedMs()}",
+            )
+        }
 
         return CollectionSpotSearchResult(
-            spots = result.spots
-                .filterByExplicitRegionKeyword(normalizedKeyword)
-                .filterBySelectedRegionCandidate(selectedRegionCandidate),
+            spots = selectedRegionFilteredSpots,
             isPartial = result.isPartial,
         )
     }
@@ -101,3 +114,8 @@ class SearchCollectionSpotsByKeywordUseCase @Inject constructor(
         const val REGION_SCOPE_SEPARATOR = " "
     }
 }
+
+private fun Long.elapsedMs(): Long =
+    (System.nanoTime() - this) / NANOS_PER_MILLISECOND
+
+private const val NANOS_PER_MILLISECOND = 1_000_000L

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -28,6 +28,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModel.kt
@@ -12,6 +12,7 @@ import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
 import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidateResult
+import com.team.yeogibeoryeo.domain.spot.log.MapSearchTimingLogger
 import com.team.yeogibeoryeo.domain.spot.usecase.CalculateDistanceMeterUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.ClearRecentCurrentLocationSpotsUseCase
 import com.team.yeogibeoryeo.domain.spot.usecase.FilterCollectionSpotsUseCase
@@ -49,6 +50,7 @@ class CollectionSpotMapViewModel @Inject constructor(
     private val observeFavoritesUseCase: ObserveFavoritesUseCase,
     private val toggleCollectionSpotFavoriteUseCase: ToggleCollectionSpotFavoriteUseCase,
     private val calculateDistanceMeterUseCase: CalculateDistanceMeterUseCase,
+    private val mapSearchTimingLogger: MapSearchTimingLogger = MapSearchTimingLogger.NoOp,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CollectionSpotMapUiState())
@@ -151,6 +153,10 @@ class CollectionSpotMapViewModel @Inject constructor(
         spotSearchJob = viewModelScope.launch {
             when (val candidateResult = resolveMapRegionSearchCandidateUseCase(keyword)) {
                 is MapRegionSearchCandidateResult.NeedSelection -> {
+                    mapSearchTimingLogger.log(
+                        "keyword search candidate selection required query=$keyword " +
+                            "candidateCount=${candidateResult.candidates.size}",
+                    )
                     showRegionSearchCandidates(candidateResult.candidates)
                 }
 
@@ -179,6 +185,11 @@ class CollectionSpotMapViewModel @Inject constructor(
         keyword: String,
         selectedRegionCandidate: MapRegionSearchCandidate?,
     ) {
+        val searchStartedAtNanos = System.nanoTime()
+        mapSearchTimingLogger.log(
+            "keyword search started query=$keyword " +
+                "selectedRegion=${selectedRegionCandidate?.displayName ?: NO_SELECTED_REGION}",
+        )
         startKeywordSearchLoading()
 
         runCatching {
@@ -187,7 +198,10 @@ class CollectionSpotMapViewModel @Inject constructor(
                 selectedRegionCandidate = selectedRegionCandidate,
             )
         }.onSuccess { result ->
-            updateSpotResult(result)
+            updateSpotResult(
+                result = result,
+                searchStartedAtNanos = searchStartedAtNanos,
+            )
         }.onFailure { throwable ->
             if (throwable is CancellationException) throw throwable
 
@@ -228,11 +242,20 @@ class CollectionSpotMapViewModel @Inject constructor(
                 selectedRegionCandidate = selectedRegionCandidate,
             )
         }
+        val mergeStartedAtNanos = System.nanoTime()
+        val mergedSpots = results.flatMap { result -> result.spots }
+        val dedupedSpots = mergedSpots.distinctBy { spot -> spot.id }
+
+        if (searchKeywords.size > 1) {
+            mapSearchTimingLogger.log(
+                "candidate keyword merge/dedup finished keywords=${searchKeywords.size} " +
+                    "before=${mergedSpots.size} after=${dedupedSpots.size} " +
+                    "elapsedMs=${mergeStartedAtNanos.elapsedMs()}",
+            )
+        }
 
         return CollectionSpotSearchResult(
-            spots = results
-                .flatMap { result -> result.spots }
-                .distinctBy { spot -> spot.id },
+            spots = dedupedSpots,
             isPartial = results.any { result -> result.isPartial },
         )
     }
@@ -284,6 +307,11 @@ class CollectionSpotMapViewModel @Inject constructor(
         currentLocationRefreshJob?.cancel()
         spotSearchJob?.cancel()
         spotSearchJob = viewModelScope.launch {
+            val searchStartedAtNanos = System.nanoTime()
+            mapSearchTimingLogger.log(
+                "map center search started latitude=${coordinate.latitude} " +
+                    "longitude=${coordinate.longitude}",
+            )
             _uiState.update {
                 it.copy(
                     isLoading = true,
@@ -305,7 +333,10 @@ class CollectionSpotMapViewModel @Inject constructor(
                     types = emptySet(),
                 )
             }.onSuccess { spots ->
-                updateSpotResult(CollectionSpotSearchResult(spots = spots))
+                updateSpotResult(
+                    result = CollectionSpotSearchResult(spots = spots),
+                    searchStartedAtNanos = searchStartedAtNanos,
+                )
             }.onFailure { throwable ->
                 if (throwable is CancellationException) throw throwable
 
@@ -320,6 +351,11 @@ class CollectionSpotMapViewModel @Inject constructor(
         coordinate: Coordinate,
         preservePreviousResultOnFailure: Boolean,
     ) {
+        val searchStartedAtNanos = System.nanoTime()
+        mapSearchTimingLogger.log(
+            "current location search started latitude=${coordinate.latitude} " +
+                "longitude=${coordinate.longitude}",
+        )
         try {
             val spots = searchCollectionSpotsByLocationUseCase(
                 coordinate = coordinate,
@@ -331,7 +367,10 @@ class CollectionSpotMapViewModel @Inject constructor(
 
             val spotsWithDistance = spots.withDistanceFrom(coordinate)
 
-            updateSpotResult(CollectionSpotSearchResult(spots = spotsWithDistance))
+            updateSpotResult(
+                result = CollectionSpotSearchResult(spots = spotsWithDistance),
+                searchStartedAtNanos = searchStartedAtNanos,
+            )
             saveRecentCurrentLocationSpotsUseCase(spotsWithDistance)
         } catch (throwable: Throwable) {
             if (throwable is CancellationException) throw throwable
@@ -562,7 +601,10 @@ class CollectionSpotMapViewModel @Inject constructor(
         }
     }
 
-    private fun updateSpotResult(result: CollectionSpotSearchResult) {
+    private fun updateSpotResult(
+        result: CollectionSpotSearchResult,
+        searchStartedAtNanos: Long? = null,
+    ) {
         originalSpots = result.spots.withFavoriteState()
 
         val filteredSpots = filterCollectionSpotsUseCase(
@@ -570,6 +612,13 @@ class CollectionSpotMapViewModel @Inject constructor(
             selectedTypes = uiState.value.selectedTypes,
         )
 
+        if (searchStartedAtNanos != null) {
+            mapSearchTimingLogger.log(
+                "viewModel search success resultCount=${filteredSpots.size} " +
+                    "elapsedMs=${searchStartedAtNanos.elapsedMs()}",
+            )
+        }
+        val stateUpdateStartedAtNanos = System.nanoTime()
         _uiState.update {
             it.copy(
                 spots = filteredSpots,
@@ -587,6 +636,10 @@ class CollectionSpotMapViewModel @Inject constructor(
                 isFavoriteSpotNearbyLoading = false,
             )
         }
+        mapSearchTimingLogger.log(
+            "ui state updated mode=ResultList resultCount=${filteredSpots.size} " +
+                "elapsedMs=${stateUpdateStartedAtNanos.elapsedMs()}",
+        )
     }
 
     private fun searchNearbySpotsForFavoriteSpot(request: FavoriteSpotMapMoveRequest) {
@@ -813,5 +866,11 @@ class CollectionSpotMapViewModel @Inject constructor(
 
     private companion object {
         const val DEFAULT_RADIUS_METER = 500
+        const val NO_SELECTED_REGION = "none"
     }
 }
+
+private fun Long.elapsedMs(): Long =
+    (System.nanoTime() - this) / NANOS_PER_MILLISECOND
+
+private const val NANOS_PER_MILLISECOND = 1_000_000L

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/log/LogcatMapSearchTimingLogger.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/map/log/LogcatMapSearchTimingLogger.kt
@@ -1,0 +1,29 @@
+package com.team.yeogibeoryeo.presentation.map.log
+
+import android.util.Log
+import com.team.yeogibeoryeo.domain.spot.log.MapSearchTimingLogger
+import com.team.yeogibeoryeo.presentation.BuildConfig
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+object LogcatMapSearchTimingLogger : MapSearchTimingLogger {
+    override fun log(message: String) {
+        if (BuildConfig.DEBUG) {
+            Log.d(MAP_SEARCH_TIMING_TAG, message)
+        }
+    }
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object MapSearchTimingLoggerModule {
+    @Provides
+    @Singleton
+    fun provideMapSearchTimingLogger(): MapSearchTimingLogger =
+        LogcatMapSearchTimingLogger
+}
+
+private const val MAP_SEARCH_TIMING_TAG = "MapSearchTiming"


### PR DESCRIPTION
Refs #257

## 작업 내용

- `MapSearchTiming` Logcat 계측 추가
- `/getSpot addr` 첫 페이지 / 전체 페이지 조회 시간 측정
- merge/dedup, selected region filter, geocoding 시간 측정
- repository search / ViewModel search success / ui state update 시간 측정
- geocoding 동시 처리 값을 `GEOCODING_CONCURRENCY_LIMIT = 3` 상수로 분리
- debug build에서만 측정 로그 출력

## 실기기 측정 결과 요약

상세 측정 결과는 #257 코멘트에 기록했습니다.

- 삼성동 후보 선택: 최종 80개, geocoding target 204개, 전체 약 15.5초
- 문래동 후보 선택: 최종 50개, candidate keyword 7개, 전체 약 16.3초
- 명동 후보 선택: 최종 8개, geocoding target 966개, 전체 약 84.8초
- 현 지도 검색: 약 3~5초

## 1차 결론

- 병목은 ViewModel state update나 merge/dedup이 아니라 `/getSpot addr` 반복 조회와 geocoding에 집중됨
- 후보 선택 검색에서는 region filter가 geocoding 이후에 적용되어 불필요한 geocoding 비용이 발생함
- 후속 #263에서 region filter 선적용으로 geocoding 대상 축소를 검토

## 확인한 점

- `GEOCODING_CONCURRENCY_LIMIT` 기본값은 3으로 유지
- 이번 PR에서는 성능 튜닝 값을 변경하지 않고 측정 기반만 추가
- 기존 검색 정책, 후보 선택 정책, 현재 위치/현 지도 검색 UX는 유지

## 후속 작업

- #263 에서 keyword 후보 검색의 region filter 선적용으로 geocoding 대상 축소 검토

## 테스트

- [x] `./gradlew.bat :data:testDebugUnitTest`
- [x] `./gradlew.bat :presentation:testDebugUnitTest`
- [x] `./gradlew.bat :presentation:compileDebugKotlin`
- [x] `./gradlew.bat :app:assembleDebug`
- [x] `git diff --check`


이번 PR은 성능 튜닝 적용이 아니라 측정 기반 추가만 포함합니다.
본격적인 검색 파이프라인 개선은 #263에서 별도 진행합니다.