### PR TITLE
[Refactor] keyword 후보 검색 region filter 선적용

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
@@ -41,6 +41,28 @@ class CollectionSpotRepositoryImpl @Inject constructor(
         types: Set<CollectionSpotType>,
     ): CollectionSpotSearchResult {
         val repositorySearchStartedAtNanos = System.nanoTime()
+        val result = searchByKeywordResultWithoutCoordinates(
+            keyword = keyword,
+            types = types,
+        )
+        val spots = geocodeSpots(result.spots)
+
+        mapSearchTimingLogger.log(
+            "repository search finished finalCount=${spots.size} " +
+                "elapsedMs=${repositorySearchStartedAtNanos.elapsedMs()}",
+        )
+
+        return CollectionSpotSearchResult(
+            spots = spots,
+            isPartial = result.isPartial,
+        )
+    }
+
+    override suspend fun searchByKeywordResultWithoutCoordinates(
+        keyword: String,
+        types: Set<CollectionSpotType>,
+    ): CollectionSpotSearchResult {
+        val repositorySearchStartedAtNanos = System.nanoTime()
         val result = remoteDataSource.searchByKeywordResult(
             serviceKey = publicDataKeyProvider.publicDataServiceKey,
             keyword = keyword,
@@ -54,16 +76,13 @@ class CollectionSpotRepositoryImpl @Inject constructor(
                 "elapsedMs=${typeFilterStartedAtNanos.elapsedMs()}",
         )
 
-        val spots = typeFilteredSpots
-            .geocodeAll()
-
         mapSearchTimingLogger.log(
-            "repository search finished finalCount=${spots.size} " +
+            "repository raw search finished rawCount=${typeFilteredSpots.size} " +
                 "elapsedMs=${repositorySearchStartedAtNanos.elapsedMs()}",
         )
 
         return CollectionSpotSearchResult(
-            spots = spots,
+            spots = typeFilteredSpots,
             isPartial = result.isPartial,
         )
     }
@@ -116,6 +135,10 @@ class CollectionSpotRepositoryImpl @Inject constructor(
             coordinate = coordinate,
         )
     }
+
+    override suspend fun geocodeSpots(
+        spots: List<CollectionSpot>,
+    ): List<CollectionSpot> = spots.geocodeAll()
 
     private fun List<CollectionSpot>.filterByTypes(
         types: Set<CollectionSpotType>,

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImplTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImplTest.kt
@@ -67,6 +67,28 @@ class CollectionSpotRepositoryImplTest {
     }
 
     @Test
+    fun `좌표 없는 검색어 기반 조회는 geocoding하지 않고 결과를 반환한다`() = runBlocking {
+        val apiService = FakeSpotApiService(
+            response = createNormalResponse(),
+        )
+        val spotGeocoder = FakeSpotGeocoder()
+        val repository = createRepository(
+            apiService = apiService,
+            spotGeocoder = spotGeocoder,
+        )
+
+        val result = repository.searchByKeywordResultWithoutCoordinates(
+            keyword = "문래동",
+        )
+
+        assertEquals(TEST_SERVICE_KEY, apiService.requestedServiceKey)
+        assertEquals("문래동", apiService.requestedAddr)
+        assertEquals(2, result.spots.size)
+        assertEquals(emptyList<String>(), spotGeocoder.requestedAddresses)
+        assertNull(result.spots.first().coordinate)
+    }
+
+    @Test
     fun `검색어 기반 조회 시 여러 페이지 결과를 변환하고 반환한다`() = runBlocking {
         val apiService = FakeSpotApiService(
             response = createResponse(

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/CollectionSpotRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/CollectionSpotRepository.kt
@@ -27,12 +27,7 @@ interface CollectionSpotRepository {
     suspend fun searchByKeywordResultWithoutCoordinates(
         keyword: String,
         types: Set<CollectionSpotType> = emptySet()
-    ): CollectionSpotSearchResult {
-        return searchByKeywordResult(
-            keyword = keyword,
-            types = types,
-        )
-    }
+    ): CollectionSpotSearchResult
 
     suspend fun searchByLocation(
         coordinate: Coordinate,

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/CollectionSpotRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/CollectionSpotRepository.kt
@@ -24,11 +24,27 @@ interface CollectionSpotRepository {
         )
     }
 
+    suspend fun searchByKeywordResultWithoutCoordinates(
+        keyword: String,
+        types: Set<CollectionSpotType> = emptySet()
+    ): CollectionSpotSearchResult {
+        return searchByKeywordResult(
+            keyword = keyword,
+            types = types,
+        )
+    }
+
     suspend fun searchByLocation(
         coordinate: Coordinate,
         radiusMeter: Int,
         types: Set<CollectionSpotType> = emptySet()
     ): List<CollectionSpot>
+
+    suspend fun geocodeSpots(
+        spots: List<CollectionSpot>
+    ): List<CollectionSpot> {
+        return spots.map { spot -> geocodeSpot(spot) }
+    }
 
     suspend fun geocodeSpot(
         spot: CollectionSpot

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
@@ -32,12 +32,21 @@ class SearchCollectionSpotsByKeywordUseCase @Inject constructor(
         selectedRegionCandidate: MapRegionSearchCandidate? = null,
     ): CollectionSpotSearchResult {
         val normalizedKeyword = normalizeKeywordUseCase(keyword)
-        val result = repository.searchByKeywordResult(
+        val result = repository.searchByKeywordResultWithoutCoordinates(
             keyword = normalizedKeyword,
             types = types,
         )
+        val explicitRegionFilterStartedAtNanos = System.nanoTime()
         val explicitRegionFilteredSpots = result.spots
             .filterByExplicitRegionKeyword(normalizedKeyword)
+        if (CollectionSpotAddressSearchPolicy.isEupMyeonDongCandidate(normalizedKeyword)) {
+            mapSearchTimingLogger.log(
+                "explicit region filter finished before=${result.spots.size} " +
+                    "after=${explicitRegionFilteredSpots.size} " +
+                    "elapsedMs=${explicitRegionFilterStartedAtNanos.elapsedMs()}",
+            )
+        }
+
         val selectedRegionFilterStartedAtNanos = System.nanoTime()
         val selectedRegionFilteredSpots = explicitRegionFilteredSpots
             .filterBySelectedRegionCandidate(selectedRegionCandidate)
@@ -49,9 +58,10 @@ class SearchCollectionSpotsByKeywordUseCase @Inject constructor(
                     "elapsedMs=${selectedRegionFilterStartedAtNanos.elapsedMs()}",
             )
         }
+        val geocodedSpots = repository.geocodeSpots(selectedRegionFilteredSpots)
 
         return CollectionSpotSearchResult(
-            spots = selectedRegionFilteredSpots,
+            spots = geocodedSpots,
             isPartial = result.isPartial,
         )
     }

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCaseTest.kt
@@ -38,6 +38,28 @@ class SearchCollectionSpotsByKeywordUseCaseTest {
         }
 
     @Test
+    fun `명시 지역 필터에서 제외되는 결과는 geocoding하지 않는다`() =
+        runSuspendTest {
+            val myeongDongSpot = collectionSpot(
+                id = "myeongdong",
+                address = "서울특별시 중구 명동길 26 (명동)",
+                coordinate = null,
+            )
+            val bongMyeongDongSpot = collectionSpot(
+                id = "bongmyeongdong",
+                address = "충청북도 청주시 흥덕구 송절로124번길 65 (봉명동)",
+                coordinate = null,
+            )
+            repository.keywordSpots = listOf(myeongDongSpot, bongMyeongDongSpot)
+
+            val result = useCase(keyword = "명동")
+
+            assertEquals(listOf("myeongdong"), repository.geocodedSpotIds)
+            assertEquals(listOf("myeongdong"), result.map { spot -> spot.id })
+            assertEquals(DEFAULT_COORDINATE, result.first().coordinate)
+        }
+
+    @Test
     fun `명동 검색에서 번지에 붙은 괄호 속 봉명동 결과는 제외한다`() =
         runSuspendTest {
             val spot = collectionSpot(

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.team.yeogibeoryeo.domain.spot.usecase
 
 import com.team.yeogibeoryeo.domain.region.model.Region
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotSearchResult
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
@@ -136,6 +137,38 @@ class SearchCollectionSpotsByKeywordUseCaseTest {
         }
 
     @Test
+    fun `선택 지역 필터에서 제외되는 결과는 geocoding하지 않는다`() =
+        runSuspendTest {
+            val seoulSpot = collectionSpot(
+                id = "seoul-myeongdong",
+                address = "서울특별시 중구 명동길 3",
+                coordinate = null,
+            )
+            val jecheonSpot = collectionSpot(
+                id = "jecheon-myeongdong",
+                address = "충청북도 제천시 명동 1",
+                coordinate = null,
+            )
+            repository.keywordSpots = listOf(seoulSpot, jecheonSpot)
+
+            val result = useCase(
+                keyword = "명동",
+                selectedRegionCandidate = MapRegionSearchCandidate(
+                    region = Region(
+                        sido = "서울특별시",
+                        sigungu = "중구",
+                        eupmyeondong = "명동",
+                    ),
+                    searchKeyword = "명동",
+                ),
+            )
+
+            assertEquals(listOf("seoul-myeongdong"), repository.geocodedSpotIds)
+            assertEquals(listOf("seoul-myeongdong"), result.map { spot -> spot.id })
+            assertEquals(DEFAULT_COORDINATE, result.first().coordinate)
+        }
+
+    @Test
     fun `선택 지역 후보가 있어도 지역 범위가 불명확한 도로명 주소 결과는 유지한다`() =
         runSuspendTest {
             val roadAddressSpot = collectionSpot(
@@ -168,6 +201,7 @@ class SearchCollectionSpotsByKeywordUseCaseTest {
     private fun collectionSpot(
         id: String,
         address: String,
+        coordinate: Coordinate? = Coordinate(latitude = 37.5666102, longitude = 126.9783881),
     ): CollectionSpot {
         return CollectionSpot(
             id = id,
@@ -175,13 +209,14 @@ class SearchCollectionSpotsByKeywordUseCaseTest {
             type = CollectionSpotType.STANDARD_BAG_STORE,
             address = address,
             detailLocation = null,
-            coordinate = Coordinate(latitude = 37.5666102, longitude = 126.9783881),
+            coordinate = coordinate,
         )
     }
 
     private class FakeCollectionSpotRepository : CollectionSpotRepository {
         var keywordSpots: List<CollectionSpot> = emptyList()
         val keywords = mutableListOf<String>()
+        val geocodedSpotIds = mutableListOf<String>()
 
         override suspend fun searchByKeyword(
             keyword: String,
@@ -191,12 +226,31 @@ class SearchCollectionSpotsByKeywordUseCaseTest {
             return keywordSpots
         }
 
+        override suspend fun searchByKeywordResultWithoutCoordinates(
+            keyword: String,
+            types: Set<CollectionSpotType>,
+        ) = CollectionSpotSearchResult(
+            spots = searchByKeyword(
+                keyword = keyword,
+                types = types,
+            ),
+        )
+
         override suspend fun searchByLocation(
             coordinate: Coordinate,
             radiusMeter: Int,
             types: Set<CollectionSpotType>,
         ): List<CollectionSpot> = emptyList()
 
-        override suspend fun geocodeSpot(spot: CollectionSpot): CollectionSpot = spot
+        override suspend fun geocodeSpot(spot: CollectionSpot): CollectionSpot {
+            geocodedSpotIds += spot.id
+            return spot.copy(
+                coordinate = spot.coordinate ?: DEFAULT_COORDINATE,
+            )
+        }
+    }
+
+    private companion object {
+        val DEFAULT_COORDINATE = Coordinate(latitude = 37.5666102, longitude = 126.9783881)
     }
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTestFixture.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTestFixture.kt
@@ -253,6 +253,19 @@ internal class FakeCollectionSpotRepository(
         )
     }
 
+    override suspend fun searchByKeywordResultWithoutCoordinates(
+        keyword: String,
+        types: Set<CollectionSpotType>,
+    ): CollectionSpotSearchResult {
+        return CollectionSpotSearchResult(
+            spots = searchByKeyword(
+                keyword = keyword,
+                types = types,
+            ),
+            isPartial = isKeywordSearchPartial,
+        )
+    }
+
     override suspend fun searchByLocation(
         coordinate: Coordinate,
         radiusMeter: Int,


### PR DESCRIPTION
## 작업 내용

- keyword raw search 경로 추가
- `SearchCollectionSpotsByKeywordUseCase`에서 explicit/selected region filter를 geocoding 이전에 적용
- 필터 통과 spot만 geocode하도록 변경
- 기존 keyword 검색 결과 정책 유지
- location/current map 검색 경로는 변경하지 않음
- `GEOCODING_CONCURRENCY_LIMIT = 3` 유지

## 실기기 before-after 측정

### 명동

- 후보 선택: `서울특별시 중구 명동`
- 최종 결과: 8개 유지
- geocoding targetCount: 약 974 -> 16
- geocoding time: 약 41.8초 -> 약 0.78초
- ViewModel 전체: 약 84.8초 -> 약 24.5초

남은 병목:

- `/getSpot addr` 15페이지 순차 조회 약 22.2초

### 삼성동

- 후보 선택: `대전광역시 동구 삼성동`
- 최종 결과: 80개 유지
- geocoding targetCount: 204 -> 57
- geocoding time: 약 8.7초 -> 약 2.4초

### 문래동

- 후보 선택: `서울특별시 영등포구 문래동`
- 최종 결과: 50개 유지
- candidate keyword 7개 흐름 유지
- region filter로 크게 줄어드는 케이스는 아니며, 남은 병목은 candidate keyword 순차 조회 쪽으로 확인

## 확인한 점

- `GEOCODING_CONCURRENCY_LIMIT = 3` 유지
- `/getSpot addr` pagination 정책 변경 없음
- candidate `searchKeywords` 병렬화 없음
- 현재 위치 검색 / 현 지도 검색 경로 변경 없음
- 마커 UI / BottomSheet UX 변경 없음

## 테스트

- [x] `./gradlew.bat :domain:test`
- [x] `./gradlew.bat :data:testDebugUnitTest`
- [x] `./gradlew.bat :presentation:testDebugUnitTest`
- [x] `./gradlew.bat :presentation:compileDebugKotlin`
- [x] `./gradlew.bat :app:assembleDebug`
- [x] `git diff --check`

## 후속 작업

- #265 에서 keyword/location raw search 및 geocoding 파이프라인 책임 정리
- candidate `searchKeywords` 병렬화와 geocoding concurrency 비교는 별도 실험 이슈로 분리

Refs #257
Refs #263