### PR TITLE
[Refactor] 지도 검색 조회와 geocoding 책임 분리

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/di/SpotDataModule.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/di/SpotDataModule.kt
@@ -2,7 +2,9 @@ package com.team.yeogibeoryeo.data.spot.di
 
 import com.team.yeogibeoryeo.data.spot.geocoder.AndroidSpotGeocoder
 import com.team.yeogibeoryeo.data.spot.geocoder.SpotGeocoder
+import com.team.yeogibeoryeo.data.spot.repository.CollectionSpotGeocodingRepositoryImpl
 import com.team.yeogibeoryeo.data.spot.repository.CollectionSpotRepositoryImpl
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotGeocodingRepository
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import dagger.Binds
 import dagger.Module
@@ -19,6 +21,12 @@ abstract class SpotDataModule {
     abstract fun bindCollectionSpotRepository(
         collectionSpotRepositoryImpl: CollectionSpotRepositoryImpl,
     ): CollectionSpotRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindCollectionSpotGeocodingRepository(
+        collectionSpotGeocodingRepositoryImpl: CollectionSpotGeocodingRepositoryImpl,
+    ): CollectionSpotGeocodingRepository
 
     @Binds
     @Singleton

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotGeocodingRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotGeocodingRepositoryImpl.kt
@@ -1,0 +1,115 @@
+package com.team.yeogibeoryeo.data.spot.repository
+
+import com.team.yeogibeoryeo.data.spot.geocoder.SpotGeocoder
+import com.team.yeogibeoryeo.domain.spot.log.MapSearchTimingLogger
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotGeocodingRepository
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+
+class CollectionSpotGeocodingRepositoryImpl @Inject constructor(
+    private val spotGeocoder: SpotGeocoder,
+    private val mapSearchTimingLogger: MapSearchTimingLogger = MapSearchTimingLogger.NoOp,
+) : CollectionSpotGeocodingRepository {
+
+    override suspend fun geocodeSpot(
+        spot: CollectionSpot,
+    ): CollectionSpot {
+        val coordinate = spot.address.toGeocodeKey()?.let { address ->
+            spotGeocoder.geocode(address)
+        }
+
+        return spot.copy(
+            coordinate = coordinate,
+        )
+    }
+
+    override suspend fun geocodeSpots(
+        spots: List<CollectionSpot>,
+    ): List<CollectionSpot> {
+        if (spots.isEmpty()) return spots
+
+        return supervisorScope {
+            val addressKeys = spots.mapNotNull { spot -> spot.address.toGeocodeKey() }
+                .distinct()
+            val geocodeJobsByAddress = LinkedHashMap<String, Deferred<Coordinate?>>()
+            val geocodeSemaphore = Semaphore(GEOCODING_CONCURRENCY_LIMIT)
+            val geocodingStartedAtNanos = System.nanoTime()
+
+            mapSearchTimingLogger.log(
+                "geocoding started targetCount=${addressKeys.size} " +
+                    "concurrency=$GEOCODING_CONCURRENCY_LIMIT",
+            )
+
+            addressKeys.forEach { addressKey ->
+                geocodeJobsByAddress.getOrPut(addressKey) {
+                    async {
+                        geocodeSafely(
+                            address = addressKey,
+                            semaphore = geocodeSemaphore,
+                        )
+                    }
+                }
+            }
+
+            val coordinatesByAddress = geocodeJobsByAddress
+                .mapValues { (_, geocodeJob) -> geocodeJob.await() }
+            val geocodeSuccessCount = coordinatesByAddress.values.count { coordinate -> coordinate != null }
+
+            mapSearchTimingLogger.log(
+                "geocoding finished success=$geocodeSuccessCount " +
+                    "null=${coordinatesByAddress.size - geocodeSuccessCount} " +
+                    "elapsedMs=${geocodingStartedAtNanos.elapsedMs()}",
+            )
+
+            spots.map { spot ->
+                val addressKey = spot.address.toGeocodeKey()
+                    ?: return@map spot
+                val coordinate = coordinatesByAddress[addressKey]
+
+                spot.copy(
+                    coordinate = coordinate,
+                )
+            }
+        }
+    }
+
+    private suspend fun geocodeSafely(
+        address: String,
+        semaphore: Semaphore,
+    ): Coordinate? {
+        return semaphore.withPermit {
+            runCatching {
+                spotGeocoder.geocode(address)
+            }.getOrElse { exception ->
+                if (exception is CancellationException) throw exception
+
+                null
+            }
+        }
+    }
+
+    private fun String.toGeocodeKey(): String? {
+        return replace(PARENTHESIZED_TEXT_REGEX, " ")
+            .trim()
+            .replace(WHITESPACE_REGEX, " ")
+            .takeIf { it.isNotBlank() }
+    }
+
+    private companion object {
+        const val GEOCODING_CONCURRENCY_LIMIT = 3
+        val PARENTHESIZED_TEXT_REGEX = "\\([^)]*\\)".toRegex()
+        val WHITESPACE_REGEX = "\\s+".toRegex()
+    }
+}
+
+private fun Long.elapsedMs(): Long =
+    (System.nanoTime() - this) / NANOS_PER_MILLISECOND
+
+private const val NANOS_PER_MILLISECOND = 1_000_000L

--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package com.team.yeogibeoryeo.data.spot.repository
 
 import com.team.yeogibeoryeo.data.core.key.AppKeyProvider
-import com.team.yeogibeoryeo.data.spot.geocoder.SpotGeocoder
 import com.team.yeogibeoryeo.data.spot.mapper.SpotMapper
 import com.team.yeogibeoryeo.data.spot.remote.datasource.SpotRemoteDataSource
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
@@ -11,54 +10,15 @@ import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.log.MapSearchTimingLogger
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import javax.inject.Inject
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.async
-import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
-import kotlinx.coroutines.supervisorScope
 
 class CollectionSpotRepositoryImpl @Inject constructor(
     private val remoteDataSource: SpotRemoteDataSource,
     private val spotMapper: SpotMapper,
-    private val spotGeocoder: SpotGeocoder,
     private val publicDataKeyProvider: AppKeyProvider,
     private val mapSearchTimingLogger: MapSearchTimingLogger = MapSearchTimingLogger.NoOp,
 ) : CollectionSpotRepository {
 
-    override suspend fun searchByKeyword(
-        keyword: String,
-        types: Set<CollectionSpotType>,
-    ): List<CollectionSpot> {
-        return searchByKeywordResult(
-            keyword = keyword,
-            types = types,
-        ).spots
-    }
-
-    override suspend fun searchByKeywordResult(
-        keyword: String,
-        types: Set<CollectionSpotType>,
-    ): CollectionSpotSearchResult {
-        val repositorySearchStartedAtNanos = System.nanoTime()
-        val result = searchByKeywordResultWithoutCoordinates(
-            keyword = keyword,
-            types = types,
-        )
-        val spots = geocodeSpots(result.spots)
-
-        mapSearchTimingLogger.log(
-            "repository search finished finalCount=${spots.size} " +
-                "elapsedMs=${repositorySearchStartedAtNanos.elapsedMs()}",
-        )
-
-        return CollectionSpotSearchResult(
-            spots = spots,
-            isPartial = result.isPartial,
-        )
-    }
-
-    override suspend fun searchByKeywordResultWithoutCoordinates(
+    override suspend fun searchRawByKeyword(
         keyword: String,
         types: Set<CollectionSpotType>,
     ): CollectionSpotSearchResult {
@@ -87,12 +47,11 @@ class CollectionSpotRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun searchByLocation(
+    override suspend fun searchRawByLocation(
         coordinate: Coordinate,
         radiusMeter: Int,
         types: Set<CollectionSpotType>,
     ): List<CollectionSpot> {
-        val repositorySearchStartedAtNanos = System.nanoTime()
         val remoteSearchStartedAtNanos = System.nanoTime()
         val spots = remoteDataSource.searchByLocation(
             serviceKey = publicDataKeyProvider.publicDataServiceKey,
@@ -115,30 +74,7 @@ class CollectionSpotRepositoryImpl @Inject constructor(
         )
 
         return typeFilteredSpots
-            .geocodeAll()
-            .also { geocodedSpots ->
-                mapSearchTimingLogger.log(
-                    "repository search finished finalCount=${geocodedSpots.size} " +
-                        "elapsedMs=${repositorySearchStartedAtNanos.elapsedMs()}",
-                )
-            }
     }
-
-    override suspend fun geocodeSpot(
-        spot: CollectionSpot,
-    ): CollectionSpot {
-        val coordinate = spot.address.toGeocodeKey()?.let { address ->
-            spotGeocoder.geocode(address)
-        }
-
-        return spot.copy(
-            coordinate = coordinate,
-        )
-    }
-
-    override suspend fun geocodeSpots(
-        spots: List<CollectionSpot>,
-    ): List<CollectionSpot> = spots.geocodeAll()
 
     private fun List<CollectionSpot>.filterByTypes(
         types: Set<CollectionSpotType>,
@@ -148,82 +84,6 @@ class CollectionSpotRepositoryImpl @Inject constructor(
         return filter { spot ->
             spot.type in types
         }
-    }
-
-    private suspend fun List<CollectionSpot>.geocodeAll(): List<CollectionSpot> {
-        if (isEmpty()) return this
-
-        return supervisorScope {
-            val addressKeys = mapNotNull { spot -> spot.address.toGeocodeKey() }
-                .distinct()
-            val geocodeJobsByAddress = LinkedHashMap<String, Deferred<Coordinate?>>()
-            val geocodeSemaphore = Semaphore(GEOCODING_CONCURRENCY_LIMIT)
-            val geocodingStartedAtNanos = System.nanoTime()
-
-            mapSearchTimingLogger.log(
-                "geocoding started targetCount=${addressKeys.size} " +
-                    "concurrency=$GEOCODING_CONCURRENCY_LIMIT",
-            )
-
-            addressKeys.forEach { addressKey ->
-                geocodeJobsByAddress.getOrPut(addressKey) {
-                    async {
-                        geocodeSafely(
-                            address = addressKey,
-                            semaphore = geocodeSemaphore,
-                        )
-                    }
-                }
-            }
-
-            val coordinatesByAddress = geocodeJobsByAddress
-                .mapValues { (_, geocodeJob) -> geocodeJob.await() }
-            val geocodeSuccessCount = coordinatesByAddress.values.count { coordinate -> coordinate != null }
-
-            mapSearchTimingLogger.log(
-                "geocoding finished success=$geocodeSuccessCount " +
-                    "null=${coordinatesByAddress.size - geocodeSuccessCount} " +
-                    "elapsedMs=${geocodingStartedAtNanos.elapsedMs()}",
-            )
-
-            map { spot ->
-                val addressKey = spot.address.toGeocodeKey()
-                    ?: return@map spot
-                val coordinate = coordinatesByAddress[addressKey]
-
-                spot.copy(
-                    coordinate = coordinate,
-                )
-            }
-        }
-    }
-
-    private suspend fun geocodeSafely(
-        address: String,
-        semaphore: Semaphore,
-    ): Coordinate? {
-        return semaphore.withPermit {
-            runCatching {
-                spotGeocoder.geocode(address)
-            }.getOrElse { exception ->
-                if (exception is CancellationException) throw exception
-
-                null
-            }
-        }
-    }
-
-    private fun String.toGeocodeKey(): String? {
-        return replace(PARENTHESIZED_TEXT_REGEX, " ")
-            .trim()
-            .replace(WHITESPACE_REGEX, " ")
-            .takeIf { it.isNotBlank() }
-    }
-
-    private companion object {
-        const val GEOCODING_CONCURRENCY_LIMIT = 3
-        val PARENTHESIZED_TEXT_REGEX = "\\([^)]*\\)".toRegex()
-        val WHITESPACE_REGEX = "\\s+".toRegex()
     }
 }
 

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotGeocodingRepositoryImplTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotGeocodingRepositoryImplTest.kt
@@ -1,0 +1,209 @@
+package com.team.yeogibeoryeo.data.spot.repository
+
+import com.team.yeogibeoryeo.data.spot.geocoder.SpotGeocoder
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CollectionSpotGeocodingRepositoryImplTest {
+
+    @Test
+    fun `단일 장소 주소를 geocoding하여 좌표를 설정한다`() = runBlocking {
+        val repository = createRepository()
+        val spot = collectionSpot(
+            id = "battery-bin",
+            address = "서울특별시 영등포구 문래동",
+        )
+
+        val result = repository.geocodeSpot(spot)
+
+        assertEquals(37.5, result.coordinate?.latitude)
+        assertEquals(126.9, result.coordinate?.longitude)
+    }
+
+    @Test
+    fun `같은 주소는 한 번만 geocoding하고 기존 순서를 유지한다`() = runBlocking {
+        val spotGeocoder = FakeSpotGeocoder(
+            coordinatesByAddress = mapOf(
+                "서울특별시 영등포구 문래동" to Coordinate(
+                    latitude = 37.5,
+                    longitude = 126.9,
+                ),
+                "서울특별시 구로구 구로동" to Coordinate(
+                    latitude = 37.4,
+                    longitude = 126.8,
+                ),
+            ),
+        )
+        val repository = createRepository(spotGeocoder)
+
+        val result = repository.geocodeSpots(
+            listOf(
+                collectionSpot(
+                    id = "battery-bin-1",
+                    name = "폐건전지 수거함",
+                    address = "서울특별시 영등포구 문래동",
+                ),
+                collectionSpot(
+                    id = "battery-bin-2",
+                    name = "폐건전지 수거함 2",
+                    address = " 서울특별시 영등포구 문래동 ",
+                ),
+                collectionSpot(
+                    id = "recycling-center",
+                    name = "재활용센터",
+                    address = "서울특별시 구로구 구로동",
+                ),
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                "폐건전지 수거함",
+                "폐건전지 수거함 2",
+                "재활용센터",
+            ),
+            result.map { spot -> spot.name },
+        )
+        assertEquals(
+            listOf(
+                "서울특별시 영등포구 문래동",
+                "서울특별시 구로구 구로동",
+            ),
+            spotGeocoder.requestedAddresses,
+        )
+        assertEquals(result[0].coordinate, result[1].coordinate)
+        assertEquals(37.4, result[2].coordinate?.latitude)
+    }
+
+    @Test
+    fun `괄호가 포함된 도로명 주소는 괄호를 제거한 주소로 geocoding한다`() = runBlocking {
+        val spotGeocoder = FakeSpotGeocoder(
+            coordinatesByAddress = mapOf(
+                "서울특별시 성동구 행당로 35" to Coordinate(
+                    latitude = 37.5570,
+                    longitude = 127.0332,
+                ),
+            ),
+        )
+        val repository = createRepository(spotGeocoder)
+
+        val result = repository.geocodeSpots(
+            listOf(
+                collectionSpot(
+                    id = "standard-bag-store",
+                    address = "서울특별시 성동구 행당로 35 (금호동1가, 금북빌딩)",
+                ),
+            ),
+        )
+
+        assertEquals(
+            listOf("서울특별시 성동구 행당로 35"),
+            spotGeocoder.requestedAddresses,
+        )
+        assertEquals(37.5570, result.first().coordinate?.latitude)
+        assertEquals(127.0332, result.first().coordinate?.longitude)
+    }
+
+    @Test
+    fun `공백 주소는 geocoding하지 않고 좌표 없이 유지한다`() = runBlocking {
+        val spotGeocoder = FakeSpotGeocoder()
+        val repository = createRepository(spotGeocoder)
+
+        val result = repository.geocodeSpots(
+            listOf(
+                collectionSpot(
+                    id = "blank-address",
+                    address = " ",
+                ),
+            ),
+        )
+
+        assertEquals(1, result.size)
+        assertNull(result.first().coordinate)
+        assertEquals(emptyList<String>(), spotGeocoder.requestedAddresses)
+    }
+
+    @Test
+    fun `일부 geocoding 실패가 전체 검색 결과를 실패시키지 않는다`() = runBlocking {
+        val spotGeocoder = FakeSpotGeocoder(
+            coordinatesByAddress = mapOf(
+                "서울특별시 구로구 구로동" to Coordinate(
+                    latitude = 37.4,
+                    longitude = 126.8,
+                ),
+            ),
+            failureAddresses = setOf("서울특별시 영등포구 문래동"),
+        )
+        val repository = createRepository(spotGeocoder)
+
+        val result = repository.geocodeSpots(
+            listOf(
+                collectionSpot(
+                    id = "battery-bin",
+                    name = "폐건전지 수거함",
+                    address = "서울특별시 영등포구 문래동",
+                ),
+                collectionSpot(
+                    id = "recycling-center",
+                    name = "재활용센터",
+                    address = "서울특별시 구로구 구로동",
+                ),
+            ),
+        )
+
+        assertEquals(2, result.size)
+        assertEquals("폐건전지 수거함", result[0].name)
+        assertNull(result[0].coordinate)
+        assertEquals("재활용센터", result[1].name)
+        assertEquals(37.4, result[1].coordinate?.latitude)
+    }
+
+    private fun createRepository(
+        spotGeocoder: SpotGeocoder = FakeSpotGeocoder(),
+    ): CollectionSpotGeocodingRepositoryImpl {
+        return CollectionSpotGeocodingRepositoryImpl(
+            spotGeocoder = spotGeocoder,
+        )
+    }
+
+    private fun collectionSpot(
+        id: String,
+        name: String = "수거 장소 $id",
+        address: String,
+    ): CollectionSpot {
+        return CollectionSpot(
+            id = id,
+            name = name,
+            type = CollectionSpotType.STANDARD_BAG_STORE,
+            address = address,
+            detailLocation = null,
+            coordinate = null,
+        )
+    }
+
+    private class FakeSpotGeocoder(
+        private val coordinatesByAddress: Map<String, Coordinate> = emptyMap(),
+        private val failureAddresses: Set<String> = emptySet(),
+    ) : SpotGeocoder {
+
+        val requestedAddresses = mutableListOf<String>()
+
+        override suspend fun geocode(address: String): Coordinate? {
+            requestedAddresses += address
+
+            if (address in failureAddresses) {
+                error("geocoding failed")
+            }
+
+            return coordinatesByAddress[address] ?: Coordinate(
+                latitude = 37.5,
+                longitude = 126.9,
+            )
+        }
+    }
+}

--- a/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImplTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotRepositoryImplTest.kt
@@ -1,7 +1,6 @@
 package com.team.yeogibeoryeo.data.spot.repository
 
 import com.team.yeogibeoryeo.data.core.key.AppKeyProvider
-import com.team.yeogibeoryeo.data.spot.geocoder.SpotGeocoder
 import com.team.yeogibeoryeo.data.spot.mapper.SpotMapper
 import com.team.yeogibeoryeo.data.spot.remote.SpotApiService
 import com.team.yeogibeoryeo.data.spot.remote.datasource.SpotRemoteDataSource
@@ -16,22 +15,21 @@ import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 class CollectionSpotRepositoryImplTest {
 
     @Test
-    fun `검색어 기반 조회 결과를 CollectionSpot으로 변환하고 좌표를 설정한다`() = runBlocking {
+    fun `검색어 기반 raw 조회 결과를 CollectionSpot으로 변환한다`() = runBlocking {
         val apiService = FakeSpotApiService(
             response = createNormalResponse(),
         )
         val repository = createRepository(apiService)
 
-        val result = repository.searchByKeyword(
+        val result = repository.searchRawByKeyword(
             keyword = "문래동",
-        )
+        ).spots
 
         assertEquals(TEST_SERVICE_KEY, apiService.requestedServiceKey)
         assertEquals("문래동", apiService.requestedAddr)
@@ -43,9 +41,7 @@ class CollectionSpotRepositoryImplTest {
         assertEquals("서울특별시 영등포구 문래동", firstSpot.address)
         assertEquals("주민센터 앞", firstSpot.detailLocation)
         assertEquals(CollectionSpotType.BATTERY_BIN, firstSpot.type)
-        assertNotNull(firstSpot.coordinate)
-        assertEquals(37.5, firstSpot.coordinate?.latitude)
-        assertEquals(126.9, firstSpot.coordinate?.longitude)
+        assertNull(firstSpot.coordinate)
     }
 
     @Test
@@ -55,10 +51,10 @@ class CollectionSpotRepositoryImplTest {
         )
         val repository = createRepository(apiService)
 
-        val result = repository.searchByKeyword(
+        val result = repository.searchRawByKeyword(
             keyword = "문래동",
             types = setOf(CollectionSpotType.RECYCLING_CENTER),
-        )
+        ).spots
 
         assertEquals(TEST_SERVICE_KEY, apiService.requestedServiceKey)
         assertEquals(1, result.size)
@@ -71,20 +67,17 @@ class CollectionSpotRepositoryImplTest {
         val apiService = FakeSpotApiService(
             response = createNormalResponse(),
         )
-        val spotGeocoder = FakeSpotGeocoder()
         val repository = createRepository(
             apiService = apiService,
-            spotGeocoder = spotGeocoder,
         )
 
-        val result = repository.searchByKeywordResultWithoutCoordinates(
+        val result = repository.searchRawByKeyword(
             keyword = "문래동",
         )
 
         assertEquals(TEST_SERVICE_KEY, apiService.requestedServiceKey)
         assertEquals("문래동", apiService.requestedAddr)
         assertEquals(2, result.spots.size)
-        assertEquals(emptyList<String>(), spotGeocoder.requestedAddresses)
         assertNull(result.spots.first().coordinate)
     }
 
@@ -113,9 +106,9 @@ class CollectionSpotRepositoryImplTest {
         )
         val repository = createRepository(apiService)
 
-        val result = repository.searchByKeyword(
+        val result = repository.searchRawByKeyword(
             keyword = "문래동",
-        )
+        ).spots
 
         assertEquals(listOf(1, 2), apiService.requestedPageNos)
         assertEquals(
@@ -131,7 +124,7 @@ class CollectionSpotRepositoryImplTest {
         )
         val repository = createRepository(apiService)
 
-        val result = repository.searchByLocation(
+        val result = repository.searchRawByLocation(
             coordinate = Coordinate(
                 latitude = 37.5182396969791,
                 longitude = 126.895880210522,
@@ -154,147 +147,20 @@ class CollectionSpotRepositoryImplTest {
         )
         val repository = createRepository(apiService)
 
-        val result = repository.searchByKeyword(
+        val result = repository.searchRawByKeyword(
             keyword = "약수동",
-        )
+        ).spots
 
         assertEquals(TEST_SERVICE_KEY, apiService.requestedServiceKey)
         assertEquals(emptyList<Any>(), result)
     }
 
-    @Test
-    fun `같은 주소는 한 번만 geocoding하고 기존 순서를 유지한다`() = runBlocking {
-        val apiService = FakeSpotApiService(
-            response = createDuplicateAddressResponse(),
-        )
-        val spotGeocoder = FakeSpotGeocoder(
-            coordinatesByAddress = mapOf(
-                "서울특별시 영등포구 문래동" to Coordinate(
-                    latitude = 37.5,
-                    longitude = 126.9,
-                ),
-                "서울특별시 구로구 구로동" to Coordinate(
-                    latitude = 37.4,
-                    longitude = 126.8,
-                ),
-            ),
-        )
-        val repository = createRepository(
-            apiService = apiService,
-            spotGeocoder = spotGeocoder,
-        )
-
-        val result = repository.searchByKeyword(
-            keyword = "문래동",
-        )
-
-        assertEquals(
-            listOf(
-                "폐건전지 수거함",
-                "폐건전지 수거함 2",
-                "재활용센터",
-            ),
-            result.map { it.name },
-        )
-        assertEquals(
-            listOf(
-                "서울특별시 영등포구 문래동",
-                "서울특별시 구로구 구로동",
-            ),
-            spotGeocoder.requestedAddresses,
-        )
-        assertEquals(result[0].coordinate, result[1].coordinate)
-        assertEquals(37.4, result[2].coordinate?.latitude)
-    }
-
-    @Test
-    fun `괄호가 포함된 도로명 주소는 괄호를 제거한 주소로 geocoding한다`() = runBlocking {
-        val apiService = FakeSpotApiService(
-            response = createParenthesizedRoadAddressResponse(),
-        )
-        val spotGeocoder = FakeSpotGeocoder(
-            coordinatesByAddress = mapOf(
-                "서울특별시 성동구 행당로 35" to Coordinate(
-                    latitude = 37.5570,
-                    longitude = 127.0332,
-                ),
-            ),
-        )
-        val repository = createRepository(
-            apiService = apiService,
-            spotGeocoder = spotGeocoder,
-        )
-
-        val result = repository.searchByKeyword(
-            keyword = "금호동",
-        )
-
-        assertEquals(
-            listOf("서울특별시 성동구 행당로 35"),
-            spotGeocoder.requestedAddresses,
-        )
-        assertEquals(37.5570, result.first().coordinate?.latitude)
-        assertEquals(127.0332, result.first().coordinate?.longitude)
-    }
-
-    @Test
-    fun `공백 주소는 geocoding하지 않고 좌표 없이 유지한다`() = runBlocking {
-        val apiService = FakeSpotApiService(
-            response = createBlankAddressResponse(),
-        )
-        val spotGeocoder = FakeSpotGeocoder()
-        val repository = createRepository(
-            apiService = apiService,
-            spotGeocoder = spotGeocoder,
-        )
-
-        val result = repository.searchByKeyword(
-            keyword = "문래동",
-        )
-
-        assertEquals(1, result.size)
-        assertNull(result.first().coordinate)
-        assertEquals(emptyList<String>(), spotGeocoder.requestedAddresses)
-    }
-
-    @Test
-    fun `일부 geocoding 실패가 전체 검색 결과를 실패시키지 않는다`() = runBlocking {
-        val apiService = FakeSpotApiService(
-            response = createNormalResponse(),
-        )
-        val spotGeocoder = FakeSpotGeocoder(
-            coordinatesByAddress = mapOf(
-                "서울특별시 구로구 구로동" to Coordinate(
-                    latitude = 37.4,
-                    longitude = 126.8,
-                ),
-            ),
-            failureAddresses = setOf("서울특별시 영등포구 문래동"),
-        )
-        val repository = createRepository(
-            apiService = apiService,
-            spotGeocoder = spotGeocoder,
-        )
-
-        val result = repository.searchByKeyword(
-            keyword = "문래동",
-        )
-
-        assertEquals(2, result.size)
-        assertEquals("폐건전지 수거함", result[0].name)
-        assertNull(result[0].coordinate)
-        assertEquals("재활용센터", result[1].name)
-        assertEquals(37.4, result[1].coordinate?.latitude)
-    }
-
     private fun createRepository(
         apiService: FakeSpotApiService,
-        spotGeocoder: SpotGeocoder = FakeSpotGeocoder(),
     ): CollectionSpotRepositoryImpl {
         return CollectionSpotRepositoryImpl(
             remoteDataSource = SpotRemoteDataSource(apiService),
             spotMapper = SpotMapper(),
-            spotGeocoder = spotGeocoder,
             publicDataKeyProvider = FakePublicDataKeyProvider(),
         )
     }
@@ -302,27 +168,6 @@ class CollectionSpotRepositoryImplTest {
     private class FakePublicDataKeyProvider : AppKeyProvider {
         override val publicDataServiceKey: String = TEST_SERVICE_KEY
         override val naverClientId: String = "naver-client-id"
-    }
-
-    private class FakeSpotGeocoder(
-        private val coordinatesByAddress: Map<String, Coordinate> = emptyMap(),
-        private val failureAddresses: Set<String> = emptySet(),
-    ) : SpotGeocoder {
-
-        val requestedAddresses = mutableListOf<String>()
-
-        override suspend fun geocode(address: String): Coordinate? {
-            requestedAddresses += address
-
-            if (address in failureAddresses) {
-                error("geocoding failed")
-            }
-
-            return coordinatesByAddress[address] ?: Coordinate(
-                latitude = 37.5,
-                longitude = 126.9,
-            )
-        }
     }
 
     private class FakeSpotApiService(
@@ -386,82 +231,6 @@ class CollectionSpotRepositoryImplTest {
                                     spotNm = "재활용센터",
                                     addrBase = "서울특별시 구로구 구로동",
                                     addrDtl = "센터 입구",
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
-            )
-        }
-
-        fun createDuplicateAddressResponse(): SpotResponseDto {
-            return SpotResponseDto(
-                response = SpotResponseBodyDto(
-                    header = SpotHeaderDto(
-                        resultCode = "00",
-                        resultMsg = "NORMAL SERVICE",
-                    ),
-                    body = SpotBodyDto(
-                        items = SpotItemsDto(
-                            item = listOf(
-                                SpotItemDto(
-                                    spotNm = "폐건전지 수거함",
-                                    addrBase = "서울특별시 영등포구 문래동",
-                                    addrDtl = "주민센터 앞",
-                                ),
-                                SpotItemDto(
-                                    spotNm = "폐건전지 수거함 2",
-                                    addrBase = " 서울특별시 영등포구 문래동 ",
-                                    addrDtl = "학교 앞",
-                                ),
-                                SpotItemDto(
-                                    spotNm = "재활용센터",
-                                    addrBase = "서울특별시 구로구 구로동",
-                                    addrDtl = "센터 입구",
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
-            )
-        }
-
-        fun createParenthesizedRoadAddressResponse(): SpotResponseDto {
-            return SpotResponseDto(
-                response = SpotResponseBodyDto(
-                    header = SpotHeaderDto(
-                        resultCode = "00",
-                        resultMsg = "NORMAL SERVICE",
-                    ),
-                    body = SpotBodyDto(
-                        items = SpotItemsDto(
-                            item = listOf(
-                                SpotItemDto(
-                                    spotNm = "종량제봉투 판매소",
-                                    addrBase = "서울특별시 성동구 행당로 35 (금호동1가, 금북빌딩)",
-                                    addrDtl = "103호, 105호",
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
-            )
-        }
-
-        fun createBlankAddressResponse(): SpotResponseDto {
-            return SpotResponseDto(
-                response = SpotResponseBodyDto(
-                    header = SpotHeaderDto(
-                        resultCode = "00",
-                        resultMsg = "NORMAL SERVICE",
-                    ),
-                    body = SpotBodyDto(
-                        items = SpotItemsDto(
-                            item = listOf(
-                                SpotItemDto(
-                                    spotNm = "주소 없는 수거함",
-                                    addrBase = " ",
-                                    addrDtl = "상세 위치",
                                 ),
                             ),
                         ),

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/CollectionSpotGeocodingRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/CollectionSpotGeocodingRepository.kt
@@ -1,0 +1,16 @@
+package com.team.yeogibeoryeo.domain.spot.repository
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+
+interface CollectionSpotGeocodingRepository {
+
+    suspend fun geocodeSpots(
+        spots: List<CollectionSpot>
+    ): List<CollectionSpot> {
+        return spots.map { spot -> geocodeSpot(spot) }
+    }
+
+    suspend fun geocodeSpot(
+        spot: CollectionSpot
+    ): CollectionSpot
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/CollectionSpotRepository.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/repository/CollectionSpotRepository.kt
@@ -7,41 +7,14 @@ import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 
 interface CollectionSpotRepository {
 
-    suspend fun searchByKeyword(
-        keyword: String,
-        types: Set<CollectionSpotType> = emptySet()
-    ): List<CollectionSpot>
-
-    suspend fun searchByKeywordResult(
-        keyword: String,
-        types: Set<CollectionSpotType> = emptySet()
-    ): CollectionSpotSearchResult {
-        return CollectionSpotSearchResult(
-            spots = searchByKeyword(
-                keyword = keyword,
-                types = types,
-            ),
-        )
-    }
-
-    suspend fun searchByKeywordResultWithoutCoordinates(
+    suspend fun searchRawByKeyword(
         keyword: String,
         types: Set<CollectionSpotType> = emptySet()
     ): CollectionSpotSearchResult
 
-    suspend fun searchByLocation(
+    suspend fun searchRawByLocation(
         coordinate: Coordinate,
         radiusMeter: Int,
         types: Set<CollectionSpotType> = emptySet()
     ): List<CollectionSpot>
-
-    suspend fun geocodeSpots(
-        spots: List<CollectionSpot>
-    ): List<CollectionSpot> {
-        return spots.map { spot -> geocodeSpot(spot) }
-    }
-
-    suspend fun geocodeSpot(
-        spot: CollectionSpot
-    ): CollectionSpot
 }

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/GeocodeCollectionSpotUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/GeocodeCollectionSpotUseCase.kt
@@ -1,11 +1,11 @@
 package com.team.yeogibeoryeo.domain.spot.usecase
 
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
-import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotGeocodingRepository
 import javax.inject.Inject
 
 class GeocodeCollectionSpotUseCase @Inject constructor(
-    private val repository: CollectionSpotRepository
+    private val repository: CollectionSpotGeocodingRepository
 ) {
     suspend operator fun invoke(
         spot: CollectionSpot

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCase.kt
@@ -6,11 +6,13 @@ import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotSearchResult
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
 import com.team.yeogibeoryeo.domain.spot.log.MapSearchTimingLogger
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotGeocodingRepository
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import javax.inject.Inject
 
 class SearchCollectionSpotsByKeywordUseCase @Inject constructor(
     private val repository: CollectionSpotRepository,
+    private val geocodingRepository: CollectionSpotGeocodingRepository,
     private val normalizeKeywordUseCase: NormalizeCollectionSpotSearchKeywordUseCase,
     private val mapSearchTimingLogger: MapSearchTimingLogger = MapSearchTimingLogger.NoOp,
 ) {
@@ -32,7 +34,7 @@ class SearchCollectionSpotsByKeywordUseCase @Inject constructor(
         selectedRegionCandidate: MapRegionSearchCandidate? = null,
     ): CollectionSpotSearchResult {
         val normalizedKeyword = normalizeKeywordUseCase(keyword)
-        val result = repository.searchByKeywordResultWithoutCoordinates(
+        val result = repository.searchRawByKeyword(
             keyword = normalizedKeyword,
             types = types,
         )
@@ -58,7 +60,7 @@ class SearchCollectionSpotsByKeywordUseCase @Inject constructor(
                     "elapsedMs=${selectedRegionFilterStartedAtNanos.elapsedMs()}",
             )
         }
-        val geocodedSpots = repository.geocodeSpots(selectedRegionFilteredSpots)
+        val geocodedSpots = geocodingRepository.geocodeSpots(selectedRegionFilteredSpots)
 
         return CollectionSpotSearchResult(
             spots = geocodedSpots,

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByLocationUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByLocationUseCase.kt
@@ -3,21 +3,38 @@ package com.team.yeogibeoryeo.domain.spot.usecase
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.log.MapSearchTimingLogger
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotGeocodingRepository
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import javax.inject.Inject
 
 class SearchCollectionSpotsByLocationUseCase @Inject constructor(
-    private val repository: CollectionSpotRepository
+    private val repository: CollectionSpotRepository,
+    private val geocodingRepository: CollectionSpotGeocodingRepository,
+    private val mapSearchTimingLogger: MapSearchTimingLogger = MapSearchTimingLogger.NoOp,
 ) {
     suspend operator fun invoke(
         coordinate: Coordinate,
         radiusMeter: Int,
         types: Set<CollectionSpotType> = emptySet()
     ): List<CollectionSpot> {
-        return repository.searchByLocation(
+        val searchStartedAtNanos = System.nanoTime()
+        val spots = repository.searchRawByLocation(
             coordinate = coordinate,
             radiusMeter = radiusMeter,
             types = types
         )
+        return geocodingRepository.geocodeSpots(spots)
+            .also { geocodedSpots ->
+                mapSearchTimingLogger.log(
+                    "repository search finished finalCount=${geocodedSpots.size} " +
+                        "elapsedMs=${searchStartedAtNanos.elapsedMs()}",
+                )
+            }
     }
 }
+
+private fun Long.elapsedMs(): Long =
+    (System.nanoTime() - this) / NANOS_PER_MILLISECOND
+
+private const val NANOS_PER_MILLISECOND = 1_000_000L

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByKeywordUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotSearchResult
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.model.MapRegionSearchCandidate
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotGeocodingRepository
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -15,6 +16,7 @@ class SearchCollectionSpotsByKeywordUseCaseTest {
     private val repository = FakeCollectionSpotRepository()
     private val useCase = SearchCollectionSpotsByKeywordUseCase(
         repository = repository,
+        geocodingRepository = repository,
         normalizeKeywordUseCase = NormalizeCollectionSpotSearchKeywordUseCase(),
     )
 
@@ -235,30 +237,21 @@ class SearchCollectionSpotsByKeywordUseCaseTest {
         )
     }
 
-    private class FakeCollectionSpotRepository : CollectionSpotRepository {
+    private class FakeCollectionSpotRepository : CollectionSpotRepository, CollectionSpotGeocodingRepository {
         var keywordSpots: List<CollectionSpot> = emptyList()
         val keywords = mutableListOf<String>()
         val geocodedSpotIds = mutableListOf<String>()
 
-        override suspend fun searchByKeyword(
-            keyword: String,
-            types: Set<CollectionSpotType>,
-        ): List<CollectionSpot> {
-            keywords += keyword
-            return keywordSpots
-        }
-
-        override suspend fun searchByKeywordResultWithoutCoordinates(
+        override suspend fun searchRawByKeyword(
             keyword: String,
             types: Set<CollectionSpotType>,
         ) = CollectionSpotSearchResult(
-            spots = searchByKeyword(
-                keyword = keyword,
-                types = types,
-            ),
-        )
+            spots = keywordSpots,
+        ).also {
+            keywords += keyword
+        }
 
-        override suspend fun searchByLocation(
+        override suspend fun searchRawByLocation(
             coordinate: Coordinate,
             radiusMeter: Int,
             types: Set<CollectionSpotType>,

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByLocationUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/spot/usecase/SearchCollectionSpotsByLocationUseCaseTest.kt
@@ -1,0 +1,92 @@
+package com.team.yeogibeoryeo.domain.spot.usecase
+
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpot
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotSearchResult
+import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
+import com.team.yeogibeoryeo.domain.spot.model.Coordinate
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotGeocodingRepository
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SearchCollectionSpotsByLocationUseCaseTest {
+
+    private val repository = FakeCollectionSpotRepository()
+    private val geocodingRepository = FakeCollectionSpotGeocodingRepository()
+    private val useCase = SearchCollectionSpotsByLocationUseCase(
+        repository = repository,
+        geocodingRepository = geocodingRepository,
+    )
+
+    @Test
+    fun `현재 위치 검색은 raw location search 후 geocoding한다`() = runBlocking {
+        val coordinate = Coordinate(latitude = 37.5182396969791, longitude = 126.895880210522)
+        val rawSpot = collectionSpot(id = "spot-1", coordinate = null)
+        repository.locationSpots = listOf(rawSpot)
+
+        val result = useCase(
+            coordinate = coordinate,
+            radiusMeter = 500,
+        )
+
+        assertEquals(coordinate, repository.lastCoordinate)
+        assertEquals(500, repository.lastRadiusMeter)
+        assertEquals(listOf("spot-1"), geocodingRepository.geocodedSpotIds)
+        assertEquals(DEFAULT_COORDINATE, result.first().coordinate)
+    }
+
+    private class FakeCollectionSpotRepository : CollectionSpotRepository {
+        var locationSpots: List<CollectionSpot> = emptyList()
+        var lastCoordinate: Coordinate? = null
+        var lastRadiusMeter: Int? = null
+
+        override suspend fun searchRawByKeyword(
+            keyword: String,
+            types: Set<CollectionSpotType>,
+        ): CollectionSpotSearchResult {
+            return CollectionSpotSearchResult(spots = emptyList())
+        }
+
+        override suspend fun searchRawByLocation(
+            coordinate: Coordinate,
+            radiusMeter: Int,
+            types: Set<CollectionSpotType>,
+        ): List<CollectionSpot> {
+            lastCoordinate = coordinate
+            lastRadiusMeter = radiusMeter
+            return locationSpots
+        }
+    }
+
+    private class FakeCollectionSpotGeocodingRepository : CollectionSpotGeocodingRepository {
+        val geocodedSpotIds = mutableListOf<String>()
+
+        override suspend fun geocodeSpot(
+            spot: CollectionSpot,
+        ): CollectionSpot {
+            geocodedSpotIds += spot.id
+            return spot.copy(
+                coordinate = spot.coordinate ?: DEFAULT_COORDINATE,
+            )
+        }
+    }
+
+    private fun collectionSpot(
+        id: String,
+        coordinate: Coordinate?,
+    ): CollectionSpot {
+        return CollectionSpot(
+            id = id,
+            name = "수거 장소 $id",
+            type = CollectionSpotType.STANDARD_BAG_STORE,
+            address = "서울특별시 영등포구 문래동",
+            detailLocation = null,
+            coordinate = coordinate,
+        )
+    }
+
+    private companion object {
+        val DEFAULT_COORDINATE = Coordinate(latitude = 37.5666102, longitude = 126.9783881)
+    }
+}

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTestFixture.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/map/CollectionSpotMapViewModelTestFixture.kt
@@ -16,6 +16,7 @@ import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotSearchResult
 import com.team.yeogibeoryeo.domain.spot.model.CollectionSpotType
 import com.team.yeogibeoryeo.domain.spot.model.Coordinate
 import com.team.yeogibeoryeo.domain.spot.model.RecentCurrentLocationSpotCacheEntry
+import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotGeocodingRepository
 import com.team.yeogibeoryeo.domain.spot.repository.CollectionSpotRepository
 import com.team.yeogibeoryeo.domain.spot.repository.RecentCurrentLocationSpotCacheRepository
 import com.team.yeogibeoryeo.domain.spot.usecase.CalculateDistanceMeterUseCase
@@ -88,9 +89,13 @@ internal fun createViewModel(
         ),
         searchCollectionSpotsByKeywordUseCase = SearchCollectionSpotsByKeywordUseCase(
             repository = repository,
+            geocodingRepository = repository,
             normalizeKeywordUseCase = normalizeKeywordUseCase,
         ),
-        searchCollectionSpotsByLocationUseCase = SearchCollectionSpotsByLocationUseCase(repository),
+        searchCollectionSpotsByLocationUseCase = SearchCollectionSpotsByLocationUseCase(
+            repository = repository,
+            geocodingRepository = repository,
+        ),
         filterCollectionSpotsUseCase = FilterCollectionSpotsUseCase(),
         currentLocationProvider = currentLocationProvider,
         locationPermissionChecker = FakeLocationPermissionChecker(hasFineLocationPermission),
@@ -225,48 +230,25 @@ internal class FakeCollectionSpotRepository(
     internal val keywordSearchThrowable: Throwable? = null,
     internal val locationSearchThrowable: Throwable? = null,
     internal val locationSearchResultProvider: (suspend () -> List<CollectionSpot>)? = null,
-) : CollectionSpotRepository {
+) : CollectionSpotRepository, CollectionSpotGeocodingRepository {
     val keywords = mutableListOf<String>()
     var locationSearchCallCount = 0
     var lastLocationCoordinate: Coordinate? = null
     var lastRadiusMeter: Int? = null
 
-    override suspend fun searchByKeyword(
+    override suspend fun searchRawByKeyword(
         keyword: String,
         types: Set<CollectionSpotType>,
-    ): List<CollectionSpot> {
+    ): CollectionSpotSearchResult {
         keywords += keyword
         keywordSearchThrowable?.let { throw it }
-        return keywordSpots
-    }
-
-    override suspend fun searchByKeywordResult(
-        keyword: String,
-        types: Set<CollectionSpotType>,
-    ): CollectionSpotSearchResult {
         return CollectionSpotSearchResult(
-            spots = searchByKeyword(
-                keyword = keyword,
-                types = types,
-            ),
+            spots = keywordSpots,
             isPartial = isKeywordSearchPartial,
         )
     }
 
-    override suspend fun searchByKeywordResultWithoutCoordinates(
-        keyword: String,
-        types: Set<CollectionSpotType>,
-    ): CollectionSpotSearchResult {
-        return CollectionSpotSearchResult(
-            spots = searchByKeyword(
-                keyword = keyword,
-                types = types,
-            ),
-            isPartial = isKeywordSearchPartial,
-        )
-    }
-
-    override suspend fun searchByLocation(
+    override suspend fun searchRawByLocation(
         coordinate: Coordinate,
         radiusMeter: Int,
         types: Set<CollectionSpotType>,


### PR DESCRIPTION
## 작업 배경

#257 1차 성능 측정과 #263 keyword 후보 검색 최적화를 통해 지도 검색 병목이 `/getSpot addr` 반복 조회와 geocoding 구간에 집중되어 있음을 확인했습니다.

#263에서는 keyword 검색에 한해 아래 구조로 먼저 개선했습니다.

```text
raw search -> region filter -> geocode
```

하지만 location/current map 검색은 여전히 repository 내부에서 search와 geocoding이 함께 수행되고 있어, 검색 경로별 책임 구조가 일관되지 않았습니다.

```text
keyword 검색:
raw search -> usecase filter -> geocode

location/current map 검색:
repository 내부에서 search + geocode
```

이번 PR에서는 성능 튜닝 값을 바로 변경하지 않고, 후속 성능 실험을 안전하게 진행할 수 있도록 **검색 조회와 geocoding 책임을 분리**했습니다.

---

## 작업 내용

### 1. `CollectionSpotRepository`를 raw search 전용 interface로 정리

* `searchRawByKeyword`
* `searchRawByLocation`

`/getSpot` API 조회와 DTO → domain mapping, type filter까지만 담당하도록 정리했습니다.

---

### 2. `CollectionSpotGeocodingRepository` 추가

* `geocodeSpot`
* `geocodeSpots`

주소 기반 geocoding 책임을 별도 repository로 분리했습니다.

---

### 3. data 구현체 분리

#### `CollectionSpotRepositoryImpl`

* `/getSpot` API 조회
* DTO → domain mapping
* type filter
* raw search 결과 반환

#### `CollectionSpotGeocodingRepositoryImpl`

* address 기반 geocoding
* 동일 주소 dedup geocoding
* geocoding 실패 허용 정책 유지

---

### 4. keyword/location 검색 파이프라인 통일

검색 경로별 파이프라인을 아래처럼 정리했습니다.

```text
keyword 검색:
raw search -> region filter -> geocode

location/current map 검색:
raw search -> geocode
```

이를 통해 keyword 검색과 location/current map 검색 모두 usecase에서 geocoding 시점을 제어할 수 있게 되었습니다.

---

### 5. DI binding 추가

아래 repository binding을 추가했습니다.

* `CollectionSpotRepository`
* `CollectionSpotGeocodingRepository`

---

### 6. 테스트 보강 및 분리

* location 검색이 raw search 후 geocoding되는지 테스트 추가
* data 테스트를 검색 조회 책임 / geocoding 책임별 테스트 파일로 분리

---

## 유지한 정책

이번 PR에서는 아래 정책을 변경하지 않았습니다.

* `GEOCODING_CONCURRENCY_LIMIT = 3` 유지
* candidate `searchKeywords` 병렬화 없음
* geocoding concurrency 변경 없음
* `/getSpot` pagination 정책 변경 없음
* geocoding cache 도입 없음
* 검색 결과 cache 도입 없음
* region filter 정책 변경 없음
* UI/UX 변경 없음
* 마커 / BottomSheet / 필터칩 동작 변경 없음

---

## 수동 확인

Debug build 에뮬레이터에서 아래 항목을 확인했습니다.

* `명동` keyword 후보 선택 검색 정상 동작
* 현 지도에서 검색 정상 동작
* 즐겨찾기 등 기존 지도 기능 정상 동작
* `MapSearchTiming` 로그 정상 출력 확인

예시 로그:

```text
map center search started
getSpot location finished
type filter finished
geocoding started targetCount=41 concurrency=3
geocoding finished
repository search finished
viewModel search success
ui state updated
```

---

## 테스트

아래 명령을 실행했습니다.

```bash
./gradlew.bat :domain:test
./gradlew.bat :data:testDebugUnitTest
./gradlew.bat :presentation:testDebugUnitTest :presentation:compileDebugKotlin
./gradlew.bat :app:assembleDebug
git diff --check
```

---

## 후속 작업

#267에서 실제 성능 실험을 진행할 예정입니다.

* candidate `searchKeywords` 제한 병렬화 검토
* geocoding concurrency `3 / 4 / 5` 비교
* API partial/failure 영향 확인
* `명동 / 삼성동 / 문래동` 실기기 반복 측정
* 최종 적용 여부 결정

---

## 관련 이슈

* Refs #257
* Refs #263
* Refs #265
* Refs #267
