### PR TITLE
[Feature] 홈 화면 가로모드 레이아웃 대응

### DIFF
--- a/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
+++ b/app/src/main/java/com/team/yeogibeoryeo/navigation/YeogiBeoryeoNavHost.kt
@@ -67,12 +67,19 @@ fun YeogiBeoryeoNavHost(
     val isItemDetailScreen = currentDestination?.hasRoute<ItemGuideDetailRoute>() == true
     val isUsefulGuideScreen = currentDestination?.hasRoute<ItemUsefulGuideRoute>() == true
     val isSettingsDetailScreen = currentDestination?.hasRoute<SettingsDetailRoute>() == true
+    var isItemSearchBottomBarScrollEnabled by remember { mutableStateOf(false) }
     val hidesBottomBarOnScroll =
-        isItemSearchScreen || isItemDetailScreen || isUsefulGuideScreen || isSettingsDetailScreen
+        (isItemSearchScreen && isItemSearchBottomBarScrollEnabled) ||
+            isItemDetailScreen ||
+            isUsefulGuideScreen ||
+            isSettingsDetailScreen
     var isBottomBarVisible by remember { mutableStateOf(true) }
 
     LaunchedEffect(currentBackStackEntry) {
         isBottomBarVisible = true
+        if (!isItemSearchScreen) {
+            isItemSearchBottomBarScrollEnabled = false
+        }
     }
 
     Scaffold(
@@ -216,6 +223,11 @@ fun YeogiBeoryeoNavHost(
                     onBottomBarVisibilityChanged = { isVisible ->
                         if (isItemSearchScreen) {
                             isBottomBarVisible = isVisible
+                        }
+                    },
+                    onItemSearchBottomBarScrollEnabledChanged = { isEnabled ->
+                        if (isItemSearchScreen) {
+                            isItemSearchBottomBarScrollEnabled = isEnabled
                         }
                     },
                 )

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchInitialContent.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.team.yeogibeoryeo.presentation.R
 import com.team.yeogibeoryeo.presentation.common.components.AppTopBarDefaults
+import com.team.yeogibeoryeo.presentation.common.effects.BottomBarVisibilityOnScrollEffect
 import com.team.yeogibeoryeo.presentation.common.text.KoreanLineBreakText
 import com.team.yeogibeoryeo.presentation.search.components.HomeRegionalGuideSummaryBanner
 import com.team.yeogibeoryeo.presentation.search.components.ItemSearchBar
@@ -74,6 +75,8 @@ fun ItemSearchInitialContent(
     modifier: Modifier = Modifier,
     onRegionalGuideSummaryClick: (String) -> Unit = {},
     onRegionalGuideSummaryRetryClick: () -> Unit = {},
+    onBottomBarVisibilityChanged: (Boolean) -> Unit = {},
+    onItemSearchBottomBarScrollEnabledChanged: (Boolean) -> Unit = {},
 ) {
     var viewportBottomInRootPx by rememberSaveable { mutableIntStateOf(0) }
     var maxSelectedQuickCategoryCount by rememberSaveable { mutableIntStateOf(quickCategories.size) }
@@ -102,7 +105,24 @@ fun ItemSearchInitialContent(
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background),
     ) {
-        val metrics = itemSearchScreenMetrics(maxWidth = maxWidth)
+        val metrics = itemSearchScreenMetrics(
+            maxWidth = maxWidth,
+            maxHeight = maxHeight,
+        )
+
+        LaunchedEffect(metrics.isCompactLandscape) {
+            onItemSearchBottomBarScrollEnabledChanged(metrics.isCompactLandscape)
+            if (!metrics.isCompactLandscape) {
+                onBottomBarVisibilityChanged(true)
+            }
+        }
+
+        if (metrics.isCompactLandscape) {
+            BottomBarVisibilityOnScrollEffect(
+                listState = listState,
+                onBottomBarVisibilityChanged = onBottomBarVisibilityChanged,
+            )
+        }
 
         LazyColumn(
             state = listState,
@@ -145,6 +165,7 @@ fun ItemSearchInitialContent(
                         guides = itemUsefulGuideContents,
                         onGuideClick = onUsefulGuideClick,
                         contentPadding = PaddingValues(horizontal = metrics.horizontalPadding),
+                        itemWidthFraction = metrics.usefulGuideBannerWidthFraction,
                     )
                 }
             }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchLayoutDefaults.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchLayoutDefaults.kt
@@ -45,6 +45,7 @@ internal object ItemSearchSizeDefaults {
 
 internal object ItemSearchFractionDefaults {
     const val USEFUL_GUIDE_BANNER_WIDTH = 0.94f
+    const val USEFUL_GUIDE_LANDSCAPE_BANNER_WIDTH = 0.56f
 }
 
 internal object ItemSearchAlphaDefaults {

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreen.kt
@@ -70,6 +70,7 @@ fun ItemSearchRoute(
     modifier: Modifier = Modifier,
     initialQuery: String? = null,
     onBottomBarVisibilityChanged: (Boolean) -> Unit = {},
+    onItemSearchBottomBarScrollEnabledChanged: (Boolean) -> Unit = {},
     viewModel: ItemSearchViewModel = hiltViewModel(),
     regionalGuideSummaryViewModel: HomeRegionalGuideSummaryViewModel = hiltViewModel(),
 ) {
@@ -129,6 +130,7 @@ fun ItemSearchRoute(
         searchResultListState = searchResultListState,
         categoryListState = categoryListState,
         onBottomBarVisibilityChanged = onBottomBarVisibilityChanged,
+        onItemSearchBottomBarScrollEnabledChanged = onItemSearchBottomBarScrollEnabledChanged,
         modifier = modifier,
     )
 }
@@ -155,14 +157,22 @@ fun ItemSearchScreen(
     searchResultListState: LazyListState = rememberLazyListState(),
     categoryListState: LazyListState = rememberLazyListState(),
     onBottomBarVisibilityChanged: (Boolean) -> Unit = {},
+    onItemSearchBottomBarScrollEnabledChanged: (Boolean) -> Unit = {},
 ) {
-    LaunchedEffect(uiState.hasSearched, uiState.guides.isEmpty()) {
-        if (!uiState.hasSearched || uiState.guides.isEmpty()) {
+    val showsInitialContent =
+        !uiState.hasSearched && !uiState.isLoading && uiState.errorMessageResId == null
+    val showsSearchResults = uiState.guides.isNotEmpty()
+
+    LaunchedEffect(showsInitialContent, showsSearchResults) {
+        if (!showsInitialContent) {
+            onItemSearchBottomBarScrollEnabledChanged(showsSearchResults)
+        }
+        if (!showsSearchResults) {
             onBottomBarVisibilityChanged(true)
         }
     }
 
-    if (!uiState.hasSearched && !uiState.isLoading && uiState.errorMessageResId == null) {
+    if (showsInitialContent) {
         ItemSearchInitialContent(
             query = uiState.query,
             onQueryChange = onQueryChange,
@@ -187,6 +197,8 @@ fun ItemSearchScreen(
             onSettingsClick = onSettingsClick,
             listState = categoryListState,
             modifier = modifier.statusBarsPadding(),
+            onBottomBarVisibilityChanged = onBottomBarVisibilityChanged,
+            onItemSearchBottomBarScrollEnabledChanged = onItemSearchBottomBarScrollEnabledChanged,
         )
         return
     }
@@ -197,7 +209,10 @@ fun ItemSearchScreen(
             .background(MaterialTheme.colorScheme.background),
     ) {
         val spacing = ItemSearchLayoutDefaults.spacing
-        val metrics = itemSearchScreenMetrics(maxWidth = maxWidth)
+        val metrics = itemSearchScreenMetrics(
+            maxWidth = maxWidth,
+            maxHeight = maxHeight,
+        )
         val density = LocalDensity.current
         val coroutineScope = rememberCoroutineScope()
 

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreenMetrics.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreenMetrics.kt
@@ -8,19 +8,58 @@ import com.team.yeogibeoryeo.presentation.common.components.AppTopBarDefaults
 @Composable
 internal fun itemSearchScreenMetrics(
     maxWidth: Dp,
+    maxHeight: Dp,
 ): ItemSearchScreenMetrics {
+    val spec = itemSearchScreenMetricsSpec(
+        maxWidth = maxWidth,
+        maxHeight = maxHeight,
+    )
+
+    return ItemSearchScreenMetrics(
+        horizontalPadding = spec.horizontalPadding,
+        topPadding = spec.topPadding,
+        homeHeaderTopPadding = spec.homeHeaderTopPadding,
+        screenVerticalSpace = spec.screenVerticalSpace,
+        sectionVerticalSpace = spec.sectionVerticalSpace,
+        listBottomPadding = spec.listBottomPadding,
+        searchIconSize = spec.searchIconSize,
+        usefulGuideBannerWidthFraction = spec.usefulGuideBannerWidthFraction,
+        isCompactLandscape = spec.isCompactLandscape,
+    )
+}
+
+internal fun itemSearchScreenMetricsSpec(
+    maxWidth: Dp,
+    maxHeight: Dp,
+): ItemSearchScreenMetricsSpec {
     val spacing = ItemSearchLayoutDefaults.spacing
     val size = ItemSearchLayoutDefaults.size
     val isNarrowPhone = maxWidth <= ItemSearchScreenBreakpoints.NarrowPhoneWidth
+    val isCompactLandscape =
+        maxWidth > maxHeight && maxHeight <= ItemSearchScreenBreakpoints.CompactLandscapeHeight
 
-    return ItemSearchScreenMetrics(
+    return ItemSearchScreenMetricsSpec(
         horizontalPadding = if (isNarrowPhone) spacing.md else spacing.xl,
-        topPadding = if (isNarrowPhone) spacing.lg else spacing.xl,
+        topPadding = when {
+            isCompactLandscape -> spacing.md
+            isNarrowPhone -> spacing.lg
+            else -> spacing.xl
+        },
         homeHeaderTopPadding = (AppTopBarDefaults.height - AppTopBarDefaults.buttonSize) / 2f,
-        screenVerticalSpace = if (isNarrowPhone) spacing.lg else spacing.xl,
+        screenVerticalSpace = when {
+            isCompactLandscape -> spacing.md
+            isNarrowPhone -> spacing.lg
+            else -> spacing.xl
+        },
         sectionVerticalSpace = spacing.md,
         listBottomPadding = spacing.xl,
         searchIconSize = if (isNarrowPhone) size.iconStandard else size.iconSmall,
+        usefulGuideBannerWidthFraction = if (isCompactLandscape) {
+            ItemSearchLayoutDefaults.fraction.USEFUL_GUIDE_LANDSCAPE_BANNER_WIDTH
+        } else {
+            ItemSearchLayoutDefaults.fraction.USEFUL_GUIDE_BANNER_WIDTH
+        },
+        isCompactLandscape = isCompactLandscape,
     )
 }
 
@@ -32,8 +71,23 @@ internal data class ItemSearchScreenMetrics(
     val sectionVerticalSpace: Dp,
     val listBottomPadding: Dp,
     val searchIconSize: Dp,
+    val usefulGuideBannerWidthFraction: Float,
+    val isCompactLandscape: Boolean,
+)
+
+internal data class ItemSearchScreenMetricsSpec(
+    val horizontalPadding: Dp,
+    val topPadding: Dp,
+    val homeHeaderTopPadding: Dp,
+    val screenVerticalSpace: Dp,
+    val sectionVerticalSpace: Dp,
+    val listBottomPadding: Dp,
+    val searchIconSize: Dp,
+    val usefulGuideBannerWidthFraction: Float,
+    val isCompactLandscape: Boolean,
 )
 
 private object ItemSearchScreenBreakpoints {
     val NarrowPhoneWidth = 384.dp
+    val CompactLandscapeHeight = 480.dp
 }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemUsefulGuideBannerRow.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/ItemUsefulGuideBannerRow.kt
@@ -50,10 +50,10 @@ fun ItemUsefulGuideBannerRow(
     onGuideClick: (ItemUsefulGuideContent) -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
+    itemWidthFraction: Float = ItemSearchLayoutDefaults.fraction.USEFUL_GUIDE_BANNER_WIDTH,
 ) {
     val spacing = ItemSearchLayoutDefaults.spacing
     val size = ItemSearchLayoutDefaults.size
-    val fraction = ItemSearchLayoutDefaults.fraction
     val listState = rememberLazyListState()
     val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
     val selectedIndex by remember {
@@ -85,7 +85,7 @@ fun ItemUsefulGuideBannerRow(
                     guide = guide,
                     onClick = { onGuideClick(guide) },
                     modifier = Modifier
-                        .fillParentMaxWidth(fraction.USEFUL_GUIDE_BANNER_WIDTH)
+                        .fillParentMaxWidth(itemWidthFraction)
                         .height(size.usefulGuideBannerCardHeight),
                 )
             }

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridCollapseLayout.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridCollapseLayout.kt
@@ -25,11 +25,15 @@ internal fun quickCategoryGridCollapseLayout(
         rowSpacingPx = rowSpacingPx,
     )
     val measuredCollapsedItemCount = visibleRowCount * columnCount
+    val minCollapsedItemCount = quickCategoryMinCollapsedItemCount(columnCount)
+    val validFixedCollapsedItemCount = fixedCollapsedItemCount.takeIf {
+        it >= minCollapsedItemCount && it % columnCount == 0
+    }
     val collapsedItemCount =
-        fixedCollapsedItemCount.takeIf { it > 0 } ?: measuredCollapsedItemCount
+        validFixedCollapsedItemCount ?: measuredCollapsedItemCount
     val needsMoreToggle = categoryCount > collapsedItemCount
     val needsCollapseToggle =
-        categoryCount > quickCategoryMinCollapsedItemCount(columnCount)
+        categoryCount > minCollapsedItemCount
     val showsMore = !isExpanded && needsMoreToggle
 
     return QuickCategoryGridCollapseLayout(

--- a/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridMetrics.kt
+++ b/presentation/src/main/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridMetrics.kt
@@ -39,7 +39,7 @@ internal fun quickCategoryGridMetricsSpec(
 ): QuickCategoryGridMetricsSpec {
     val spacing = ItemSearchLayoutDefaults.spacing
     val size = ItemSearchLayoutDefaults.size
-    val useLargeFontLayout = fontScale >= QuickCategoryGridBreakpoints.LargeFontScale
+    val useLargeFontLayout = fontScale >= QuickCategoryGridBreakpoints.LARGE_FONT_SCALE
     val useFourColumnCompactVisuals =
         !useLargeFontLayout &&
             maxWidth >= QuickCategoryGridBreakpoints.NarrowContentWidth &&
@@ -105,11 +105,20 @@ internal fun quickCategoryGridMetricsSpec(
     }
     val maxColumnCount =
         if (useNarrowLargeFontLayout) {
-            QuickCategoryGridDefaults.NarrowLargeFontMaxColumnCount
+            QuickCategoryGridDefaults.NARROW_LARGE_FONT_MAX_COLUMN_COUNT
+        } else if (
+            useLargeFontLayout &&
+            maxWidth >= QuickCategoryGridBreakpoints.MediumLandscapeContentWidth
+        ) {
+            QuickCategoryGridDefaults.LANDSCAPE_MAX_COLUMN_COUNT
         } else if (useLargeFontLayout) {
-            QuickCategoryGridDefaults.LargeFontMaxColumnCount
+            QuickCategoryGridDefaults.LARGE_FONT_MAX_COLUMN_COUNT
+        } else if (maxWidth >= QuickCategoryGridBreakpoints.LandscapeContentWidth) {
+            QuickCategoryGridDefaults.LANDSCAPE_MAX_COLUMN_COUNT
+        } else if (maxWidth >= QuickCategoryGridBreakpoints.MediumLandscapeContentWidth) {
+            QuickCategoryGridDefaults.MEDIUM_LANDSCAPE_MAX_COLUMN_COUNT
         } else {
-            QuickCategoryGridDefaults.MaxColumnCount
+            QuickCategoryGridDefaults.MAX_COLUMN_COUNT
         }
     val columnCount =
         (maxWidth / cellSize)
@@ -160,9 +169,11 @@ internal val LocalQuickCategoryGridMetrics = compositionLocalOf<QuickCategoryGri
 }
 
 private object QuickCategoryGridDefaults {
-    const val MaxColumnCount = 4
-    const val NarrowLargeFontMaxColumnCount = 2
-    const val LargeFontMaxColumnCount = 3
+    const val MAX_COLUMN_COUNT = 4
+    const val MEDIUM_LANDSCAPE_MAX_COLUMN_COUNT = 5
+    const val LANDSCAPE_MAX_COLUMN_COUNT = 6
+    const val NARROW_LARGE_FONT_MAX_COLUMN_COUNT = 2
+    const val LARGE_FONT_MAX_COLUMN_COUNT = 3
     val NarrowLargeFontCellSize = 128.dp
     val WideLargeFontCellSize = 112.dp
     val NarrowCellSize = 80.dp
@@ -187,6 +198,8 @@ private object QuickCategoryGridBreakpoints {
     val WidePhoneContentWidth = 336.dp
     val LargePhoneContentWidth = 352.dp
     val ExpandedWidePhoneContentWidth = 360.dp
+    val MediumLandscapeContentWidth = 450.dp
+    val LandscapeContentWidth = 560.dp
     val WideLargeFontContentWidth = 352.dp
-    const val LargeFontScale = 1.3f
+    const val LARGE_FONT_SCALE = 1.3f
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreenMetricsTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/ItemSearchScreenMetricsTest.kt
@@ -1,0 +1,52 @@
+package com.team.yeogibeoryeo.presentation.search
+
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ItemSearchScreenMetricsTest {
+    @Test
+    fun `높이가 480dp 이하인 가로 화면은 compact landscape로 본다`() {
+        listOf(
+            480.dp to 320.dp,
+            568.dp to 320.dp,
+            640.dp to 360.dp,
+            800.dp to 480.dp,
+        ).forEach { (maxWidth, maxHeight) ->
+            val metrics = itemSearchScreenMetricsSpec(
+                maxWidth = maxWidth,
+                maxHeight = maxHeight,
+            )
+
+            assertTrue(metrics.isCompactLandscape)
+            assertEquals(
+                ItemSearchLayoutDefaults.fraction.USEFUL_GUIDE_LANDSCAPE_BANNER_WIDTH,
+                metrics.usefulGuideBannerWidthFraction,
+            )
+            assertEquals(ItemSearchLayoutDefaults.spacing.md, metrics.screenVerticalSpace)
+        }
+    }
+
+    @Test
+    fun `세로 화면이나 높이가 480dp보다 큰 가로 화면은 일반 간격을 유지한다`() {
+        listOf(
+            Triple(360.dp, 640.dp, ItemSearchLayoutDefaults.spacing.lg),
+            Triple(800.dp, 481.dp, ItemSearchLayoutDefaults.spacing.xl),
+            Triple(900.dp, 600.dp, ItemSearchLayoutDefaults.spacing.xl),
+        ).forEach { (maxWidth, maxHeight, expectedScreenVerticalSpace) ->
+            val metrics = itemSearchScreenMetricsSpec(
+                maxWidth = maxWidth,
+                maxHeight = maxHeight,
+            )
+
+            assertFalse(metrics.isCompactLandscape)
+            assertEquals(
+                ItemSearchLayoutDefaults.fraction.USEFUL_GUIDE_BANNER_WIDTH,
+                metrics.usefulGuideBannerWidthFraction,
+            )
+            assertEquals(expectedScreenVerticalSpace, metrics.screenVerticalSpace)
+        }
+    }
+}

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridCollapseLayoutTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridCollapseLayoutTest.kt
@@ -10,6 +10,8 @@ class QuickCategoryGridCollapseLayoutTest {
             2 to 8,
             3 to 9,
             4 to 8,
+            5 to 10,
+            6 to 12,
         ).forEach { (columnCount, expectedCollapsedItemCount) ->
             val layout = quickCategoryGridCollapseLayout(
                 categoryCount = 20,
@@ -112,6 +114,20 @@ class QuickCategoryGridCollapseLayoutTest {
 
         assertEquals(8, layout.collapsedItemCount)
         assertEquals(7, layout.visibleCategoryCount)
+        assertEquals(true, layout.showsMore)
+    }
+
+    @Test
+    fun `고정된 접힘 슬롯이 현재 열 수와 맞지 않으면 다시 계산한다`() {
+        val layout = quickCategoryGridCollapseLayout(
+            categoryCount = 20,
+            columnCount = 6,
+            fixedCollapsedItemCount = 8,
+            isExpanded = false,
+        )
+
+        assertEquals(12, layout.collapsedItemCount)
+        assertEquals(11, layout.visibleCategoryCount)
         assertEquals(true, layout.showsMore)
     }
 }

--- a/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridMetricsTest.kt
+++ b/presentation/src/test/java/com/team/yeogibeoryeo/presentation/search/components/QuickCategoryGridMetricsTest.kt
@@ -76,6 +76,24 @@ class QuickCategoryGridMetricsTest {
     }
 
     @Test
+    fun `일반 글자 크기에서는 가로모드 폭에 맞춰 최대 6열까지 늘린다`() {
+        mapOf(
+            449.dp to 4,
+            450.dp to 5,
+            559.dp to 5,
+            560.dp to 6,
+            800.dp to 6,
+        ).forEach { (maxWidth, expectedColumnCount) ->
+            val metrics = quickCategoryGridMetricsSpec(
+                maxWidth = maxWidth,
+                fontScale = 1.0f,
+            )
+
+            assertEquals(expectedColumnCount, metrics.columnCount)
+        }
+    }
+
+    @Test
     fun `큰 글자 크기에서는 font scale 1_3부터 최대 3열로 제한한다`() {
         val normalFont = quickCategoryGridMetricsSpec(
             maxWidth = 320.dp,
@@ -124,5 +142,24 @@ class QuickCategoryGridMetricsTest {
 
         assertEquals(3, wideLargeFont.columnCount)
         assertEquals(112.dp, wideLargeFont.cellSize)
+    }
+
+    @Test
+    fun `큰 글자 크기에서도 가로모드 폭에 맞춰 최대 6열까지 늘린다`() {
+        listOf(1.3f, 1.5f).forEach { fontScale ->
+            mapOf(
+                449.dp to 3,
+                450.dp to 4,
+                560.dp to 5,
+                800.dp to 6,
+            ).forEach { (maxWidth, expectedColumnCount) ->
+                val metrics = quickCategoryGridMetricsSpec(
+                    maxWidth = maxWidth,
+                    fontScale = fontScale,
+                )
+
+                assertEquals(expectedColumnCount, metrics.columnCount)
+            }
+        }
     }
 }


### PR DESCRIPTION
## 작업 내용

- 홈 화면의 compact landscape 기준을 추가해 세로 간격과 안내 배너 폭을 조정했습니다.
- 빠른 분류 그리드가 가로 화면 폭에 따라 5열, 6열까지 노출되도록 확장했습니다.
- 홈 화면 compact landscape에서 아래로 스크롤하면 bottom navigation이 숨겨지고, 위로 스크롤하면 다시 보이도록 연결했습니다.
- 화면 회전 뒤 `더보기`/`접기`가 이전 열 수 기준으로 어긋나지 않도록 접힘 슬롯을 현재 열 수 기준으로 다시 계산했습니다.

## 변경 이유

가로모드에서는 홈 화면의 세로 공간이 줄어들어 기존 세로모드 기준 간격과 4열 그리드가 화면을 비효율적으로 사용했습니다. 기기별 가로 폭 차이를 고려해 실제 content width 기준으로 노출 열 수를 정하고, height가 낮은 compact landscape에서만 bottom navigation 숨김 동작을 적용했습니다.

## 주요 변경 사항

- `ItemSearchScreenMetrics`에 `maxHeight` 기반 compact landscape 판단 추가
- 안내 배너 가로모드 카드 폭 조정
- 빠른 분류 그리드 최대 열 수를 4열에서 5열/6열까지 adaptive 확장
- 가로모드 홈 화면에서 `BottomBarVisibilityOnScrollEffect` 재사용
- `fixedCollapsedItemCount`가 현재 열 수와 맞지 않으면 무시하고 재계산
- layout metrics와 더보기/접기 회귀 테스트 추가

## 확인 사항

### 가로모드 matrix

가로모드는 viewport width와 font scale 조합을 나눠 홈 그리드의 접힘 상태와 `더보기` 위치를 확인했습니다.
아래 스크린샷은 각 조건에서 실제 화면에 보이는 상태입니다.

| Viewport(dp) | font scale 1.0 | font scale 1.3 | font scale 1.5 |
|---|---|---|---|
| 568x320 | <img width="220" alt="landscape_568x320_font1_0_grid" src="https://github.com/user-attachments/assets/ed2dfabe-0ac1-4a14-9213-bcc9ff50ba59" /> | <img width="220" alt="landscape_568x320_font1_3_grid" src="https://github.com/user-attachments/assets/d460f1e5-0063-4498-a08b-b3828e026991" /> | <img width="220" alt="landscape_568x320_font1_5_grid" src="https://github.com/user-attachments/assets/de5afdcc-a47e-43ef-9946-85e4fe298326" /> |
| 640x360 | <img width="220" alt="landscape_640x360_font1_0_grid" src="https://github.com/user-attachments/assets/f1095312-5c02-4613-acf4-bc053d867159" /> | <img width="220" alt="landscape_640x360_font1_3_grid" src="https://github.com/user-attachments/assets/be1df5eb-c4fa-49cd-a712-7f274709a669" /> | <img width="220" alt="landscape_640x360_font1_5_grid" src="https://github.com/user-attachments/assets/bade10bd-e444-45ec-a5a5-9cd464312dd0" /> |
| 800x480 | <img width="220" alt="landscape_800x480_font1_0_grid" src="https://github.com/user-attachments/assets/1208ee9a-d5a6-42fe-b51c-56e02bc9dc3f" /> | <img width="220" alt="landscape_800x480_font1_3_grid" src="https://github.com/user-attachments/assets/c7253548-b77b-4c95-83be-e0ed0c622863" /> | <img width="220" alt="landscape_800x480_font1_5_grid" src="https://github.com/user-attachments/assets/74ee1c81-2ed0-4da7-8128-68d32fa082ef" /> |
| 915x412 | <img width="220" alt="landscape_915x412_font1_0_grid" src="https://github.com/user-attachments/assets/e04a72e8-065c-444a-bfa2-1ddf12ebf657" /> | <img width="220" alt="landscape_915x412_font1_3_grid" src="https://github.com/user-attachments/assets/fe9e4f96-d8c6-4a15-83f4-3109fb3a4d9d" /> | <img width="220" alt="landscape_915x412_font1_5_grid" src="https://github.com/user-attachments/assets/a8e3c109-7bcd-413c-acae-6475b3045a35" /> |

- 화면에는 접힘 상태의 카테고리와 `더보기`가 함께 보입니다.
- 열 수 정책은 screenshot의 보이는 카테고리 개수만으로 판단하지 않고 `QuickCategoryGridMetricsTest`에서 경계값으로 확인했습니다.
- 회전 뒤 저장된 `fixedCollapsedItemCount`가 현재 열 수와 맞지 않으면 현재 viewport 기준으로 다시 계산합니다.

### 세로 모드

<p align="center">
  <img src="https://github.com/user-attachments/assets/8de4ce12-a1dc-4cf0-b3a2-3518b522b57c" width="280" />
</p>

### 가로 모드

#### 홈 상단 표시

<p align="center">
  <img src="https://github.com/user-attachments/assets/ac8fd23c-09ac-4395-b0d4-204b9c7af895" width="900" />
</p>

#### 아래로 스크롤 후 Bottom Navigation 숨김

<p align="center">
  <img src="https://github.com/user-attachments/assets/dfe14515-1b48-4da0-b4dd-e022e066eb21" width="900" />
</p>

#### 위로 스크롤 후 Bottom Navigation 복귀

<p align="center">
  <img src="https://github.com/user-attachments/assets/a7cc0f5f-ec64-4d64-8207-901c13fea178" width="900" />
</p>

#### 더보기 확장

<p align="center">
  <img src="https://github.com/user-attachments/assets/ac1e2f37-b89f-441e-9017-9a6182e91e41" width="900" />
</p>

#### 접기 버튼 노출

<p align="center">
  <img src="https://github.com/user-attachments/assets/88ec4a9d-5c28-4f14-8d21-92dcf4cb817a" width="900" />
</p>

#### 접기 후 접힘 상태 복귀

<p align="center">
  <img src="https://github.com/user-attachments/assets/690965ef-c8bc-4820-924b-0483698cf6c0" width="900" />
</p>

## 테스트

- `./gradlew.bat clean :presentation:compileDebugKotlin :app:compileDebugKotlin --no-build-cache --no-configuration-cache`
- `./gradlew.bat :presentation:testDebugUnitTest --tests "com.team.yeogibeoryeo.presentation.search.components.QuickCategoryGridCollapseLayoutTest" --tests "com.team.yeogibeoryeo.presentation.search.components.QuickCategoryGridMetricsTest" --tests "com.team.yeogibeoryeo.presentation.search.ItemSearchScreenMetricsTest" --no-build-cache --no-configuration-cache`
- Pixel 9 Pro Emulator 대표 화면 수동 QA

## 관련 이슈

Related #261



