### PR TITLE
fix: 지역 가이드 광주광역시 API 시도명 alias 정규화

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionNormalizer.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/RegionNormalizer.kt
@@ -1,6 +1,7 @@
 package com.team.yeogibeoryeo.data.region
 
 import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.region.model.RegionSidoAliasPolicy
 
 /**
  * 행정구역 명칭을 배출 가이드 API(/info) 표준 포맷으로 보정하는 유틸리티
@@ -25,6 +26,7 @@ object RegionNormalizer {
         "전북특별자치도",
         "전라북도",
         "전라남도",
+        RegionSidoAliasPolicy.GWANGJU_JEONNAM_INTEGRATED_SIDO,
         "경상북도",
         "경상남도",
         "제주특별자치도",

--- a/data/src/main/java/com/team/yeogibeoryeo/data/region/parser/RegionAddressParser.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/region/parser/RegionAddressParser.kt
@@ -2,6 +2,7 @@ package com.team.yeogibeoryeo.data.region.parser
 
 import com.team.yeogibeoryeo.data.region.RegionNormalizer
 import com.team.yeogibeoryeo.domain.region.model.Region
+import com.team.yeogibeoryeo.domain.region.model.RegionSidoAliasPolicy
 import javax.inject.Inject
 
 class RegionAddressParser @Inject constructor() {
@@ -52,7 +53,9 @@ class RegionAddressParser @Inject constructor() {
             eupmyeondong = eupmyeondong ?: normalizedAddress.extractParenthesizedEupmyeondong()
         )
 
-        return RegionNormalizer.normalize(parsedRegion)
+        return RegionSidoAliasPolicy.normalizeInputRegion(
+            RegionNormalizer.normalize(parsedRegion)
+        )
     }
 
     private fun String.cleanRegionToken(): String =
@@ -74,7 +77,9 @@ class RegionAddressParser @Inject constructor() {
         endsWith("시") || endsWith("군") || endsWith("구")
 
     private fun String.isEupmyeondongName(): Boolean =
-        endsWith("읍") || endsWith("면") || endsWith("동")
+        !contains("(") &&
+            !contains(")") &&
+            (endsWith("읍") || endsWith("면") || endsWith("동"))
 
     companion object {
         private val WHITESPACE_REGEX = "\\s+".toRegex()

--- a/data/src/test/java/com/team/yeogibeoryeo/data/region/parser/RegionAddressParserTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/region/parser/RegionAddressParserTest.kt
@@ -114,6 +114,39 @@ class RegionAddressParserTest {
     }
 
     @Test
+    fun `전남광주통합특별시 광주 5개 구 주소는 광주광역시로 정규화된다`() {
+        val result = parser.parse(
+            "전남광주통합특별시 서구 풍금로151번길 14"
+        )
+
+        assertEquals("광주광역시", result.sido)
+        assertEquals("서구", result.sigungu)
+        assertNull(result.eupmyeondong)
+    }
+
+    @Test
+    fun `도로명 주소의 건물번호와 괄호 안 동명이 붙어 있으면 괄호 안 동명만 추출한다`() {
+        val result = parser.parse(
+            "전남광주통합특별시 서구 풍금로151번길 14(금호동)"
+        )
+
+        assertEquals("광주광역시", result.sido)
+        assertEquals("서구", result.sigungu)
+        assertEquals("금호동", result.eupmyeondong)
+    }
+
+    @Test
+    fun `전남광주통합특별시 전남 시군 주소는 전라남도로 정규화된다`() {
+        val result = parser.parse(
+            "전남광주통합특별시 고흥군 고흥읍"
+        )
+
+        assertEquals("전라남도", result.sido)
+        assertEquals("고흥군", result.sigungu)
+        assertEquals("고흥읍", result.eupmyeondong)
+    }
+
+    @Test
     fun `과거 시도명은 현재 공식 시도명으로 정규화된다`() {
         val result = parser.parse(
             "강원도 춘천시 후평동"

--- a/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImplTest.kt
+++ b/data/src/test/java/com/team/yeogibeoryeo/data/regionalguide/repository/RegionalDisposalGuideRepositoryImplTest.kt
@@ -100,6 +100,32 @@ class RegionalDisposalGuideRepositoryImplTest {
     }
 
     @Test
+    fun `repository는 API 시도명 원본값을 정규화하지 않는다`() = runBlocking {
+        fakeDataSource.mockResult = Result.success(
+            listOf(
+                RegionalGuideItemDto(
+                    sidoName = "전남광주통합특별시",
+                    sigunguName = "광산구",
+                    dongName = "광산구 전체"
+                )
+            )
+        )
+
+        val result = repository.getRegionalDisposalGuideCandidates(
+            RegionalGuideQuery(
+                displayRegion = Region(sido = "광주광역시", sigungu = "광산구"),
+                sigunguQuery = "광산구"
+            )
+        )
+
+        val guide = result.getOrThrow().single()
+
+        assertEquals("전남광주통합특별시", guide.region.sido)
+        assertEquals("광산구", guide.region.sigungu)
+        assertEquals("광산구 전체", guide.targetRegionName)
+    }
+
+    @Test
     fun `원격 데이터 소스 실패는 Result failure로 유지한다`() = runBlocking {
         fakeDataSource.mockResult = Result.failure(IllegalStateException("network error"))
 

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/region/model/RegionSidoAliasPolicy.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/region/model/RegionSidoAliasPolicy.kt
@@ -1,0 +1,59 @@
+package com.team.yeogibeoryeo.domain.region.model
+
+object RegionSidoAliasPolicy {
+
+    fun normalizeInputRegion(region: Region): Region {
+        val normalizedSido = normalizeSidoForInput(
+            sido = region.sido,
+            sigungu = region.sigungu,
+        )
+
+        return region.copy(sido = normalizedSido ?: region.sido)
+    }
+
+    fun normalizeSidoForInput(
+        sido: String?,
+        sigungu: String?,
+    ): String? {
+        val normalizedSido = sido.normalizeRegionName() ?: return null
+        val normalizedSigungu = sigungu.normalizeRegionName()
+
+        return when {
+            normalizedSido != GWANGJU_JEONNAM_INTEGRATED_SIDO -> normalizedSido
+            normalizedSigungu in GWANGJU_SIGUNGU_NAMES -> GWANGJU_SIDO
+            normalizedSigungu != null -> JEONNAM_SIDO
+            else -> normalizedSido
+        }
+    }
+
+    fun isSameSido(
+        requestedSido: String?,
+        candidateSido: String?,
+        candidateSigungu: String?,
+    ): Boolean {
+        val requested = requestedSido.normalizeRegionName() ?: return true
+        val candidate = normalizeSidoForInput(
+            sido = candidateSido,
+            sigungu = candidateSigungu,
+        ) ?: return false
+
+        return requested == candidate
+    }
+
+    private fun String?.normalizeRegionName(): String? =
+        this
+            ?.trim()
+            ?.takeIf { value -> value.isNotBlank() }
+
+    private const val GWANGJU_SIDO = "광주광역시"
+    private const val JEONNAM_SIDO = "전라남도"
+    const val GWANGJU_JEONNAM_INTEGRATED_SIDO = "전남광주통합특별시"
+
+    private val GWANGJU_SIGUNGU_NAMES = setOf(
+        "동구",
+        "서구",
+        "남구",
+        "북구",
+        "광산구",
+    )
+}

--- a/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
+++ b/domain/src/main/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCase.kt
@@ -5,6 +5,7 @@ import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalDisposalGuide
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideCandidateLookupReason
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideLookupResult
 import com.team.yeogibeoryeo.domain.regionalguide.model.RegionalGuideQuery
+import com.team.yeogibeoryeo.domain.region.model.RegionSidoAliasPolicy
 import javax.inject.Inject
 
 class SelectRegionalGuideCandidateUseCase @Inject constructor() {
@@ -70,7 +71,13 @@ class SelectRegionalGuideCandidateUseCase @Inject constructor() {
     ): List<RegionalDisposalGuide> {
         if (sido.isNullOrBlank()) return this
 
-        return filter { guide -> guide.region.sido == sido }
+        return filter { guide ->
+            RegionSidoAliasPolicy.isSameSido(
+                requestedSido = sido,
+                candidateSido = guide.region.sido,
+                candidateSigungu = guide.region.sigungu,
+            )
+        }
     }
 
     private fun List<RegionalDisposalGuide>.filterBySigungu(

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/region/model/RegionSidoAliasPolicyTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/region/model/RegionSidoAliasPolicyTest.kt
@@ -1,0 +1,88 @@
+package com.team.yeogibeoryeo.domain.region.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RegionSidoAliasPolicyTest {
+
+    @Test
+    fun `전남광주통합특별시와 광주 5개 구 입력은 광주광역시로 정규화된다`() {
+        val gwangjuSigunguNames = listOf("동구", "서구", "남구", "북구", "광산구")
+
+        gwangjuSigunguNames.forEach { sigungu ->
+            val result = RegionSidoAliasPolicy.normalizeSidoForInput(
+                sido = "전남광주통합특별시",
+                sigungu = sigungu,
+            )
+
+            assertEquals("광주광역시", result)
+        }
+    }
+
+    @Test
+    fun `전남광주통합특별시와 전남 시군 입력은 전라남도로 정규화된다`() {
+        val result = RegionSidoAliasPolicy.normalizeSidoForInput(
+            sido = "전남광주통합특별시",
+            sigungu = "고흥군",
+        )
+
+        assertEquals("전라남도", result)
+    }
+
+    @Test
+    fun `광주광역시는 전남광주통합특별시의 광주 5개 구와 같은 시도로 비교된다`() {
+        val gwangjuSigunguNames = listOf("동구", "서구", "남구", "북구", "광산구")
+
+        gwangjuSigunguNames.forEach { sigungu ->
+            assertTrue(
+                RegionSidoAliasPolicy.isSameSido(
+                    requestedSido = "광주광역시",
+                    candidateSido = "전남광주통합특별시",
+                    candidateSigungu = sigungu,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `광주광역시는 전남광주통합특별시의 전남 시군과 같은 시도로 비교되지 않는다`() {
+        assertFalse(
+            RegionSidoAliasPolicy.isSameSido(
+                requestedSido = "광주광역시",
+                candidateSido = "전남광주통합특별시",
+                candidateSigungu = "고흥군",
+            )
+        )
+    }
+
+    @Test
+    fun `전라남도는 전남광주통합특별시의 전남 시군과 같은 시도로 비교된다`() {
+        assertTrue(
+            RegionSidoAliasPolicy.isSameSido(
+                requestedSido = "전라남도",
+                candidateSido = "전남광주통합특별시",
+                candidateSigungu = "고흥군",
+            )
+        )
+    }
+
+    @Test
+    fun `기존 동일 시도 비교는 유지된다`() {
+        assertTrue(
+            RegionSidoAliasPolicy.isSameSido(
+                requestedSido = "서울특별시",
+                candidateSido = "서울특별시",
+                candidateSigungu = "중구",
+            )
+        )
+        assertFalse(
+            RegionSidoAliasPolicy.isSameSido(
+                requestedSido = "서울특별시",
+                candidateSido = "대구광역시",
+                candidateSigungu = "중구",
+            )
+        )
+    }
+}

--- a/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
+++ b/domain/src/test/java/com/team/yeogibeoryeo/domain/regionalguide/usecase/SelectRegionalGuideCandidateUseCaseTest.kt
@@ -62,6 +62,102 @@ class SelectRegionalGuideDirectMatchUseCaseTest {
     }
 
     @Test
+    fun `광주광역시 선택값은 전남광주통합특별시 광주 후보를 필터링하지 않는다`() {
+        val result = useCase(
+            candidates = listOf(
+                regionalDisposalGuide(
+                    sido = "전남광주통합특별시",
+                    sigungu = "광산구",
+                    targetRegionName = "광산구 전체"
+                ),
+                regionalDisposalGuide(
+                    sido = "대구광역시",
+                    sigungu = "광산구",
+                    targetRegionName = "다른 시도 후보"
+                )
+            ),
+            query = regionalGuideQuery(
+                displayRegion = Region(sido = "광주광역시", sigungu = "광산구"),
+                sigunguQuery = "광산구"
+            )
+        )
+
+        val guide = (result as RegionalGuideLookupResult.Success).guide
+
+        assertEquals("광주광역시", guide.region.sido)
+        assertEquals("광산구", guide.region.sigungu)
+        assertEquals("광산구 전체", guide.targetRegionName)
+    }
+
+    @Test
+    fun `광주광역시 5개 구 선택값은 전남광주통합특별시 후보와 매칭된다`() {
+        val gwangjuSigunguNames = listOf("동구", "서구", "남구", "북구", "광산구")
+
+        gwangjuSigunguNames.forEach { sigungu ->
+            val result = useCase(
+                candidates = listOf(
+                    regionalDisposalGuide(
+                        sido = "전남광주통합특별시",
+                        sigungu = sigungu,
+                        targetRegionName = "$sigungu 전체"
+                    )
+                ),
+                query = regionalGuideQuery(
+                    displayRegion = Region(sido = "광주광역시", sigungu = sigungu),
+                    sigunguQuery = sigungu
+                )
+            )
+
+            val guide = (result as RegionalGuideLookupResult.Success).guide
+
+            assertEquals(sigungu, guide.region.sigungu)
+            assertEquals("$sigungu 전체", guide.targetRegionName)
+        }
+    }
+
+    @Test
+    fun `광주광역시 선택값은 전남광주통합특별시 전남 시군 후보를 선택하지 않는다`() {
+        val result = useCase(
+            candidates = listOf(
+                regionalDisposalGuide(
+                    sido = "전남광주통합특별시",
+                    sigungu = "고흥군",
+                    targetRegionName = "고흥군 전체"
+                )
+            ),
+            query = regionalGuideQuery(
+                displayRegion = Region(sido = "광주광역시", sigungu = "고흥군"),
+                sigunguQuery = "고흥군"
+            )
+        )
+
+        assertEquals(RegionalGuideLookupResult.CandidateNotFound, result)
+    }
+
+    @Test
+    fun `전라남도 선택값은 전남광주통합특별시 전남 시군 후보와 매칭된다`() {
+        val result = useCase(
+            candidates = listOf(
+                regionalDisposalGuide(
+                    sido = "전남광주통합특별시",
+                    sigungu = "고흥군",
+                    targetRegionName = "고흥군 전체"
+                )
+            ),
+            query = regionalGuideQuery(
+                displayRegion = Region(sido = "전라남도", sigungu = "고흥군"),
+                sigunguQuery = "고흥군"
+            )
+        )
+
+        val guide = (result as RegionalGuideLookupResult.Success).guide
+
+        assertEquals("전라남도", guide.region.sido)
+        assertEquals("고흥군", guide.region.sigungu)
+        assertEquals("고흥군 전체", guide.targetRegionName)
+    }
+
+    @Test
     fun `대상지역 설명에 선택 읍면동이 포함되면 해당 후보를 선택하고 Region 읍면동은 선택값으로 유지한다`() {
         val result = useCase(
             candidates = listOf(


### PR DESCRIPTION
## 작업 내용

지역별 배출 가이드에서 앱의 행정구역 선택값 `광주광역시`와 `/info` API 응답의 시도명 `전남광주통합특별시`가 달라 광주 지역 후보가 필터링될 수 있는 문제를 수정했습니다.

`/info` 원본 응답 값은 변경하지 않고, 지역 매칭/필터링 비교 단계에서만 시도명 alias 정규화를 적용했습니다.

또한 `전남광주통합특별시` 응답에는 광주 5개 구뿐 아니라 전남 시군 데이터도 함께 포함되어 있어, 전체를 `광주광역시`로 일괄 치환하지 않고 시군구 기준으로 광주/전남을 구분하도록 정리했습니다.

## 변경 사항

- `RegionSidoAliasPolicy`를 추가해 지역명 alias 비교 정책을 domain 계층에 분리
- `광주광역시`와 `전남광주통합특별시 + 광주 5개 구`를 같은 시도 기준으로 비교
- `전라남도`와 `전남광주통합특별시 + 전남 시군`을 같은 시도 기준으로 비교
- `filterBySido()`에서 시도명 완전 일치 대신 alias policy 기반 비교 적용
- `/info` 응답 매핑 단계에서는 원본 `CTPV_NM` 값을 유지
- 주소 검색 입력값은 앱 행정구역 기준으로 사용할 수 있도록 alias 정규화 적용
- `전남광주통합특별시 서구 ... (금호동)`처럼 괄호 안 법정동이 있는 주소 파싱 보강
- 광주 5개 구, 전남 시군, 원본 응답 유지, 기존 시도 비교 흐름 관련 테스트 추가

## 구현 메모

`RegionNormalizer`의 공식 시도명 목록에 `전남광주통합특별시`를 추가했습니다.

이는 `/info` API 응답의 원본 시도명을 잘못된 값으로 버리거나 다른 값으로 덮어쓰지 않고, 우선 유효한 시도명 토큰으로 인식하기 위한 처리입니다.

실제 `광주광역시` 또는 `전라남도` 기준 비교는 `RegionNormalizer`가 아니라 `RegionSidoAliasPolicy`에서만 수행합니다.

이렇게 분리해 `/info` 원본 응답 값은 유지하고, 비교/입력값 정규화가 필요한 지점에서만 alias policy를 적용하도록 했습니다.

## 유지한 기존 정책

- `/info` API 호출 방식 유지
- `/info` 원본 응답 데이터 유지
- 행정구역 JSON 전체 개편 제외
- Favorites key 구조 유지
- 후보 자동 선택 정책 변경 없음
- 정확 매칭 및 fallback 후보 선택 정책 유지
- 특정 화면에서만 처리하는 임시 보정 없음
- 인천 행정체제 개편 대응은 이번 PR 범위에서 제외

## 제외한 범위

- `/info` 원본 데이터 변경
- 행정구역 JSON 전체 교체
- 공식 안내 기반 배출요일/시간 보정
- 최신 row 대표값 선택 정책
- 후보 선택 UI 리디자인
- 시스템 뒤로가기 복원 정책
- 인천 행정체제 개편 대응
- 전남 전체 행정구역 정책 정리

## 테스트

- [x] `git diff --check`
- [x] `./gradlew :domain:test`
- [x] `./gradlew :data:testDebugUnitTest`
- [x] `./gradlew :presentation:testDebugUnitTest`
- [x] `./gradlew :presentation:compileDebugKotlin`
- [x] `./gradlew :app:assembleDebug`

## 확인한 케이스

- `광주광역시 > 광산구`
  - `/info` 응답의 `전남광주통합특별시 + 광산구` 후보가 필터링되지 않음

- `광주광역시 > 동구`
  - `/info` 응답의 `전남광주통합특별시 + 동구` 후보가 광주 5개 구 기준으로 매칭됨

- `광주광역시 > 서구`
  - `전남광주통합특별시 서구 ... (금호동)` 주소 파싱 시 `광주광역시 > 서구 > 금호동` 기준으로 입력값 정규화

- `광주광역시 > 남구`
  - `/info` 응답의 `전남광주통합특별시 + 남구` 후보가 광주 5개 구 기준으로 매칭됨

- `광주광역시 > 북구`
  - `/info` 응답의 `전남광주통합특별시 + 북구` 후보가 광주 5개 구 기준으로 매칭됨

- `전라남도 > 고흥군`
  - `전남광주통합특별시 + 전남 시군` 응답이 `광주광역시`로 잘못 매칭되지 않고 `전라남도` 기준으로 비교됨

- 기존 다른 시도
  - alias 대상이 아닌 시도명은 기존 비교 결과 유지

## 스크린샷

| API 응답 지역명 기준 조회 시작 | alias 매칭 후 조회 결과 |
| --- | --- |
| <img width="360" alt="전남광주통합특별시 응답 지역명으로 조회 로딩" src="https://github.com/user-attachments/assets/02613f08-ba09-4f31-bb40-6f4b54b771dc" /> | <img width="360" alt="광주광역시 서구 금호동 조회 결과" src="https://github.com/user-attachments/assets/b84bb961-5823-4053-9cd4-0d0788259dbf" /> |

> 로딩 화면에서는 `/info` 응답 원본 지역명인 `전남광주통합특별시`가 표시되고, 결과 화면에서는 앱 선택 기준인 `광주광역시 > 서구 > 금호동`으로 정상 조회됩니다. 이번 PR은 원본 응답 값을 변경하지 않고 매칭/필터링 단계에서만 alias를 적용합니다.

## Notes

- 이번 PR은 #270 작업 브랜치의 develop 반영 PR이며, 이슈 close는 main 병합 PR에서 처리합니다.
- `전남광주통합특별시`는 광주 5개 구와 전남 시군 데이터가 함께 내려오는 응답값이므로, 전체를 `광주광역시`로 일괄 치환하지 않았습니다.
- 인천 행정체제 개편 대응은 #272에서 별도 처리합니다.
- API 데이터 신뢰도, 공식 안내와의 불일치, 최신 row 대표값 선택 정책은 #166에서 별도 조사합니다.

## 관련 이슈

- Related #270
- Related #166
- Related #245
- Related #272