### PR TITLE
[Refactor] geocoding concurrency 제한값 조정

### DIFF
--- a/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotGeocodingRepositoryImpl.kt
+++ b/data/src/main/java/com/team/yeogibeoryeo/data/spot/repository/CollectionSpotGeocodingRepositoryImpl.kt
@@ -103,7 +103,7 @@ class CollectionSpotGeocodingRepositoryImpl @Inject constructor(
     }
 
     private companion object {
-        const val GEOCODING_CONCURRENCY_LIMIT = 3
+        const val GEOCODING_CONCURRENCY_LIMIT = 4
         val PARENTHESIZED_TEXT_REGEX = "\\([^)]*\\)".toRegex()
         val WHITESPACE_REGEX = "\\s+".toRegex()
     }


### PR DESCRIPTION
## 작업 배경

#257, #263, #265를 통해 지도 검색 병목을 단계적으로 측정/개선했습니다.

이번 PR에서는 #267 실기기 측정 결과를 바탕으로 `GEOCODING_CONCURRENCY_LIMIT` 값을 조정합니다.

기존에는 geocoding 동시 처리 제한값이 `3`이었고, 이번 실험에서 `3 / 4 / 5`를 비교했습니다.

---

## 작업 내용

- `GEOCODING_CONCURRENCY_LIMIT` 값을 `3 -> 4`로 변경
- `concurrency=5`는 적용하지 않음
- candidate `searchKeywords` 병렬화는 이번 PR에서 적용하지 않음
- `/getSpot addr` pagination 정책은 변경하지 않음
- 기존 검색 결과 / 후보 선택 / partial result 정책 유지

---

## 실기기 측정 결과 요약

| 케이스 | concurrency=3 | concurrency=4 | concurrency=5 |
|---|---:|---:|---:|
| 삼성동 | 전체 평균 약 `9.5초`, geo 약 `1.9초` | 전체 평균 약 `7.0초`, geo 약 `1.5초` | 미측정 |
| 금호동 | 전체 약 `16.8초`, geo 약 `7.9초` | 전체 `12.3~15.4초`, geo `5.5~6.7초` | 전체 `36~39초`, geo `4.8~6.0초` |
| 명동 keyword | API 병목 | 전체 `15~60초`, geo 약 `0.6초` | 전체 약 `48초`, geo 약 `0.5초` |
| 명동 현 지도 | geo `1.7~2.8초` | geo `1.2~1.6초` | geo `1.1~1.4초` |

---

## 판단 근거

`concurrency=4`는 geocoding 대상이 많은 케이스에서 처리 시간이 줄어드는 효과가 있었습니다.

특히 금호동, 현 지도 검색처럼 geocoding target count가 많은 경우 `3 -> 4` 변경으로 geocoding 시간이 줄었습니다.

반면 `concurrency=5`는 geocoding 구간만 보면 일부 개선이 있었지만, 금호동 측정에서 전체 시간이 크게 튀는 결과가 나왔습니다. 서버/API 부담 증가 가능성까지 고려하면 안정적인 적용값으로 보기 어려워 이번 PR에서는 적용하지 않았습니다.

---

## 추가로 확인한 병목

명동 keyword 검색은 geocoding보다 `/getSpot addr` 15페이지 순차 조회가 주요 병목이었습니다.

또한 `명동1가`, `명동2가`를 직접 조회하면 각각 1페이지로 끝나고, 두 결과 수의 합이 기존 명동 후보 선택 최종 결과 수와 동일하게 나타났습니다.

이 부분은 결과 ID set 비교가 필요하므로 이번 PR에서 변경하지 않고 #274 후속 이슈로 분리했습니다.

---

## 후속 작업

- #274
  - 후보 지역 세부 keyword 우선 조회로 `/getSpot addr` 페이지 조회를 줄일 수 있는지 검증
  - 명동 후보 검색에서 기존 결과 ID set과 `명동1가 + 명동2가` 결과 ID set 비교
  - 문래동도 동일 방식으로 broad keyword 생략 가능성 검토

---

## 변경하지 않은 것

- candidate `searchKeywords` 병렬화
- broad keyword 생략 정책
- `/getSpot addr` pagination 정책
- geocoding cache
- 검색 결과 cache
- 검색 UI/UX
- 마커 UI
- BottomSheet UX
- 후보 선택 정책
- partial result 정책

---

## 검증

- [x] `./gradlew.bat :domain:test`
- [x] `./gradlew.bat :data:testDebugUnitTest`
- [x] `./gradlew.bat :presentation:testDebugUnitTest`
- [x] `./gradlew.bat :presentation:compileDebugKotlin`
- [x] `./gradlew.bat :app:assembleDebug`
- [x] `git diff --check`

---

Refs #267  
Refs #274