### PR TITLE
[Setting] PR 라벨 자동화 추가

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,87 @@
+"module: app":
+  - changed-files:
+      - any-glob-to-any-file: "app/**"
+
+"module: common":
+  - changed-files:
+      - any-glob-to-any-file: "common/**"
+
+"module: data":
+  - changed-files:
+      - any-glob-to-any-file: "data/**"
+
+"module: domain":
+  - changed-files:
+      - any-glob-to-any-file: "domain/**"
+
+"module: presentation":
+  - changed-files:
+      - any-glob-to-any-file: "presentation/**"
+
+"module: search":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "presentation/src/main/java/**/search/**"
+          - "presentation/src/test/java/**/search/**"
+          - "presentation/src/androidTest/java/**/search/**"
+
+"module: map":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "presentation/src/main/java/**/map/**"
+          - "presentation/src/test/java/**/map/**"
+          - "presentation/src/androidTest/java/**/map/**"
+
+"module: regionalguide":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "presentation/src/main/java/**/regionalguide/**"
+          - "presentation/src/test/java/**/regionalguide/**"
+          - "presentation/src/androidTest/java/**/regionalguide/**"
+
+"module: bookmark":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "presentation/src/main/java/**/favorites/**"
+          - "presentation/src/test/java/**/favorites/**"
+          - "presentation/src/androidTest/java/**/favorites/**"
+
+"type: setting":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "gradle/**"
+          - "**/*.gradle.kts"
+          - "settings.gradle.kts"
+          - "gradle.properties"
+  - head-branch:
+      - "^setting/"
+
+"type: docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "**/*.md"
+          - "DATA_SOURCES.md"
+          - "README.md"
+          - "THIRD_PARTY_NOTICES.md"
+  - head-branch:
+      - "^docs/"
+
+"type: feature":
+  - head-branch:
+      - "^feature/"
+
+"type: bug":
+  - head-branch:
+      - "^fix/"
+      - "^bug/"
+      - "^bugfix/"
+
+"type: refactor":
+  - head-branch:
+      - "^refactor/"
+
+"type: spike":
+  - head-branch:
+      - "^spike/"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,27 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  labeler:
+    name: Label pull request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@v6
+        with:
+          sync-labels: false


### PR DESCRIPTION
## 작업 내용

- `actions/labeler@v6` 기반 PR 라벨 자동화 workflow를 추가했습니다.
- 변경 파일 경로 기준으로 `module:*` 라벨을 자동 부여하도록 설정했습니다.
- 브랜치명 기준으로 `type:*` 라벨을 자동 부여하도록 설정했습니다.
- `status:*` 라벨과 이슈 라벨 자동화는 범위에서 제외했습니다.

## 주요 변경 사항

- `.github/labeler.yml`
  - `app`, `common`, `data`, `domain`, `presentation` 모듈 라벨 규칙 추가
  - `search`, `map`, `regionalguide`, `bookmark` 세부 라벨 규칙 추가
  - `setting`, `docs`, `feature`, `bug`, `refactor`, `spike` 타입 라벨 규칙 추가
- `.github/workflows/pr-labeler.yml`
  - `pull_request_target` 이벤트에서 labeler 실행
  - 기존 라벨을 제거하지 않도록 `sync-labels: false` 적용

## 확인 사항

- PR 라벨 자동화는 workflow로 반영했습니다.
- merged branch 자동 삭제는 repository setting 변경이 필요해 이번 diff에는 포함하지 않았습니다.
- 2026년 7월 10일 기준 `main`, `develop` 브랜치 보호 설정을 확인했지만 두 브랜치 모두 protected 상태가 아니었습니다.
- `develop -> main` PR처럼 `develop`이 head branch가 되는 흐름이 있을 수 있어, 현재 상태에서 `gh repo edit --delete-branch-on-merge`를 바로 켜지는 않습니다.
- approve 이후에는 `main`, `develop` 보호 설정 또는 release PR 흐름을 먼저 정리한 뒤, 안전하다고 확인되면 GitHub 기본 merged branch 자동 삭제 설정을 켜겠습니다.
- 이번 PR은 labeler workflow를 처음 추가하는 PR이라, 이 PR 자체에서는 base branch에 workflow가 없어 자동 라벨 검증이 제한될 수 있습니다. merge 후 다음 PR에서 실제 자동 부여를 확인할 수 있습니다.

## 테스트

- `npx --yes prettier@3.6.2 --check .github/labeler.yml .github/workflows/pr-labeler.yml`
- 설정된 라벨이 GitHub repository에 모두 존재하는지 확인
- `gh api repos/AndroidStudy-Sesac/Yeogi-Beoryeo/branches/main --jq '{name: .name, protected: .protected}'`
- `gh api repos/AndroidStudy-Sesac/Yeogi-Beoryeo/branches/develop --jq '{name: .name, protected: .protected}'`

## 관련 이슈

Related #277
